### PR TITLE
Add ``default-token-count`` configuration item

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,6 +196,17 @@ jobs:
             - zkapauthorizer-nix-store-v4-
 
       - run:
+          name: "Build challenge-bypass-ristretto"
+          command: |
+            # Pre-build this because doing so is somewhat memory intensive and
+            # we want to turn off concurrency for this part.  We want to be
+            # able to leave concurrency on for the rest of the build, though,
+            # where it doesn't cause problems and speeds things up.
+            nix-build --cores 1 --max-jobs 1 \
+              --arg callPackage '(import <nixpkgs> { }).callPackage' \
+              ./python-challenge-bypass-ristretto.nix
+
+      - run:
           name: "Run Test Suite"
           command: |
             # Building the package has, as a side effect, running the test
@@ -208,10 +219,7 @@ jobs:
             #
             # Further, we want the "doc" output built as well because that's
             # where the coverage data ends up.
-            #
-            # Also limit the number of concurrent jobs because of resource
-            # constraints on CircleCI. :/
-            nix-build --cores 1 --max-jobs 1 --argstr hypothesisProfile ci --arg collectCoverage true --attr doc
+            nix-build --argstr hypothesisProfile ci --arg collectCoverage true --attr doc
 
       - save_cache:
           name: "Cache Nix Store Paths"

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -42,6 +42,13 @@ The client can also be configured with the value of a single pass::
 
 The value given here must agree with the value servers use in their configuration or the storage service will be unusable.
 
+The client can also be configured with the number of passes to expect in exchange for one voucher::
+
+  [storageclient.plugins.privatestorageio-zkapauthz-v1]
+  default-token-count = 32768
+
+The value given here must agree with the value the issuer uses in its configuration or redemption may fail.
+
 Server
 ------
 

--- a/src/_zkapauthorizer/_plugin.py
+++ b/src/_zkapauthorizer/_plugin.py
@@ -185,17 +185,12 @@ class ZKAPAuthorizer(object):
         )
 
 
-    def get_client_resource(self, node_config, default_token_count=None, reactor=None):
+    def get_client_resource(self, node_config, reactor=None):
         """
         Get an ``IZKAPRoot`` for the given node configuration.
 
         :param allmydata.node._Config node_config: The configuration object
             for the relevant node.
-
-        :param int default_token_count: Configure the payment controller with
-            a default number of tokens to request during voucher redemption.
-            This is only used if a number of tokens isn't specified at the
-            point of redemption.
         """
         if reactor is None:
             from twisted.internet import reactor
@@ -203,7 +198,6 @@ class ZKAPAuthorizer(object):
             node_config,
             store=self._get_store(node_config),
             redeemer=self._get_redeemer(node_config, None, reactor),
-            default_token_count=default_token_count,
             clock=reactor,
         )
 

--- a/src/_zkapauthorizer/configutil.py
+++ b/src/_zkapauthorizer/configutil.py
@@ -1,0 +1,75 @@
+# Copyright 2021 PrivateStorage.io, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Basic utilities related to the Tahoe configuration file.
+"""
+
+from __future__ import (
+    division,
+    absolute_import,
+    print_function,
+    unicode_literals,
+)
+
+
+def _merge_dictionaries(dictionaries):
+    """
+    Collapse a sequence of dictionaries into one, with collisions resolved by
+    taking the value from later dictionaries in the sequence.
+
+    :param [dict] dictionaries: The dictionaries to collapse.
+
+    :return dict: The collapsed dictionary.
+    """
+    result = {}
+    for d in dictionaries:
+        result.update(d)
+    return result
+
+
+def _tahoe_config_quote(text):
+    """
+    Quote **%** in a unicode string.
+
+    :param unicode text: The string on which to perform quoting.
+
+    :return unicode: The string with ``%%`` replacing ``%``.
+    """
+    return text.replace("%", "%%")
+
+
+def config_string_from_sections(divided_sections):
+    """
+    Get the .ini-syntax unicode string representing the given configuration
+    values.
+
+    :param [dict] divided_sections: The configuration to use to generate the
+        string.  Each ``dict`` maps a top-level section name to a ``dict`` of
+        key/value pairs.  Dictionaries may have overlapping top-level
+        sections, in which case the section items are merged (for collisions,
+        last value wins).
+    """
+    sections = _merge_dictionaries(divided_sections)
+    return "".join(list(
+        "[{name}]\n{items}\n".format(
+            name=name,
+            items="\n".join(
+                "{key} = {value}".format(key=key, value=_tahoe_config_quote(value))
+                for (key, value)
+                in contents.items()
+            )
+        )
+        for (name, contents) in sections.items()
+    ))

--- a/src/_zkapauthorizer/resource.py
+++ b/src/_zkapauthorizer/resource.py
@@ -91,11 +91,33 @@ class IZKAPRoot(IResource):
     controller = Attribute("The ``PaymentController`` used by this resource tree.")
 
 
+def get_token_count(
+        plugin_name,
+        node_config,
+):
+    """
+    Retrieve the configured voucher value, in number of tokens, from the given
+    configuration.
+
+    :param unicode plugin_name: The plugin name to use to choose a
+        configuration section.
+
+    :param _Config node_config: See ``from_configuration``.
+
+    :param int default: The value to return if none is configured.
+    """
+    section_name = u"storageclient.plugins.{}".format(plugin_name)
+    return int(node_config.get_config(
+        section=section_name,
+        option=u"default-token-count",
+        default=NUM_TOKENS,
+    ))
+
+
 def from_configuration(
         node_config,
         store,
         redeemer=None,
-        default_token_count=None,
         clock=None,
 ):
     """
