### PR TITLE
Remove `renew_lease` from our storage protocol

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
       # somewhat current as of the time of this comment.  We can bump it to a
       # newer version when that makes sense.  Meanwhile, the platform won't
       # shift around beneath us unexpectedly.
-      NIX_PATH: "nixpkgs=https://github.com/PrivateStorageio/nixpkgs/archive/730129887a84a8f84f3b78ffac7add72aeb551b6.tar.gz"
+      NIX_PATH: "nixpkgs=https://github.com/PrivateStorageio/nixpkgs/archive/c12c213c1c96bd1fea9f83f9e9e1fea28d0eaec6.tar.gz"
 
     steps:
       - run:

--- a/src/_zkapauthorizer/_storage_client.py
+++ b/src/_zkapauthorizer/_storage_client.py
@@ -66,7 +66,6 @@ from .storage_common import (
     required_passes,
     allocate_buckets_message,
     add_lease_message,
-    renew_lease_message,
     slot_testv_and_readv_and_writev_message,
     has_writes,
     get_required_new_passes_for_mutable_write,
@@ -400,33 +399,6 @@ class ZKAPAuthorizerStorageClient(object):
             ),
             num_passes,
             partial(self._get_passes, add_lease_message(storage_index).encode("utf-8")),
-        )
-        returnValue(result)
-
-    @inline_callbacks
-    @with_rref
-    def renew_lease(
-            self,
-            rref,
-            storage_index,
-            renew_secret,
-    ):
-        share_sizes = (yield rref.callRemote(
-            "share_sizes",
-            storage_index,
-            None,
-        )).values()
-        num_passes = required_passes(self._pass_value, share_sizes)
-
-        result = yield call_with_passes(
-            lambda passes: rref.callRemote(
-                "renew_lease",
-                _encode_passes(passes),
-                storage_index,
-                renew_secret,
-            ),
-            num_passes,
-            partial(self._get_passes, renew_lease_message(storage_index).encode("utf-8")),
         )
         returnValue(result)
 

--- a/src/_zkapauthorizer/_storage_server.py
+++ b/src/_zkapauthorizer/_storage_server.py
@@ -103,7 +103,6 @@ from .storage_common import (
     required_passes,
     allocate_buckets_message,
     add_lease_message,
-    renew_lease_message,
     slot_testv_and_readv_and_writev_message,
     has_writes,
     get_required_new_passes_for_mutable_write,
@@ -301,24 +300,6 @@ class ZKAPAuthorizerStorageServer(Referenceable):
             self._original,
         )
         return self._original.remote_add_lease(storage_index, *a, **kw)
-
-    def remote_renew_lease(self, passes, storage_index, *a, **kw):
-        """
-        Pass-through after a pass check to ensure clients can only extend the
-        duration of share storage if they present valid passes.
-        """
-        valid_passes = _ValidationResult.validate_passes(
-            renew_lease_message(storage_index),
-            passes,
-            self._signing_key,
-        )
-        check_pass_quantity_for_lease(
-            self._pass_value,
-            storage_index,
-            valid_passes,
-            self._original,
-        )
-        return self._original.remote_renew_lease(storage_index, *a, **kw)
 
     def remote_advise_corrupt_share(self, *a, **kw):
         """

--- a/src/_zkapauthorizer/foolscap.py
+++ b/src/_zkapauthorizer/foolscap.py
@@ -141,6 +141,20 @@ def add_arguments(schema, kwargs):
     return modified_schema
 
 
+def remoteinterface_hasattr(ri, name):
+    """
+    :param InterfaceClass ri: A ``RemoteInterface`` to inspect.
+    :param str name: The name of an attribute.
+
+    :return bool: ``True`` if and only if ``ri`` has the attribute named by
+        ``name``, ``False`` otherwise.
+    """
+    try:
+        ri[name]
+    except KeyError:
+        return False
+    return True
+
 
 class RIPrivacyPassAuthorizedStorageServer(RemoteInterface):
     """
@@ -162,7 +176,7 @@ class RIPrivacyPassAuthorizedStorageServer(RemoteInterface):
 
     add_lease = add_passes(RIStorageServer["add_lease"])
 
-    if "renew_lease" in RIStorageServer:
+    if remoteinterface_hasattr(RIStorageServer, "renew_lease"):
         # Tahoe-LAFS 1.16.0 drops renew_lease from the interface.  Do likewise
         # here, if we discover we have a version of Tahoe that has done so.
         # If Tahoe has dropped this method then nothing in Tahoe is going to

--- a/src/_zkapauthorizer/foolscap.py
+++ b/src/_zkapauthorizer/foolscap.py
@@ -162,7 +162,13 @@ class RIPrivacyPassAuthorizedStorageServer(RemoteInterface):
 
     add_lease = add_passes(RIStorageServer["add_lease"])
 
