### PR TITLE
Deny writes without active lease

### DIFF
--- a/src/_zkapauthorizer/_storage_client.py
+++ b/src/_zkapauthorizer/_storage_client.py
@@ -37,6 +37,7 @@ from .storage_common import (
     add_lease_message,
     renew_lease_message,
     slot_testv_and_readv_and_writev_message,
+    has_writes,
 )
 
 @implementer(IStorageServer)
@@ -170,9 +171,13 @@ class ZKAPAuthorizerStorageClient(object):
             tw_vectors,
             r_vector,
     ):
+        if has_writes(tw_vectors):
+            passes = self._get_encoded_passes(slot_testv_and_readv_and_writev_message(storage_index), 1)
+        else:
+            passes = []
         return self._rref.callRemote(
             "slot_testv_and_readv_and_writev",
-            self._get_encoded_passes(slot_testv_and_readv_and_writev_message(storage_index), 1),
+            passes,
             storage_index,
             secrets,
             tw_vectors,

--- a/src/_zkapauthorizer/_storage_server.py
+++ b/src/_zkapauthorizer/_storage_server.py
@@ -246,7 +246,9 @@ class ZKAPAuthorizerStorageServer(Referenceable):
                 self._clock.seconds(),
             ):
                 # Passes may be supplied with the write to create the
-                # necessary lease as part of the same operation.
+                # necessary lease as part of the same operation.  This must be
+                # supported because there is no separate protocol action to
+                # *create* a slot.  Clients just begin writing to it.
                 valid_passes = self._validate_passes(
                     slot_testv_and_readv_and_writev_message(storage_index),
                     passes,

--- a/src/_zkapauthorizer/_storage_server.py
+++ b/src/_zkapauthorizer/_storage_server.py
@@ -70,6 +70,7 @@ from .storage_common import (
     add_lease_message,
     renew_lease_message,
     slot_testv_and_readv_and_writev_message,
+    has_writes,
 )
 
 class MorePassesRequired(Exception):
@@ -272,20 +273,6 @@ class ZKAPAuthorizerStorageServer(Referenceable):
         long as those shares exist.
         """
         return self._original.remote_slot_readv(*a, **kw)
-
-
-def has_writes(tw_vectors):
-    """
-    :param tw_vectors: See
-        ``allmydata.interfaces.TestAndWriteVectorsForShares``.
-
-    :return bool: ``True`` if any only if there are writes in ``tw_vectors``.
-    """
-    return any(
-        data
-        for (test, data, new_length)
-        in tw_vectors.values()
-    )
 
 
 def get_sharenums(tw_vectors):

--- a/src/_zkapauthorizer/api.py
+++ b/src/_zkapauthorizer/api.py
@@ -14,6 +14,7 @@
 
 __all__ = [
     "MorePassesRequired",
+    "LeaseRenewalRequired",
     "ZKAPAuthorizerStorageServer",
     "ZKAPAuthorizerStorageClient",
     "ZKAPAuthorizer",
@@ -21,6 +22,7 @@ __all__ = [
 
 from ._storage_server import (
     MorePassesRequired,
+    LeaseRenewalRequired,
     ZKAPAuthorizerStorageServer,
 )
 from ._storage_client import (

--- a/src/_zkapauthorizer/storage_common.py
+++ b/src/_zkapauthorizer/storage_common.py
@@ -65,3 +65,17 @@ def required_passes(bytes_per_pass, share_nums, share_size):
             (len(share_nums) * share_size) / bytes_per_pass,
         ),
     )
+
+
+def has_writes(tw_vectors):
+    """
+    :param tw_vectors: See
+        ``allmydata.interfaces.TestAndWriteVectorsForShares``.
+
+    :return bool: ``True`` if any only if there are writes in ``tw_vectors``.
+    """
+    return any(
+        data
+        for (test, data, new_length)
+        in tw_vectors.values()
+    )

--- a/src/_zkapauthorizer/storage_common.py
+++ b/src/_zkapauthorizer/storage_common.py
@@ -16,6 +16,10 @@
 Functionality shared between the storage client and server.
 """
 
+from __future__ import (
+    division,
+)
+
 from base64 import (
     b64encode,
 )

--- a/src/_zkapauthorizer/tests/strategies.py
+++ b/src/_zkapauthorizer/tests/strategies.py
@@ -319,7 +319,9 @@ def sharenum_sets():
     return sets(
         sharenums(),
         min_size=1,
-        max_size=255,
+        # This could go as high as 255 but to avoid tripping over the limits
+        # discussed in sizes(), keep it smaller.
+        max_size=8,
     )
 
 
@@ -330,8 +332,10 @@ def sizes():
     return integers(
         # Size 0 data isn't data, it's nothing.
         min_value=1,
-        # Just for practical purposes...
-        max_value=2 ** 16,
+        # For the moment there are some assumptions in the test suite that
+        # limit us to an amount of storage that can be paid for with one ZKAP.
+        # That will be fixed eventually.  For now, keep the sizes pretty low.
+        max_value=2 ** 8,
     )
 
 
@@ -342,7 +346,7 @@ def offsets():
     return integers(
         min_value=0,
         # Just for practical purposes...
-        max_value=2 ** 16,
+        max_value=2 ** 8,
     )
 
 

--- a/src/_zkapauthorizer/tests/test_storage_protocol.py
+++ b/src/_zkapauthorizer/tests/test_storage_protocol.py
@@ -140,6 +140,22 @@ class LocalRemote(object):
         )
 
 
