### PR TITLE
Report "Parsing redeem response failed" better

### DIFF
--- a/src/_zkapauthorizer/controller.py
+++ b/src/_zkapauthorizer/controller.py
@@ -944,8 +944,8 @@ class PaymentController(object):
             self._unpaid[voucher] = self.store.now()
         else:
             self._log.error(
-                "Redeeming random tokens for a voucher ({voucher}) failed: {reason}",
-                reason=reason,
+                "Redeeming random tokens for a voucher ({voucher}) failed: {reason!r}",
+                reason=reason.value,
                 voucher=voucher,
             )
             self._error[voucher] = model_Error(

--- a/src/_zkapauthorizer/controller.py
+++ b/src/_zkapauthorizer/controller.py
@@ -33,6 +33,7 @@ from functools import (
 )
 from json import (
     dumps,
+    loads,
 )
 from datetime import (
     timedelta,
@@ -75,7 +76,7 @@ from twisted.web.client import (
     Agent,
 )
 from treq import (
-    json_content,
+    content,
 )
 from treq.client import (
     HTTPClient,
@@ -533,11 +534,12 @@ class RistrettoRedeemer(object):
             }),
             headers={b"content-type": b"application/json"},
         )
+        response_body = yield content(response)
+
         try:
-            result = yield json_content(response)
+            result = loads(response_body)
         except ValueError:
-            self._log.failure("Parsing redeem response failed", response=response)
-            raise
+            raise UnexpectedResponse(response.code, response_body)
 
         success = result.get(u"success", False)
         if not success:

--- a/src/_zkapauthorizer/controller.py
+++ b/src/_zkapauthorizer/controller.py
@@ -103,6 +103,15 @@ from .model import (
 
 RETRY_INTERVAL = timedelta(milliseconds=1)
 
+@attr.s
+class UnexpectedResponse(Exception):
+    """
+    The issuer responded in an unexpected and unhandled way.
+    """
+    code = attr.ib()
+    body = attr.ib()
+
+
 class AlreadySpent(Exception):
     """
     An attempt was made to redeem a voucher which has already been redeemed.

--- a/src/_zkapauthorizer/tests/test_controller.py
+++ b/src/_zkapauthorizer/tests/test_controller.py
@@ -50,7 +50,6 @@ from testtools.matchers import (
     HasLength,
     AfterPreprocessing,
     MatchesStructure,
-    ContainsDict,
 )
 from testtools.twistedsupport import (
     succeeded,


### PR DESCRIPTION
Fixes #102 

The logs for this case will now look something like this:

```
[_zkapauthorizer.controller.PaymentController#error] Redeeming random tokens for a voucher (dnP...) failed: UnexpectedResponse(code=500, body='exception: SQLite3 returned ErrorBusy while attempting to perform step: database is locked') 
```

The underlying problem is unresolved, of course, but at least it should be more clear which problem is being hit.
