### PR TITLE
Fix `required_passes` docs and (implementation for large results)

### DIFF
--- a/src/_zkapauthorizer/storage_common.py
+++ b/src/_zkapauthorizer/storage_common.py
@@ -24,10 +24,6 @@ from base64 import (
     b64encode,
 )
 
-from math import (
-    ceil,
-)
-
 def _message_maker(label):
     def make_message(storage_index):
         return u"{label} {storage_index}".format(
@@ -59,17 +55,16 @@ def required_passes(bytes_per_pass, share_sizes):
 
     :return int: The number of passes required to cover the storage cost.
     """
-    result = int(
-        ceil(
-            sum(share_sizes, 0) / bytes_per_pass,
-        ),
-    )
     if not isinstance(share_sizes, list):
         raise TypeError(
             "Share sizes must be a list of integers, got {!r} instead".format(
                 share_sizes,
             ),
         )
+    result, b = divmod(sum(share_sizes, 0), bytes_per_pass)
+    if b:
+        result += 1
+
     # print("required_passes({}, {}) == {}".format(bytes_per_pass, share_sizes, result))
     return result
 

--- a/src/_zkapauthorizer/storage_common.py
+++ b/src/_zkapauthorizer/storage_common.py
@@ -55,7 +55,7 @@ def required_passes(bytes_per_pass, share_sizes):
     :param int bytes_per_pass: The number of bytes the storage of which for
         one lease period one pass covers.
 
-    :param set[int] share_sizes: The sizes of the shared which will be stored.
+    :param list[int] share_sizes: The sizes of the shared which will be stored.
 
     :return int: The number of passes required to cover the storage cost.
     """
@@ -64,6 +64,12 @@ def required_passes(bytes_per_pass, share_sizes):
             sum(share_sizes, 0) / bytes_per_pass,
         ),
     )
+    if not isinstance(share_sizes, list):
+        raise TypeError(
+            "Share sizes must be a list of integers, got {!r} instead".format(
+                share_sizes,
+            ),
+        )
     # print("required_passes({}, {}) == {}".format(bytes_per_pass, share_sizes, result))
     return result
 

--- a/src/_zkapauthorizer/tests/test_storage_protocol.py
+++ b/src/_zkapauthorizer/tests/test_storage_protocol.py
@@ -33,6 +33,7 @@ from testtools.matchers import (
     HasLength,
     IsInstance,
     AfterPreprocessing,
+    raises,
 )
 from testtools.twistedsupport import (
     succeeded,
@@ -49,7 +50,9 @@ from hypothesis import (
     assume,
 )
 from hypothesis.strategies import (
+    sets,
     tuples,
+    integers,
 )
 
 from twisted.python.filepath import (
@@ -101,6 +104,7 @@ from ..api import (
 from ..storage_common import (
     slot_testv_and_readv_and_writev_message,
     get_implied_data_length,
+    required_passes,
 )
 from ..model import (
     Pass,
@@ -147,6 +151,21 @@ class LocalRemote(object):
             kwargs,
         )
 
+
+class RequiredPassesTests(TestCase):
+    """
+    Tests for ``required_passes``.
+    """
+    @given(integers(min_value=1), sets(integers(min_value=0)))
+    def test_incorrect_types(self, bytes_per_pass, share_sizes):
+        """
+        ``required_passes`` raises ``TypeError`` if passed a ``set`` for
+        ``share_sizes``.
+        """
+        self.assertThat(
+            lambda: required_passes(bytes_per_pass, share_sizes),
+            raises(TypeError),
+        )
 
 class ShareTests(TestCase):
     """

--- a/src/_zkapauthorizer/tests/test_storage_protocol.py
+++ b/src/_zkapauthorizer/tests/test_storage_protocol.py
@@ -51,6 +51,7 @@ from hypothesis import (
 )
 from hypothesis.strategies import (
     sets,
+    lists,
     tuples,
     integers,
 )
@@ -166,6 +167,30 @@ class RequiredPassesTests(TestCase):
             lambda: required_passes(bytes_per_pass, share_sizes),
             raises(TypeError),
         )
+
+    @given(
+        bytes_per_pass=integers(min_value=1),
+        expected_per_share=lists(integers(min_value=1), min_size=1),
+    )
+    def test_minimum_result(self, bytes_per_pass, expected_per_share):
+        """
+        ``required_passes`` returns an integer giving the fewest passes required
+        to pay for the storage represented by the given share sizes.
+        """
+        actual = required_passes(
+            bytes_per_pass,
+            list(
+                passes * bytes_per_pass
+                for passes
+                in expected_per_share
+            ),
+        )
+        self.assertThat(
+            actual,
+            Equals(sum(expected_per_share)),
+        )
+
+
 
 class ShareTests(TestCase):
     """


### PR DESCRIPTION
Fixes #78 

Beyond fixing the docs and rejecting sets, this also works better for large results because making the function more correct also makes it easier to write the test...