### PR TITLE
Server-side cryptographically correct pass checking for allocate_buckets

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -48,3 +48,12 @@ Then also configure the Ristretto-flavored PrivacyPass issuer the server will an
 
   [storageserver.plugins.privatestorageio-zkapauthz-v1]
   ristretto-issuer-root-url = https://issuer.example.invalid/
+
+The storage server must also be configured with the path to the Ristretto-flavored PrivacyPass signing key.
+To avoid placing secret material in tahoe.cfg,
+this configuration is done using a path::
+
+  [storageserver.plugins.privatestorageio-zkapauthz-v1]
+  ristretto-signing-key-path = /path/to/signing.key
+
+The signing key is the keystone secret to the entire system and must be managed with extreme care to prevent unintended disclosure.

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -57,3 +57,4 @@ this configuration is done using a path::
   ristretto-signing-key-path = /path/to/signing.key
 
 The signing key is the keystone secret to the entire system and must be managed with extreme care to prevent unintended disclosure.
+If things go well a future version of ZKAPAuthorizer will remove the requirement that the signing key be distributed to storage servers.

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,7 @@
 from setuptools import setup
 
-setup()
+setup(
+    package_data={
+        "": ["testing-signing.key"],
+    },
+)

--- a/src/_zkapauthorizer/_plugin.py
+++ b/src/_zkapauthorizer/_plugin.py
@@ -27,6 +27,9 @@ from zope.interface import (
     implementer,
 )
 
+from twisted.python.filepath import (
+    FilePath,
+)
 from twisted.internet.defer import (
     succeed,
 )