@@ -114,22 +136,23 @@ def from_configuration(
     :param IRedeemer redeemer: The voucher redeemer to use.  If ``None`` a
         sensible one is constructed.
 
-    :param default_token_count: See ``PaymentController.default_token_count``.
-
     :param clock: See ``PaymentController._clock``.
 
     :return IZKAPRoot: The root of the resource hierarchy presented by the
         client side of the plugin.
     """
+    plugin_name = u"privatestorageio-zkapauthz-v1"
     if redeemer is None:
         redeemer = get_redeemer(
-            u"privatestorageio-zkapauthz-v1",
+            plugin_name,
             node_config,
             None,
             None,
         )
-    if default_token_count is None:
-        default_token_count = NUM_TOKENS
+    default_token_count = get_token_count(
+        plugin_name,
+        node_config,
+    )
     controller = PaymentController(
         store,
         redeemer,

--- a/src/_zkapauthorizer/tests/strategies.py
+++ b/src/_zkapauthorizer/tests/strategies.py
@@ -236,6 +236,7 @@ def client_ristrettoredeemer_configurations():
     return just({
         u"ristretto-issuer-root-url": u"https://issuer.example.invalid/",
         u"redeemer": u"ristretto",
+        u"default-token-count": u"32",
     })
 
 
@@ -245,6 +246,7 @@ def client_dummyredeemer_configurations():
     """
     return just({
         u"redeemer": u"dummy",
+        u"default-token-count": u"32",
     })
 
 
@@ -272,6 +274,7 @@ def client_unpaidredeemer_configurations():
     """
     return just({
         u"redeemer": u"unpaid",
+        u"default-token-count": u"32",
     })
 
 
@@ -281,6 +284,7 @@ def client_nonredeemer_configurations():
     """
     return just({
         u"redeemer": u"non",
+        u"default-token-count": u"32",
     })
 
 
@@ -291,6 +295,7 @@ def client_errorredeemer_configurations(details):
     return just({
         u"redeemer": u"error",
         u"details": details,
+        u"default-token-count": u"32",
     })
 
 

--- a/src/_zkapauthorizer/tests/test_client_resource.py
+++ b/src/_zkapauthorizer/tests/test_client_resource.py
@@ -384,7 +384,7 @@ class GetTokenCountTests(TestCase):
                 u"default-token-count": u"{}".format(expected_count)
             }
 
-        config_text = _config_string_from_sections([{
+        config_text = config_string_from_sections([{
             u"storageclient.plugins." + plugin_name: token_config,
         }])
         node_config = config_from_string(

--- a/src/_zkapauthorizer/tests/test_plugin.py
+++ b/src/_zkapauthorizer/tests/test_plugin.py
@@ -551,7 +551,6 @@ class ClientResourceTests(TestCase):
         self.assertThat(
             storage_server.get_client_resource(
                 config,
-                default_token_count=10,
                 reactor=Clock(),
             ),
             Provides([IResource]),


### PR DESCRIPTION
The redeemer will submit this many tokens with its redemption request now.  It
needs to agree with whatever the issuer wants to do, of course.

Fixes #186 