### PR TITLE
Expose ZKAPAuthorizer in python27Packages

### DIFF
--- a/overlays.nix
+++ b/overlays.nix
@@ -22,6 +22,9 @@ self: super: {
       # we depend on the privacypass python library, a set of bindings to the
       # challenge-bypass-ristretto Rust library
       privacypass = python-super.callPackage ./privacypass.nix { };
+
+      # And add ourselves to the collection too.
+      zkapauthorizer = python-super.callPackage ./zkapauthorizer.nix { };
     };
   };
 }


### PR DESCRIPTION
This makes it easier for consumers to user zkapauthorizer.  They just get it from python27Packages like any other Python package instead of having to callPackage zkapauthorizer.nix.
