### PR TITLE
Bust the cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,8 +106,8 @@ jobs:
             # If nixpkgs changes then potentially a lot of cached packages for
             # the base system will be invalidated so we may as well drop them
             # and make a new cache with the new packages.
-            - zkapauthorizer-nix-store-v2-{{ checksum "nixpkgs.rev" }}
-            - zkapauthorizer-nix-store-v2-
+            - zkapauthorizer-nix-store-v3-{{ checksum "nixpkgs.rev" }}
+            - zkapauthorizer-nix-store-v3-
 
       - run:
           name: "Run Test Suite"
@@ -136,7 +136,7 @@ jobs:
 
       - save_cache:
           name: "Cache Nix Store Paths"
-          key: zkapauthorizer-nix-store-v2-{{ checksum "nixpkgs.rev" }}
+          key: zkapauthorizer-nix-store-v3-{{ checksum "nixpkgs.rev" }}
           paths:
             - "/nix"
 


### PR DESCRIPTION
Our dependencies changed a while ago but we probably kept using the same cache
so we never updated it with the builds of the new dependencies.

Fixes #117 