### PR TITLE
Fix unicode/bytes handling in Tahoe config code

### DIFF
--- a/src/_zkapauthorizer/tests/test_plugin.py
+++ b/src/_zkapauthorizer/tests/test_plugin.py
@@ -21,7 +21,7 @@ from __future__ import (
 )
 
 from io import (
-    BytesIO,
+    StringIO,
 )
 from os import (
     makedirs,
@@ -397,7 +397,7 @@ class ClientPluginTests(TestCase):
             b"tub.port",
             config_text.encode("utf-8"),
         )
-        config_text = BytesIO()
+        config_text = StringIO()
         node_config.config.write(config_text)
         self.addDetail(u"config", text_content(config_text.getvalue()))
         self.addDetail(u"announcement", text_content(unicode(announcement)))

--- a/src/_zkapauthorizer/tests/test_plugin.py
+++ b/src/_zkapauthorizer/tests/test_plugin.py
@@ -20,7 +20,7 @@ from __future__ import (
     absolute_import,
 )
 
-from io import (
+from StringIO import (
     StringIO,
 )
 from os import (
@@ -397,6 +397,11 @@ class ClientPluginTests(TestCase):
             b"tub.port",
             config_text.encode("utf-8"),
         )
+        # On Tahoe-LAFS <1.16, the config is written as bytes.
+        # On Tahoe-LAFS >=1.16, the config is written as unicode.
+        #
+        # After support for Tahoe <1.16 support is dropped we probably want to
+        # switch to an io.StringIO here.
         config_text = StringIO()
         node_config.config.write(config_text)
         self.addDetail(u"config", text_content(config_text.getvalue()))

--- a/src/_zkapauthorizer/tests/test_plugin.py
+++ b/src/_zkapauthorizer/tests/test_plugin.py
@@ -400,6 +400,11 @@ class ClientPluginTests(TestCase):
         # On Tahoe-LAFS <1.16, the config is written as bytes.
         # On Tahoe-LAFS >=1.16, the config is written as unicode.
         #
+        # So we'll use `StringIO.StringIO` (not `io.StringIO`) here - which
+        # will allow either type (it will also implicitly decode bytes to
+        # unicode if we mix them, though I don't think that should happen
+        # here).
+        #
         # After support for Tahoe <1.16 support is dropped we probably want to
         # switch to an io.StringIO here.
         config_text = StringIO()

--- a/zkapauthorizer.nix
+++ b/zkapauthorizer.nix
@@ -34,15 +34,17 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    attrs
-    zope_interface
     aniso8601
-    # Inherit eliot from tahoe-lafs
-    # eliot
-    twisted
     tahoe-lafs
     challenge-bypass-ristretto
-    treq
+
+    # Inherit some things from tahoe-lafs to avoid conflicting versions
+    #
+    # attrs
+    # zope_interface
+    # twisted
+    # eliot
+    # treq
   ];
 
   checkInputs = [


### PR DESCRIPTION
Fixes #225 

Note the target of this PR is #229 .  Along with #231 this should make #229 green and then it can be merged into master to add Tahoe-LAFS 1.16.x testing to CI.  For this branch alone many tests still fail against Tahoe-LAFS 1.16 but at least `_zkapauthorizer.tests.test_plugin.ClientPluginTests.test_mismatched_ristretto_issuer` passes now.