-    renew_lease = add_passes(RIStorageServer["renew_lease"])
+    if "renew_lease" in RIStorageServer:
+        # Tahoe-LAFS 1.16.0 drops renew_lease from the interface.  Do likewise
+        # here, if we discover we have a version of Tahoe that has done so.
+        # If Tahoe has dropped this method then nothing in Tahoe is going to
+        # use it so it is fine if we don't define it.  We also do not use it
+        # ourselves.
+        renew_lease = add_passes(RIStorageServer["renew_lease"])
 
     get_buckets = RIStorageServer["get_buckets"]
 

--- a/src/_zkapauthorizer/foolscap.py
+++ b/src/_zkapauthorizer/foolscap.py
@@ -141,21 +141,6 @@ def add_arguments(schema, kwargs):
     return modified_schema
 
 
-def remoteinterface_hasattr(ri, name):
-    """
-    :param InterfaceClass ri: A ``RemoteInterface`` to inspect.
-    :param str name: The name of an attribute.
-
-    :return bool: ``True`` if and only if ``ri`` has the attribute named by
-        ``name``, ``False`` otherwise.
-    """
-    try:
-        ri[name]
-    except KeyError:
-        return False
-    return True
-
-
 class RIPrivacyPassAuthorizedStorageServer(RemoteInterface):
     """
     An object which can store and retrieve shares, subject to pass-based
@@ -175,14 +160,6 @@ class RIPrivacyPassAuthorizedStorageServer(RemoteInterface):
     allocate_buckets = add_passes(RIStorageServer["allocate_buckets"])
 
     add_lease = add_passes(RIStorageServer["add_lease"])
-
-    if remoteinterface_hasattr(RIStorageServer, "renew_lease"):
-        # Tahoe-LAFS 1.16.0 drops renew_lease from the interface.  Do likewise
-        # here, if we discover we have a version of Tahoe that has done so.
-        # If Tahoe has dropped this method then nothing in Tahoe is going to
-        # use it so it is fine if we don't define it.  We also do not use it
-        # ourselves.
-        renew_lease = add_passes(RIStorageServer["renew_lease"])
 
     get_buckets = RIStorageServer["get_buckets"]
 

--- a/src/_zkapauthorizer/storage_common.py
+++ b/src/_zkapauthorizer/storage_common.py
@@ -70,7 +70,6 @@ def _message_maker(label):
 # construction for different Tahoe-LAFS storage operations.
 allocate_buckets_message = _message_maker(u"allocate_buckets")
 add_lease_message = _message_maker(u"add_lease")
-renew_lease_message = _message_maker(u"renew_lease")
 slot_testv_and_readv_and_writev_message = _message_maker(u"slot_testv_and_readv_and_writev")
 
 # The number of bytes we're willing to store for a lease period for each pass

--- a/src/_zkapauthorizer/tests/fixtures.py
+++ b/src/_zkapauthorizer/tests/fixtures.py
@@ -37,6 +37,7 @@ from twisted.python.filepath import (
 from twisted.internet.task import (
     Clock,
 )
+from allmydata import __version__ as allmydata_version
 from allmydata.storage.server import (
     StorageServer,
 )

--- a/src/_zkapauthorizer/tests/fixtures.py
+++ b/src/_zkapauthorizer/tests/fixtures.py
@@ -38,6 +38,7 @@ from twisted.internet.task import (
     Clock,
 )
 from allmydata import __version__ as allmydata_version
+print("allmydata_version: {!r}".format(allmydata_version))
 from allmydata.storage.server import (
     StorageServer,
 )

--- a/src/_zkapauthorizer/tests/fixtures.py
+++ b/src/_zkapauthorizer/tests/fixtures.py
@@ -37,8 +37,6 @@ from twisted.python.filepath import (
 from twisted.internet.task import (
     Clock,
 )
-from allmydata import __version__ as allmydata_version
-print("allmydata_version: {!r}".format(allmydata_version))
 from allmydata.storage.server import (
     StorageServer,
 )

--- a/src/_zkapauthorizer/tests/strategies.py
+++ b/src/_zkapauthorizer/tests/strategies.py
@@ -812,18 +812,29 @@ def posix_safe_datetimes():
     )
 
 
-def clocks(now=posix_safe_datetimes()):
+def posix_timestamps():
+    """
+    Build floats in a range that can represent time without losing microsecond
+    precision.
+    """
+    return posix_safe_datetimes().map(
+        lambda when: (when - _POSIX_EPOCH).total_seconds(),
+    )
+
+
+def clocks(now=posix_timestamps()):
     """
     Build ``twisted.internet.task.Clock`` instances set to a time built by
     ``now``.
