### PR TITLE
Eliminate white space around ristretto key when reading key file

### DIFF
--- a/src/_zkapauthorizer/_plugin.py
+++ b/src/_zkapauthorizer/_plugin.py
@@ -145,7 +145,7 @@ class ZKAPAuthorizer(object):
         signing_key = SigningKey.decode_base64(
             FilePath(
                 kwargs.pop(u"ristretto-signing-key-path"),
-            ).getContent(),
+            ).getContent().strip(),
         )
         announcement = {
             u"ristretto-issuer-root-url": root_url,

--- a/src/_zkapauthorizer/tests/testing-signing.key
+++ b/src/_zkapauthorizer/tests/testing-signing.key
@@ -1,1 +1,2 @@
-mkQf85V2vyLQRUYuqRb+Ke6K+M9pOtXm4MslsuCdBgg=
+mkQf85V2vyLQRUYuqRb+Ke6K+M9pOtXm4MslsuCdBgg= 
+


### PR DESCRIPTION
It is easy to erroneously add extra white space to a text file. For example when writing with an editor like `nano` or when using `echo` without the `-n` argument.

Handing that white space over to python-challenge-bypass-ristretto's `decode_base64()` method will make it fail in a rather opaque way, see https://github.com/LeastAuthority/python-challenge-bypass-ristretto/issues/37.

This eliminates white space including newlines around the key expected to be in that file.