### PR TITLE
[WIP] Greatly reduce the interval between redemption retries

### DIFF
--- a/src/_zkapauthorizer/controller.py
+++ b/src/_zkapauthorizer/controller.py
@@ -101,7 +101,7 @@ from .model import (
     Error as model_Error,
 )
 
-RETRY_INTERVAL = timedelta(seconds=10)
+RETRY_INTERVAL = timedelta(seconds=0)
 
 class AlreadySpent(Exception):
     """

--- a/src/_zkapauthorizer/controller.py
+++ b/src/_zkapauthorizer/controller.py
@@ -101,7 +101,7 @@ from .model import (
     Error as model_Error,
 )
 
-RETRY_INTERVAL = timedelta(minutes=3)
+RETRY_INTERVAL = timedelta(seconds=10)
 
 class AlreadySpent(Exception):
     """

--- a/src/_zkapauthorizer/controller.py
+++ b/src/_zkapauthorizer/controller.py
@@ -101,7 +101,7 @@ from .model import (
     Error as model_Error,
 )
 
-RETRY_INTERVAL = timedelta(seconds=0)
+RETRY_INTERVAL = timedelta(milliseconds=1)
 
 class AlreadySpent(Exception):
     """


### PR DESCRIPTION
Relates to #146 

This is probably not a great solution.  In the case where a voucher is never paid, it imposes a much greater burden on both the client and the payment server.

Still, here's what it looks like.