+
+    :param now: A strategy that builds POSIX timestamps (ie, ints or floats in
+        the range of time_t).
     """
     def clock_at_time(when):
         c = Clock()
-        c.advance((when - _POSIX_EPOCH).total_seconds())
+        c.advance(when)
         return c
     return now.map(clock_at_time)
-
-
 
 
 @implementer(IFilesystemNode)

--- a/src/_zkapauthorizer/tests/test_storage_protocol.py
+++ b/src/_zkapauthorizer/tests/test_storage_protocol.py
@@ -224,12 +224,14 @@ class ShareTests(TestCase):
             self.anonymous_storage_server,
             self.pass_value,
             self.signing_key,
+            clock=self.clock,
         )
         self.local_remote_server = LocalRemote(self.server)
         self.client = ZKAPAuthorizerStorageClient(
             self.pass_value,
             get_rref=lambda: self.local_remote_server,
             get_passes=self.pass_factory.get,
+            clock=self.clock,
         )
 
     def test_get_version(self):
@@ -1011,10 +1013,6 @@ class ShareTests(TestCase):
         # Hypothesis causes our storage server to be used many times.  Clean
         # up between iterations.
         cleanup_storage_server(self.anonymous_storage_server)
-
-        # Make the client and server use our clock.
-        self.server._clock = clock
-        self.client._clock = clock
 
         secrets = (write_enabler, renew_secret, cancel_secret)
 

--- a/src/_zkapauthorizer/tests/test_storage_protocol.py
+++ b/src/_zkapauthorizer/tests/test_storage_protocol.py
@@ -25,6 +25,7 @@ from fixtures import (
 )
 from testtools import (
     TestCase,
+    skipIf,
 )
 from testtools.matchers import (
     Always,
@@ -72,6 +73,7 @@ from challenge_bypass_ristretto import (
     random_signing_key,
 )
 
+from allmydata import __version__ as allmydata_version
 from allmydata.storage.common import (
     storage_index_to_dir,
 )
@@ -129,6 +131,7 @@ from .._storage_client import (
 from ..foolscap import (
     ShareStat,
 )
+
 
 class RequiredPassesTests(TestCase):
     """
@@ -522,6 +525,7 @@ class ShareTests(TestCase):
         leases = list(self.anonymous_storage_server.get_leases(storage_index))
         self.assertThat(leases, HasLength(2))
 
+    @skipIf(allmydata_version >= "1.16.", "Tahoe-LAFS 1.16.0 removed renew_lease")
     @given(
         storage_index=storage_indexes(),
         renew_secret=lease_renew_secrets(),

--- a/src/_zkapauthorizer/tests/test_storage_server.py
+++ b/src/_zkapauthorizer/tests/test_storage_server.py
@@ -204,7 +204,9 @@ class PassValidationTests(TestCase):
         # the same time so we can do lease expiration calculations more
         # easily.
         self.clock.advance(time())
-        self.anonymous_storage_server = self.useFixture(AnonymousStorageServer()).storage_server
+        self.anonymous_storage_server = self.useFixture(
+            AnonymousStorageServer(self.clock),
+        ).storage_server
         self.signing_key = random_signing_key()
         self.storage_server = ZKAPAuthorizerStorageServer(
             self.anonymous_storage_server,

--- a/src/_zkapauthorizer/tests/test_storage_server.py
+++ b/src/_zkapauthorizer/tests/test_storage_server.py
@@ -97,7 +97,6 @@ from ..storage_common import (
     required_passes,
     allocate_buckets_message,
     add_lease_message,
-    renew_lease_message,
     slot_testv_and_readv_and_writev_message,
     get_implied_data_length,
     get_required_new_passes_for_mutable_write,
@@ -539,40 +538,6 @@ class PassValidationTests(TestCase):
             allocated_size,
             add_lease,
             add_lease_message,
-        )
-
-    @given(
-        storage_index=storage_indexes(),
-        secrets=tuples(
-            lease_renew_secrets(),
-            lease_cancel_secrets(),
-        ),
-        sharenums=sharenum_sets(),
-        allocated_size=sizes(),
-    )
-    def test_renew_lease_fails_without_passes(self, storage_index, secrets, sharenums, allocated_size):
-        """
-        If ``remote_renew_lease`` is invoked without supplying enough passes to
-        cover the storage for all shares on the given storage index, the
-        operation fails with ``MorePassesRequired``.
-        """
-        renew_secret, cancel_secret = secrets
-        def renew_lease(storage_server, passes):
-            return storage_server.doRemoteCall(
-                "renew_lease", (
-                    passes,
-                    storage_index,
-                    renew_secret,
-                ),
-                {},
-            )
-        return self._test_lease_operation_fails_without_passes(
-            storage_index,
-            secrets,
-            sharenums,
-            allocated_size,
-            renew_lease,
-            renew_lease_message,
         )
 
     @given(


### PR DESCRIPTION
Fixes #224 
Fixes #230 

Started off trying to accommodate Tahoe-LAFS <1.16 and >=1.16 with conditionals, morphed into just deleting `renew_lease` after #230 became apparent.

Apart from deleted code this includes some other fixes for lease-related tests to handle implementation changes in Tahoe-LAFS around telling time.

Note the merge target is #229 and this should fix most of the test failures with the new CI configuration supplied there.