### PR TITLE
Better misconfiguration failure

### DIFF
--- a/src/_zkapauthorizer/tests/_exception.py
+++ b/src/_zkapauthorizer/tests/_exception.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2009-2012 testtools developers.
+#
+# Copyright 2019 PrivateStorage.io, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = [
+    'MatchesExceptionType',
+    'Raises',
+    'raises',
+    ]
+
+import sys
+
+from testtools.matchers import (
+    Matcher,
+    Mismatch,
+)
+from testtools.content import (
+    TracebackContent,
+)
+
+
+def _is_exception(exc):
+    return isinstance(exc, BaseException)
+
+
+def _is_user_exception(exc):
+    return isinstance(exc, Exception)
+
+
+class MatchesExceptionType(Matcher):
+    """
+    Match an exc_info tuple against an exception type.
+    """
+
+    def __init__(self, exception_type):
+        """
+        Create a MatchesException that will match exc_info's for exception.
+
+        :param exception: An exception type.
+        """
+        Matcher.__init__(self)
+        self.expected = exception_type
+
+    def match(self, other):
+        if type(other) != tuple:
+            return Mismatch('{!r} is not an exc_info tuple'.format(other))
+        expected_class = self.expected
+        etype, evalue, etb = other
+        if not issubclass(etype, expected_class):
+            return Mismatch(
+                "{} is an instance of {}, expected an instance of {}.".format(
+                    evalue,
+                    etype,
+                    expected_class,
+                ),
+                dict(
+                    traceback=TracebackContent(other, None),
+                ),
+            )
+
+    def __str__(self):
+        return "MatchesExceptionType({!r})".format(self.expected)
+
+
+class Raises(Matcher):
+    """Match if the matchee raises an exception when called.
+
+    Exceptions which are not subclasses of Exception propogate out of the
+    Raises.match call unless they are explicitly matched.
+    """
+
+    def __init__(self, exception_matcher):
+        """
+        Create a Raises matcher.
+
+        :param exception_matcher: Validator for the exception raised by
+            matchee. The exc_info tuple for the exception raised is passed
+            into that matcher.
+        """
+        self.exception_matcher = exception_matcher
+
+    def match(self, matchee):
+        try:
+            result = matchee()
+            return Mismatch('%r returned %r' % (matchee, result))
+        # Catch all exceptions: Raises() should be able to match a
+        # KeyboardInterrupt or SystemExit.
+        except:
+            exc_info = sys.exc_info()
+            mismatch = self.exception_matcher.match(exc_info)
+            exc_type = exc_info[1]
+            # It's safer not to keep the traceback around.
+            del exc_info
+            if mismatch:
+                # The exception did not match, or no explicit matching logic was
+                # performed. If the exception is a non-user exception then
+                # propagate it.
+                if _is_exception(exc_type) and not _is_user_exception(exc_type):
+                    raise
+                return mismatch
+        return None
+
+    def __str__(self):
+        return 'Raises()'
+
+
+def raises(exception_type):
+    """Make a matcher that checks that a callable raises an exception.
+
+    This is a convenience function, exactly equivalent to::
+
+        return Raises(MatchesExceptionType(exception_type))
+
+    See `Raises` and `MatchesExceptionType` for more information.
+    """
+    return Raises(MatchesExceptionType(exception_type))

