### PR TITLE
remove the circleci-cli dependency

### DIFF
--- a/zkapauthorizer.nix
+++ b/zkapauthorizer.nix
@@ -1,4 +1,4 @@
-{ buildPythonPackage, sphinx,
+{ buildPythonPackage, sphinx
 , attrs, zope_interface, aniso8601, twisted, tahoe-lafs, privacypass
 , fixtures, testtools, hypothesis, pyflakes, treq, coverage
 , hypothesisProfile ? null

--- a/zkapauthorizer.nix
+++ b/zkapauthorizer.nix
@@ -1,4 +1,4 @@
-{ buildPythonPackage, sphinx, circleci-cli
+{ buildPythonPackage, sphinx,
 , attrs, zope_interface, aniso8601, twisted, tahoe-lafs, privacypass
 , fixtures, testtools, hypothesis, pyflakes, treq, coverage
 , hypothesisProfile ? null
@@ -21,7 +21,6 @@ buildPythonPackage rec {
 
   depsBuildBuild = [
     sphinx
-    circleci-cli
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
This is a hold-over from setting up a manual administration/management environment.  It's not related to actually packaging the Python software.