### PR TITLE
Web interface to get all unused tokens

### DIFF
--- a/docs/source/interface.rst
+++ b/docs/source/interface.rst
@@ -54,6 +54,7 @@ The elements of the list are objects like the one returned by issuing a **GET** 
 
 This endpoint allows an external agent to retrieve unused unblinded tokens present in the node's database.
 Unblinded tokens are returned in ascending text sorted order.
+This order matches the order in which tokens will be used by the system.
 This endpoint accepts several query arguments:
 
   * limit: An integer limiting the number of unblinded tokens to retrieve.

--- a/src/_zkapauthorizer/model.py
+++ b/src/_zkapauthorizer/model.py
@@ -314,7 +314,7 @@ class VoucherStore(object):
             """
             CREATE TEMPORARY TABLE [extracting]
             AS
-            SELECT [token] FROM [unblinded-tokens] LIMIT ?
+            SELECT [token] FROM [unblinded-tokens] ORDER BY [token] LIMIT ?
             """,
             (count,),
         )

--- a/src/_zkapauthorizer/tests/test_model.py
+++ b/src/_zkapauthorizer/tests/test_model.py
@@ -276,7 +276,7 @@ class UnblindedTokenStoreTests(TestCase):
         )
         store.insert_unblinded_tokens_for_voucher(voucher_value, tokens)
         retrieved_tokens = store.extract_unblinded_tokens(len(tokens))
-        self.expectThat(tokens, Equals(retrieved_tokens))
+        self.expectThat(tokens, AfterPreprocessing(sorted, Equals(retrieved_tokens)))
 
         # After extraction, the unblinded tokens are no longer available.
         more_unblinded_tokens = store.extract_unblinded_tokens(1)


### PR DESCRIPTION
Fixes: #60 

Note most of this feature was already implemented by #56.  This only ensures the tokens come out in a particular order which is convenient for backup/store purposes.
