### PR TITLE
Fixes related to integration testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
       # time of this comment.  We can bump it to a newer version when that
       # makes sense.  Meanwhile, the platform won't shift around beneath us
       # unexpectedly.
-      NIXPKGS_REV: "5d5cd70516001e79516d2ade8bcf31df208a4ef3"
+      NIXPKGS_REV: "8bf142e001b6876b021c8ee90c2c7cec385fe8e9"
 
     steps:
       - run:

--- a/src/_zkapauthorizer/foolscap.py
+++ b/src/_zkapauthorizer/foolscap.py
@@ -6,8 +6,7 @@ from foolscap.constraint import (
     ByteStringConstraint,
 )
 from foolscap.api import (
-    ChoiceOf,
-    SetOf,
+    Any,
     DictOf,
     ListOf,
 )
@@ -17,7 +16,6 @@ from foolscap.remoteinterface import (
 )
 
 from allmydata.interfaces import (
-    MAX_BUCKETS,
     StorageIndex,
     RIStorageServer,
     Offset,

--- a/src/_zkapauthorizer/foolscap.py
+++ b/src/_zkapauthorizer/foolscap.py
@@ -125,7 +125,10 @@ class RIPrivacyPassAuthorizedStorageServer(RemoteInterface):
 
     def share_sizes(
             storage_index_or_slot=StorageIndex,
-            sharenums=ChoiceOf(None, SetOf(int, maxLength=MAX_BUCKETS)),
+            # Notionally, ChoiceOf(None, SetOf(int, maxLength=MAX_BUCKETS)).
+            # However, support for such a construction appears to be
+            # unimplemented in Foolscap.  So, instead...
+            sharenums=Any(),
     ):
         """
         Get the size of the given shares in the given storage index or slot.  If a


### PR DESCRIPTION
While integration testing I discovered that you cannot have `ChoiceOf(SetOf(...), ...)`.  Foolscap explodes with an assertion error in the implementation of `SetOf` when it is given the wrong constraint object.