--- a/src/_zkapauthorizer/tests/foolscap.py
+++ b/src/_zkapauthorizer/tests/foolscap.py
@@ -1,0 +1,120 @@
+# Copyright 2019 PrivateStorage.io, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Testing helpers related to Foolscap.
+"""
+
+from __future__ import (
+    absolute_import,
+)
+
+from zope.interface import (
+    implementer,
+)
+
+import attr
+
+from twisted.internet.defer import (
+    execute,
+)
+
+from foolscap.api import (
+    RemoteInterface,
+)
+
+from allmydata.interfaces import (
+    RIStorageServer,
+)
+
+class RIStub(RemoteInterface):
+    pass
+
+@implementer(RIStorageServer)
+class StubStorageServer(object):
+    pass
+
+
+def get_anonymous_storage_server():
+    return StubStorageServer()
+
+
+@attr.s
+class DummyReferenceable(object):
+    _interface = attr.ib()
+
+    def getInterface(self):
+        return self._interface
+
+    def doRemoteCall(self, *a, **kw):
+        return None
+
+@attr.s
+class LocalTracker(object):
+    """
+    Pretend to be a tracker for a ``LocalRemote``.
+    """
+    interface = attr.ib()
+    interfaceName = attr.ib(default=None)
+
+    def __attrs_post_init__(self):
+        self.interfaceName = self.interface.__remote_name__
+
+    def getURL(self):
+        return b"pb://abcd@127.0.0.1:12345/efgh"
+
+
+@attr.s
+class LocalRemote(object):
+    """
+    Adapt a referenceable to behave as if it were a remote reference instead.
+
+    This is only a partial implementation of ``IRemoteReference`` so it
+    doesn't declare the interface.
+
+    ``foolscap.referenceable.LocalReferenceable`` is in many ways a better
+    adapter between these interfaces but it also uses ``eventually`` which
+    complicates matters immensely for testing.
+
+    :ivar foolscap.ipb.IReferenceable _referenceable: The object to which this
+        provides a simulated remote interface.
+    """
+    _referenceable = attr.ib()
+    check_args = attr.ib(default=True)
+    tracker = attr.ib(default=None)
+
+    def __attrs_post_init__(self):
+        self.tracker = LocalTracker(
+            self._referenceable.getInterface(),
+        )
+
+    def callRemote(self, methname, *args, **kwargs):
+        """
+        Call the given method on the wrapped object, passing the given arguments.
+
+        Arguments are checked for conformance to the remote interface but the
+        return value is not (because I don't know how -exarkun).
+
+        :return Deferred: The result of the call on the wrapped object.
+        """
+        schema = self._referenceable.getInterface()[methname]
+        if self.check_args:
+            schema.checkAllArgs(args, kwargs, inbound=False)
+        # TODO: Figure out how to call checkResults on the result.
+        return execute(
+            self._referenceable.doRemoteCall,
+            methname,
+            args,
+            kwargs,
+        )

--- a/src/_zkapauthorizer/tests/matchers.py
+++ b/src/_zkapauthorizer/tests/matchers.py
@@ -16,6 +16,15 @@
 Testtools matchers useful for the test suite.
 """
 
+__all__ = [
+    "Provides",
+    "raises",
+    "returns",
+    "matches_version_dictionary",
+    "between",
+    "leases_current",
+]
+
 from datetime import (
     datetime,
 )
@@ -34,6 +43,10 @@ from testtools.matchers import (
     Equals,
     AfterPreprocessing,
     AllMatch,
+)
+
+from ._exception import (
+    raises,
 )
 
 @attr.s

--- a/src/_zkapauthorizer/tests/test_foolscap.py
+++ b/src/_zkapauthorizer/tests/test_foolscap.py
@@ -1,0 +1,97 @@
+# Copyright 2019 PrivateStorage.io, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for Foolscap-related test helpers.
+"""
+
+from __future__ import (
+    absolute_import,
+)
+
+from testtools import (
+    TestCase,
+)
+from testtools.matchers import (
+    MatchesAll,
+    AfterPreprocessing,
+    Always,
+    IsInstance,
+)
+
+from foolscap.furl import (
+    decode_furl,
+)
+from foolscap.pb import (
+    Tub,
+)
+from foolscap.referenceable import (
+    RemoteReferenceTracker,
+    RemoteReferenceOnly,
+)
+
+from hypothesis import (
+    given,
+)
+from hypothesis.strategies import (
+    one_of,
+    just,
+)
+
+from .foolscap import (
+    RIStub,
+    LocalRemote,
+    DummyReferenceable,
+)
+
+def remote_reference():
+    tub = Tub()
+    tub.setLocation("127.0.0.1:12345")
+    url = tub.buildURL(b"efgh")
+
+    # Ugh ugh ugh.  Skip over the extra correctness checking in
+    # RemoteReferenceTracker.__init__ that requires having a broker by passing
+    # the url as None and setting it after.
+    tracker = RemoteReferenceTracker(None, None, None, RIStub)
+    tracker.url = url
+
+    ref = RemoteReferenceOnly(tracker)
+    return ref
+
+
+class LocalRemoteTests(TestCase):
+    """
+    Tests for the ``LocalRemote`` test double.
+    """
+    @given(
+        ref=one_of(
+            just(remote_reference()),
+            just(LocalRemote(DummyReferenceable(RIStub))),
+        ),
+    )
+    def test_tracker_url(self, ref):
+        """
+        The URL of a remote reference can be retrieved using the tracker
+        attribute.
+        """
+        self.assertThat(
+            ref.tracker.getURL(),
+            MatchesAll(
+                IsInstance(bytes),
+                AfterPreprocessing(
+                    decode_furl,
+                    Always(),
+                ),
+            ),
+        )

--- a/src/_zkapauthorizer/tests/test_storage_protocol.py
+++ b/src/_zkapauthorizer/tests/test_storage_protocol.py
@@ -20,8 +20,6 @@ from __future__ import (
     absolute_import,
 )
 
-import attr
-
 from fixtures import (
     MonkeyPatch,
 )
@@ -59,9 +57,6 @@ from hypothesis.strategies import (
 from twisted.python.filepath import (
     FilePath,
 )
-from twisted.internet.defer import (
-    execute,
-)
 
 from foolscap.referenceable import (
     LocalReferenceable,
@@ -98,6 +93,9 @@ from .storage_common import (
     cleanup_storage_server,
     write_toy_shares,
 )
+from .foolscap import (
+    LocalRemote,
+)
 from ..api import (
     ZKAPAuthorizerStorageServer,
     ZKAPAuthorizerStorageClient,
@@ -113,44 +111,6 @@ from ..model import (
 from ..foolscap import (
     ShareStat,
 )
-
-@attr.s
-class LocalRemote(object):
-    """
-    Adapt a referenceable to behave as if it were a remote reference instead.
-
-    This is only a partial implementation of ``IRemoteReference`` so it
-    doesn't declare the interface.
-
-    ``foolscap.referenceable.LocalReferenceable`` is in many ways a better
-    adapter between these interfaces but it also uses ``eventually`` which
-    complicates matters immensely for testing.
-
-    :ivar foolscap.ipb.IReferenceable _referenceable: The object to which this
-        provides a simulated remote interface.
-    """
-    _referenceable = attr.ib()
-    check_args = attr.ib(default=True)
-
-    def callRemote(self, methname, *args, **kwargs):
-        """
-        Call the given method on the wrapped object, passing the given arguments.
-
-        Arguments are checked for conformance to the remote interface but the
-        return value is not (because I don't know how -exarkun).
-
-        :return Deferred: The result of the call on the wrapped object.
-        """
-        schema = self._referenceable.getInterface()[methname]
-        if self.check_args:
-            schema.checkAllArgs(args, kwargs, inbound=False)
-        # TODO: Figure out how to call checkResults on the result.
-        return execute(
-            self._referenceable.doRemoteCall,
-            methname,
-            args,
-            kwargs,
-        )
 
 
 class RequiredPassesTests(TestCase):


### PR DESCRIPTION
Fixes #83 by raising a specific exception, `IncorrectStorageServerReference`, if the object reachable using the storage server furl from the configuration/announcement does not provide the expected remote interface.