+def assume_one_pass(test_and_write_vectors_for_shares):
+    """
+    Assume that the writes represented by the given ``TestAndWriteVectors``
+    will cost at most one pass.
+    """
+    from .._storage_server import (
+        BYTES_PER_PASS,
+        get_sharenums,
+        get_allocated_size,
+        required_passes,
+    )
+    tw_vectors = {k: v.for_call() for (k, v) in test_and_write_vectors_for_shares.items()}
+    sharenums = get_sharenums(tw_vectors)
+    allocated_size = get_allocated_size(tw_vectors)
+    assume(required_passes(BYTES_PER_PASS, sharenums, allocated_size) <= 1)
+
 
 class ShareTests(TestCase):
     """
@@ -194,6 +210,9 @@ class ShareTests(TestCase):
         resulting buckets can be read back using *get_buckets* and methods of
         those resulting buckets.
         """
+        # XXX
+        assume(len(sharenums) * size < 128 * 1024 * 10)
+
         # Hypothesis causes our storage server to be used many times.  Clean
         # up between iterations.
         cleanup_storage_server(self.anonymous_storage_server)
@@ -381,6 +400,9 @@ class ShareTests(TestCase):
         Mutable share data written using *slot_testv_and_readv_and_writev* can be
         read back.
         """
+        # XXX
+        assume_one_pass(test_and_write_vectors_for_shares)
+
         # Hypothesis causes our storage server to be used many times.  Clean
         # up between iterations.
         cleanup_storage_server(self.anonymous_storage_server)
@@ -458,6 +480,9 @@ class ShareTests(TestCase):
         When mutable share data is written using *slot_testv_and_readv_and_writev*
         any leases on the corresponding slot remain the same.
         """
+        # XXX
+        assume_one_pass(test_and_write_vectors_for_shares)
+
         # Hypothesis causes our storage server to be used many times.  Clean
         # up between iterations.
         cleanup_storage_server(self.anonymous_storage_server)

--- a/src/_zkapauthorizer/tests/test_storage_server.py
+++ b/src/_zkapauthorizer/tests/test_storage_server.py
@@ -177,8 +177,11 @@ class PassValidationTests(TestCase):
 
         try:
             result = mutable_write()
-        except MorePassesRequired:
-            pass
+        except MorePassesRequired as e:
+            self.assertThat(
+                e.required_count,
+                Equals(1),
+            )
         else:
             self.fail("expected LeaseRenewalRequired, got {}".format(result))
 

--- a/src/_zkapauthorizer/tests/test_storage_server.py
+++ b/src/_zkapauthorizer/tests/test_storage_server.py
@@ -38,6 +38,7 @@ from hypothesis import (
 from hypothesis.strategies import (
     integers,
     lists,
+    tuples,
 )
 from privacypass import (
     RandomToken,
@@ -52,6 +53,10 @@ from .privacypass import (
 )
 from .strategies import (
     zkaps,
+    storage_indexes,
+    write_enabler_secrets,
+    lease_renew_secrets,
+    lease_cancel_secrets,
 )
 from .fixtures import (
     AnonymousStorageServer,
@@ -137,3 +142,45 @@ class PassValidationTests(TestCase):
             allocate_buckets,
             raises(MorePassesRequired),
         )
+
+
+    @given(
+        storage_index=storage_indexes(),
+        secrets=tuples(
+            write_enabler_secrets(),
+            lease_renew_secrets(),
+            lease_cancel_secrets(),
+        ),
+    )
+    def test_create_mutable_fails_without_passes(self, storage_index, secrets):
+        """
+        If ``remote_slot_testv_and_readv_and_writev`` is invoked to perform
+        initial writes on shares without supplying passes, the operation fails
+        with ``LeaseRenewalRequired``.
+        """
+        data = b"01234567"
+        offset = 0
+        sharenum = 0
+        mutable_write = lambda: self.storage_server.doRemoteCall(
+            "slot_testv_and_readv_and_writev",
+            (),
+            dict(
+                passes=[],
+                storage_index=storage_index,
+                secrets=secrets,
+                tw_vectors={
+                    sharenum: ([], [(offset, data)], None),
+                },
+                r_vector=[],
+            ),
+        )
+
+        try:
+            result = mutable_write()
+        except MorePassesRequired:
+            pass
+        else:
+            self.fail("expected LeaseRenewalRequired, got {}".format(result))
+
+    # TODO
+    # a write that increases the storage cost of the share requires passes too


### PR DESCRIPTION
Fixes: #21 

This is related to #47 as well since `slot_testv_and_readv_and_writev` is the only "write" operation in the API and there is no way to acquire a lease on a mutable share without *writing* the mutable share.  So the changes here do some pass validation in that method - but only enough to implement #21.  #47 will receive more attention in a follow-up PR.