@@ -34,6 +37,9 @@ from twisted.internet.defer import (
 from allmydata.interfaces import (
     IFoolscapStoragePlugin,
     IAnnounceableStorageServer,
+)
+from privacypass import (
+    SigningKey,
 )
 
 from .api import (
@@ -104,11 +110,17 @@ class ZKAPAuthorizer(object):
     def get_storage_server(self, configuration, get_anonymous_storage_server):
         kwargs = configuration.copy()
         root_url = kwargs.pop(u"ristretto-issuer-root-url")
+        signing_key = SigningKey.decode_base64(
+            FilePath(
+                kwargs.pop(u"ristretto-signing-key-path"),
+            ).getContent(),
+        )
         announcement = {
             u"ristretto-issuer-root-url": root_url,
         }
         storage_server = ZKAPAuthorizerStorageServer(
             get_anonymous_storage_server(),
+            signing_key,
             **kwargs
         )
         return succeed(

--- a/src/_zkapauthorizer/_storage_client.py
+++ b/src/_zkapauthorizer/_storage_client.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-A Tahoe-LAFS ``IStorageServer`` implementation which presents tokens
+A Tahoe-LAFS ``IStorageServer`` implementation which presents passes
 per-call to prove authorization for writes and lease updates.
 
 This is the client part of a storage access protocol.  The server part is
@@ -34,15 +34,15 @@ from allmydata.interfaces import (
 @attr.s
 class ZKAPAuthorizerStorageClient(object):
     """
-    An implementation of the client portion of an access-token-based
+    An implementation of the client portion of an access-pass-based
     authorization scheme on top of the basic Tahoe-LAFS storage protocol.
 
     This ``IStorageServer`` implementation aims to offer the same storage
     functionality as Tahoe-LAFS' built-in storage server but with an added
-    layer of token-based authorization for some operations.  The Python
+    layer of pass-based authorization for some operations.  The Python
     interface exposed to application code is the same but the network protocol
-    is augmented with tokens which are automatically inserted by this class.
-    The tokens are interpreted by the corresponding server-side implementation
+    is augmented with passes which are automatically inserted by this class.
+    The passes are interpreted by the corresponding server-side implementation
     of this scheme.
 
     :ivar _get_rref: A no-argument callable which retrieves the most recently

--- a/src/_zkapauthorizer/_storage_client.py
+++ b/src/_zkapauthorizer/_storage_client.py
@@ -30,6 +30,13 @@ from allmydata.interfaces import (
     IStorageServer,
 )
 
+from .storage_common import (
+    allocate_buckets_message,
+    add_lease_message,
+    renew_lease_message,
+    slot_testv_and_readv_and_writev_message,
+)
+
 @implementer(IStorageServer)
 @attr.s
 class ZKAPAuthorizerStorageClient(object):
@@ -64,13 +71,16 @@ class ZKAPAuthorizerStorageClient(object):
 
     def _get_encoded_passes(self, message, count):
         """
+        :param unicode message: The message to which to bind the passes.
+
         :return: A list of passes from ``_get_passes`` encoded into their
             ``bytes`` representation.
         """
+        assert isinstance(message, unicode)
         return list(
             t.text.encode("ascii")
             for t
-            in self._get_passes(message.encode("hex"), count)
+            in self._get_passes(message.encode("utf-8"), count)
         )
 
     def get_version(self):
@@ -89,7 +99,7 @@ class ZKAPAuthorizerStorageClient(object):
     ):
         return self._rref.callRemote(
             "allocate_buckets",
-            self._get_encoded_passes(storage_index, 1),
+            self._get_encoded_passes(allocate_buckets_message(storage_index), 1),
             storage_index,
             renew_secret,
             cancel_secret,
@@ -115,7 +125,7 @@ class ZKAPAuthorizerStorageClient(object):
     ):
         return self._rref.callRemote(
             "add_lease",
-            self._get_encoded_passes(storage_index, 1),
+            self._get_encoded_passes(add_lease_message(storage_index), 1),
             storage_index,
             renew_secret,
             cancel_secret,
@@ -128,7 +138,7 @@ class ZKAPAuthorizerStorageClient(object):
     ):
         return self._rref.callRemote(
             "renew_lease",
-            self._get_encoded_passes(storage_index, 1),
+            self._get_encoded_passes(renew_lease_message(storage_index), 1),
             storage_index,
             renew_secret,
         )
@@ -157,7 +167,7 @@ class ZKAPAuthorizerStorageClient(object):
     ):
         return self._rref.callRemote(
             "slot_testv_and_readv_and_writev",
-            self._get_encoded_passes(storage_index, 1),
+            self._get_encoded_passes(slot_testv_and_readv_and_writev_message(storage_index), 1),
             storage_index,
             secrets,
             tw_vectors,

--- a/src/_zkapauthorizer/_storage_client.py
+++ b/src/_zkapauthorizer/_storage_client.py
@@ -31,6 +31,8 @@ from allmydata.interfaces import (
 )
 
 from .storage_common import (
+    BYTES_PER_PASS,
+    required_passes,
     allocate_buckets_message,
     add_lease_message,
     renew_lease_message,
@@ -99,7 +101,10 @@ class ZKAPAuthorizerStorageClient(object):
     ):
         return self._rref.callRemote(
             "allocate_buckets",
-            self._get_encoded_passes(allocate_buckets_message(storage_index), 1),
+            self._get_encoded_passes(
+                allocate_buckets_message(storage_index),
+                required_passes(BYTES_PER_PASS, sharenums, allocated_size),
+            ),
             storage_index,
             renew_secret,
             cancel_secret,

--- a/src/_zkapauthorizer/api.py
+++ b/src/_zkapauthorizer/api.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 __all__ = [
+    "MorePassesRequired",
     "ZKAPAuthorizerStorageServer",
     "ZKAPAuthorizerStorageClient",
     "ZKAPAuthorizer",
 ]
 
 from ._storage_server import (
+    MorePassesRequired,
     ZKAPAuthorizerStorageServer,
 )
 from ._storage_client import (

--- a/src/_zkapauthorizer/storage_common.py
+++ b/src/_zkapauthorizer/storage_common.py
@@ -1,0 +1,17 @@
+
+from base64 import (
+    b64encode,
+)
+
+def _message_maker(label):
+    def make_message(storage_index):
+        return u"{label} {storage_index}".format(
+            label=label,
+            storage_index=b64encode(storage_index),
+        )
+    return make_message
+
+allocate_buckets_message = _message_maker(u"allocate_buckets")
+add_lease_message = _message_maker(u"add_lease")
+renew_lease_message = _message_maker(u"renew_lease")
+slot_testv_and_readv_and_writev_message = _message_maker(u"slot_testv_and_readv_and_writev")

--- a/src/_zkapauthorizer/storage_common.py
+++ b/src/_zkapauthorizer/storage_common.py
@@ -3,6 +3,10 @@ from base64 import (
     b64encode,
 )
 
+from math import (
+    ceil,
+)
+
 def _message_maker(label):
     def make_message(storage_index):
         return u"{label} {storage_index}".format(
@@ -15,3 +19,23 @@ allocate_buckets_message = _message_maker(u"allocate_buckets")
 add_lease_message = _message_maker(u"add_lease")
 renew_lease_message = _message_maker(u"renew_lease")
 slot_testv_and_readv_and_writev_message = _message_maker(u"slot_testv_and_readv_and_writev")
+
+# The number of bytes we're willing to store for a lease period for each pass
+# submitted.
+BYTES_PER_PASS = 128 * 1024
+
+def required_passes(bytes_per_pass, share_nums, share_size):
+    """
+    Calculate the number of passes that are required to store ``stored_bytes``
+    for one lease period.
+
+    :param int stored_bytes: A number of bytes of storage for which to
+        calculate a price in passes.
+
+    :return int: The number of passes.
+    """
+    return int(
+        ceil(
+            (len(share_nums) * share_size) / bytes_per_pass,
+        ),
+    )

--- a/src/_zkapauthorizer/tests/fixtures.py
+++ b/src/_zkapauthorizer/tests/fixtures.py
@@ -1,0 +1,34 @@
+from __future__ import (
+    absolute_import,
+)
+
+from fixtures import (
+    Fixture,
+    TempDir,
+)
+
+from twisted.python.filepath import (
+    FilePath,
+)
+
+from allmydata.storage.server import (
+    StorageServer,
+)
+
+class AnonymousStorageServer(Fixture):
+    """
+    Supply an instance of allmydata.storage.server.StorageServer which
+    implements anonymous access to Tahoe-LAFS storage server functionality.
+
+    :ivar FilePath tempdir: The path to the server's storage on the
+        filesystem.
+
+    :ivar allmydata.storage.server.StorageServer storage_server: The storage
+        server.
+    """
+    def _setUp(self):
+        self.tempdir = FilePath(self.useFixture(TempDir()).join(b"storage"))
+        self.storage_server = StorageServer(
+            self.tempdir.asBytesMode().path,
+            b"x" * 20,
+        )

--- a/src/_zkapauthorizer/tests/privacypass.py
+++ b/src/_zkapauthorizer/tests/privacypass.py
@@ -1,0 +1,55 @@
+from __future__ import (
+    absolute_import,
+)
+
+from privacypass import (
+    BatchDLEQProof,
+    PublicKey,
+)
+
+def make_passes(signing_key, for_message, random_tokens):
+    blinded_tokens = list(
+        token.blind()
+        for token
+        in random_tokens
+    )
+    signatures = list(
+        signing_key.sign(blinded_token)
+        for blinded_token
+        in blinded_tokens
+    )
+    proof = BatchDLEQProof.create(
+        signing_key,
+        blinded_tokens,
+        signatures,
+    )
+    unblinded_signatures = proof.invalid_or_unblind(
+        random_tokens,
+        blinded_tokens,
+        signatures,
+        PublicKey.from_signing_key(signing_key),
+    )
+    preimages = list(
+        unblinded_signature.preimage()
+        for unblinded_signature
+        in unblinded_signatures
+    )
+    verification_keys = list(
+        unblinded_signature.derive_verification_key_sha512()
+        for unblinded_signature
+        in unblinded_signatures
+    )
+    message_signatures = list(
+        verification_key.sign_sha512(for_message.encode("utf-8"))
+        for verification_key
+        in verification_keys
+    )
+    passes = list(
+        u"{} {}".format(
+            preimage.encode_base64().decode("ascii"),
+            signature.encode_base64().decode("ascii"),
+        ).encode("ascii")
+        for (preimage, signature)
+        in zip(preimages, message_signatures)
+    )
+    return passes

--- a/src/_zkapauthorizer/tests/strategies.py
+++ b/src/_zkapauthorizer/tests/strategies.py
@@ -164,12 +164,16 @@ def node_nicknames():
     )
 
 
-def server_configurations():
+def server_configurations(signing_key_path):
     """
     Build configuration values for the server-side plugin.
+
+    :param unicode signing_key_path: A value to insert for the
+        **ristretto-signing-key-path** item.
     """
     return just({
         u"ristretto-issuer-root-url": u"https://issuer.example.invalid/",
+        u"ristretto-signing-key-path": signing_key_path.path,
     })
 
 
@@ -214,13 +218,10 @@ def zkaps():
     """
     Build random ZKAPs as ``Pass` instances.
     """
-    return binary(
-        min_size=32,
-        max_size=32,
-    ).map(
-        urlsafe_b64encode,
-    ).map(
-        lambda zkap: Pass(zkap.decode("ascii")),
+    return builds(
+        lambda preimage, signature: Pass(u"{} {}".format(preimage, signature)),
+        preimage=binary(min_size=66, max_size=66).map(urlsafe_b64encode),
+        signature=binary(min_size=66, max_size=66).map(urlsafe_b64encode),
     )
 
 

--- a/src/_zkapauthorizer/tests/test_base64.py
+++ b/src/_zkapauthorizer/tests/test_base64.py
@@ -16,6 +16,10 @@
 Tests for ``_zkapauthorizer._base64``.
 """
 
+from __future__ import (
+    absolute_import,
+)
+
 from base64 import (
     urlsafe_b64encode,
 )

--- a/src/_zkapauthorizer/tests/test_client_resource.py
+++ b/src/_zkapauthorizer/tests/test_client_resource.py
@@ -17,6 +17,10 @@ Tests for the web resource provided by the client part of the Tahoe-LAFS
 plugin.
 """
 
+from __future__ import (
+    absolute_import,
+)
+
 import attr
 
 from .._base64 import (

--- a/src/_zkapauthorizer/tests/test_controller.py
+++ b/src/_zkapauthorizer/tests/test_controller.py
@@ -16,6 +16,10 @@
 Tests for ``_zkapauthorizer.controller``.
 """
 
+from __future__ import (
+    absolute_import,
+)
+
 from json import (
     loads,
     dumps,

--- a/src/_zkapauthorizer/tests/test_matchers.py
+++ b/src/_zkapauthorizer/tests/test_matchers.py
@@ -16,6 +16,10 @@
 Tests for ``_zkapauthorizer.tests.matchers``.
 """
 
+from __future__ import (
+    absolute_import,
+)
+
 from zope.interface import (
     Interface,
     implementer,

--- a/src/_zkapauthorizer/tests/test_model.py
+++ b/src/_zkapauthorizer/tests/test_model.py
@@ -17,6 +17,10 @@
 Tests for ``_zkapauthorizer.model``.
 """
 
+from __future__ import (
+    absolute_import,
+)
+
 from os import (
     mkdir,
 )

--- a/src/_zkapauthorizer/tests/test_plugin.py
+++ b/src/_zkapauthorizer/tests/test_plugin.py
@@ -71,6 +71,9 @@ from allmydata.interfaces import (
     RIStorageServer,
 )
 
+from twisted.python.filepath import (
+    FilePath,
+)
 from twisted.plugin import (
     getPlugins,
 )
@@ -105,6 +108,9 @@ from .strategies import (
 from .matchers import (
     Provides,
 )
+
+
+SIGNING_KEY_PATH = FilePath(__file__).sibling(u"testing-signing.key")
 
 
 @implementer(RIStorageServer)
@@ -150,7 +156,7 @@ class ServerPluginTests(TestCase):
     Tests for the plugin's implementation of
     ``IFoolscapStoragePlugin.get_storage_server``.
     """
-    @given(server_configurations())
+    @given(server_configurations(SIGNING_KEY_PATH))
     def test_returns_announceable(self, configuration):
         """
         ``storage_server.get_storage_server`` returns an instance which provides
@@ -166,7 +172,7 @@ class ServerPluginTests(TestCase):
         )
 
 
-    @given(server_configurations())
+    @given(server_configurations(SIGNING_KEY_PATH))
     def test_returns_referenceable(self, configuration):
         """
         The storage server attached to the result of
@@ -187,7 +193,7 @@ class ServerPluginTests(TestCase):
             ),
         )
 
-    @given(server_configurations())
+    @given(server_configurations(SIGNING_KEY_PATH))
     def test_returns_serializable(self, configuration):
         """
         The storage server attached to the result of
@@ -211,7 +217,7 @@ class ServerPluginTests(TestCase):
         )
 
 
-    @given(server_configurations())
+    @given(server_configurations(SIGNING_KEY_PATH))
     def test_returns_hashable(self, configuration):
         """
         The storage server attached to the result of

--- a/src/_zkapauthorizer/tests/test_plugin.py
+++ b/src/_zkapauthorizer/tests/test_plugin.py
@@ -16,6 +16,10 @@
 Tests for the Tahoe-LAFS plugin.
 """
 
+from __future__ import (
+    absolute_import,
+)
+
 from io import (
     BytesIO,
 )

--- a/src/_zkapauthorizer/tests/test_storage_protocol.py
+++ b/src/_zkapauthorizer/tests/test_storage_protocol.py
@@ -16,11 +16,13 @@
 Tests for communication between the client and server components.
 """
 
+from __future__ import (
+    absolute_import,
+)
+
 import attr
 
 from fixtures import (
-    Fixture,
-    TempDir,
     MonkeyPatch,
 )
 from testtools import (
@@ -62,10 +64,6 @@ from foolscap.referenceable import (
     LocalReferenceable,
 )
 
-from allmydata.storage.server import (
-    StorageServer,
-)
-
 from .strategies import (
     storage_indexes,
     lease_renew_secrets,
@@ -81,6 +79,9 @@ from .strategies import (
 from .matchers import (
     matches_version_dictionary,
 )
+from .fixtures import (
+    AnonymousStorageServer,
+)
 from ..api import (
     ZKAPAuthorizerStorageServer,
     ZKAPAuthorizerStorageClient,
@@ -91,25 +92,6 @@ from ..foolscap import (
 from ..model import (
     Pass,
 )
-
-class AnonymousStorageServer(Fixture):
-    """
-    Supply an instance of allmydata.storage.server.StorageServer which
-    implements anonymous access to Tahoe-LAFS storage server functionality.
-
-    :ivar FilePath tempdir: The path to the server's storage on the
-        filesystem.
-
-    :ivar allmydata.storage.server.StorageServer storage_server: The storage
-        server.
-    """
-    def _setUp(self):
-        self.tempdir = FilePath(self.useFixture(TempDir()).join(b"storage"))
-        self.storage_server = StorageServer(
-            self.tempdir.asBytesMode().path,
-            b"x" * 20,
-        )
-
 
 @attr.s
 class LocalRemote(object):

--- a/src/_zkapauthorizer/tests/test_storage_server.py
+++ b/src/_zkapauthorizer/tests/test_storage_server.py
@@ -1,0 +1,123 @@
+from __future__ import (
+    absolute_import,
+)
+
+from random import (
+    shuffle,
+)
+from testtools import (
+    TestCase,
+)
+from testtools.matchers import (
+    Equals,
+    AfterPreprocessing,
+)
+from hypothesis import (
+    given,
+)
+from hypothesis.strategies import (
+    integers,
+    lists,
+)
+from privacypass import (
+    BatchDLEQProof,
+    PublicKey,
+    RandomToken,
+    random_signing_key,
+)
+
+from .strategies import (
+    zkaps,
+)
+from .fixtures import (
+    AnonymousStorageServer,
+)
+from ..api import (
+    ZKAPAuthorizerStorageServer,
+)
+
+
+def make_passes(signing_key, for_message, random_tokens):
+    blinded_tokens = list(
+        token.blind()
+        for token
+        in random_tokens
+    )
+    signatures = list(
+        signing_key.sign(blinded_token)
+        for blinded_token
+        in blinded_tokens
+    )
+    proof = BatchDLEQProof.create(
+        signing_key,
+        blinded_tokens,
+        signatures,
+    )
+    unblinded_signatures = proof.invalid_or_unblind(
+        random_tokens,
+        blinded_tokens,
+        signatures,
+        PublicKey.from_signing_key(signing_key),
+    )
+    preimages = list(
+        unblinded_signature.preimage()
+        for unblinded_signature
+        in unblinded_signatures
+    )
+    verification_keys = list(
+        unblinded_signature.derive_verification_key_sha512()
+        for unblinded_signature
+        in unblinded_signatures
+    )
+    message_signatures = list(
+        verification_key.sign_sha512(for_message.encode("utf-8"))
+        for verification_key
+        in verification_keys
+    )
+    passes = list(
+        u"{} {}".format(
+            preimage.encode_base64().decode("ascii"),
+            signature.encode_base64().decode("ascii"),
+        ).encode("ascii")
+        for (preimage, signature)
+        in zip(preimages, message_signatures)
+    )
+    return passes
+
+
+
+class PassValidationTests(TestCase):
+    """
+    Tests for pass validation performed by ``ZKAPAuthorizerStorageServer``.
+    """
+    def setUp(self):
+        super(PassValidationTests, self).setUp()
+        self.anonymous_storage_server = self.useFixture(AnonymousStorageServer()).storage_server
+        self.signing_key = random_signing_key()
+        self.storage_server = ZKAPAuthorizerStorageServer(
+            self.anonymous_storage_server,
+            self.signing_key,
+        )
+
+    @given(integers(min_value=0, max_value=64), lists(zkaps(), max_size=64))
+    def test_validation_result(self, valid_count, invalid_passes):
+        """
+        ``_get_valid_passes`` returns the number of cryptographically valid passes
+        in the list passed to it.
+        """
+        message = u"hello world"
+        valid_passes = make_passes(
+            self.signing_key,
+            message,
+            list(RandomToken.create() for i in range(valid_count)),
+        )
+        all_passes = valid_passes + list(pass_.text.encode("ascii") for pass_ in invalid_passes)
+        shuffle(all_passes)
+
+        self.assertThat(
+            self.storage_server._validate_passes(message, all_passes),
+            AfterPreprocessing(
+                set,
+                Equals(set(valid_passes)),
+            ),
+        )

--- a/src/_zkapauthorizer/tests/test_strategies.py
+++ b/src/_zkapauthorizer/tests/test_strategies.py
@@ -16,6 +16,10 @@
 Tests for our custom Hypothesis strategies.
 """
 
+from __future__ import (
+    absolute_import,
+)
+
 from testtools import (
     TestCase,
 )

--- a/src/_zkapauthorizer/tests/testing-signing.key
+++ b/src/_zkapauthorizer/tests/testing-signing.key
@@ -1,0 +1,1 @@
+mkQf85V2vyLQRUYuqRb+Ke6K+M9pOtXm4MslsuCdBgg=


### PR DESCRIPTION
Fixes: #40 

Note I reduced the scope of #40 and only address `allocate_buckets` here as this is a self-contained set of changes and the branch is large enough already.  The other methods aren't going to be completely trivial so I'll address them individually.
