### PR TITLE
Add an interface for discarding some ZKAPs

### DIFF
--- a/docs/source/interface.rst
+++ b/docs/source/interface.rst
@@ -181,6 +181,22 @@ The response is **OK** with ``application/json`` content-type response body like
 
   { }
 
+``PATCH /storage-plugins/privatestorageio-zkapauthz-v1/unblinded-token``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This endpoint allows an external agent to discard unblinded tokens from the node's database.
+The unblinded tokens to trim are indicated by supplying a single unblinded token value.
+All unblinded tokens that appear before the given unblinded token in spend order will be discarded.
+
+The request body must be ``application/json`` encoded and contain an object like::
+
+  { "first-unspent": <unblinded token string>
+  }
+
+The response is **OK** with ``application/json`` content-type response body like::
+
+  { }
+
 ``POST /storage-plugins/privatestorageio-zkapauthz-v1/calculate-price``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/_zkapauthorizer/model.py
+++ b/src/_zkapauthorizer/model.py
@@ -555,6 +555,34 @@ class VoucherStore(object):
         )
 
     @with_cursor
+    def discard_unblinded_tokens_before(self, cursor, unblinded_token):
+        """
+        Get rid of all unblinded tokens that appear before the given token in
+        spend order.
+
+        :param UnblindedToken unblinded_token: The token that defines the
+            discard point.  All unblinded tokens that appear before this token
+            in spend order are discarded.
+
+        :return: ``None``
+        """
+        cursor.execute(
+            """
+            SELECT [rowid] FROM [unblinded-tokens] WHERE [token] = ?
+            """,
+            (unblinded_token.unblinded_token,),
+        )
+        (rowid,) = cursor.fetchone()
+        cursor.execute(
+            """
+            DELETE FROM [unblinded-tokens]
+            WHERE [rowid] < ?
+            """,
+            (rowid,),
+        )
+        cursor.execute("SELECT changes()")
+
+    @with_cursor
     def discard_unblinded_tokens(self, cursor, unblinded_tokens):
         """
         Get rid of some unblinded tokens.  The tokens will be completely removed

--- a/src/_zkapauthorizer/resource.py
+++ b/src/_zkapauthorizer/resource.py
@@ -401,11 +401,12 @@ class _UnblindedTokenCollection(Resource):
             This discards all tokens that appear before the given token in
             spending order.  This is intended to support backup recovery.
         """
+        application_json(request)
         body = request.content.read()
         parsed = loads(body)
         token = UnblindedToken(parsed["first-unspent"])
         self._store.discard_unblinded_tokens_before(token)
-        return b""
+        return dumps({})
 
     def _lease_maintenance_activity(self):
         activity = self._store.get_latest_lease_maintenance_activity()

--- a/src/_zkapauthorizer/resource.py
+++ b/src/_zkapauthorizer/resource.py
@@ -70,6 +70,10 @@ from .pricecalculator import (
     PriceCalculator,
 )
 
+from .model import (
+    UnblindedToken,
+)
+
 from .controller import (
     PaymentController,
     get_redeemer,
@@ -386,6 +390,22 @@ class _UnblindedTokenCollection(Resource):
         self._store.insert_unblinded_tokens(unblinded_tokens)
         return dumps({})
 
+    def render_PATCH(self, request):
+        """
+        Change the collection of unblinded tokens that exists in the store.
+
+        The following changes are supported:
+
+          * ``{ "first-unspent": <unblinded token> }``
+
+            This discards all tokens that appear before the given token in
+            spending order.  This is intended to support backup recovery.
+        """
+        body = request.content.read()
+        parsed = loads(body)
+        token = UnblindedToken(parsed["first-unspent"])
+        self._store.discard_unblinded_tokens_before(token)
+        return b""
 
     def _lease_maintenance_activity(self):
         activity = self._store.get_latest_lease_maintenance_activity()

--- a/src/_zkapauthorizer/tests/test_client_resource.py
+++ b/src/_zkapauthorizer/tests/test_client_resource.py
@@ -873,7 +873,11 @@ class UnblindedTokenTests(TestCase):
             succeeded(
                 matches_response(
                     code_matcher=Equals(OK),
-                    body_matcher=Equals(b""),
+                    headers_matcher=application_json(),
+                    body_matcher=AfterPreprocessing(
+                        loads,
+                        Equals({}),
+                    ),
                 ),
             ),
         )

--- a/src/_zkapauthorizer/tests/test_client_resource.py
+++ b/src/_zkapauthorizer/tests/test_client_resource.py
@@ -611,6 +611,7 @@ class UnblindedTokenTests(TestCase):
         )
         root = root_from_config(config, datetime.now)
         if extra_tokens is None:
+            # None means test the system without any tokens in it at all.
             num_tokens = 0
         else:
             num_tokens = root.controller.num_redemption_groups + extra_tokens


### PR DESCRIPTION
Fixes #235 

As I was implementing this, I did realize that this still doesn't provide a *full* backup.  "Spent" is one terminal state for unblinded tokens but it isn't the only one.  "Some spending error" is also possible.  The checkpoint scheme here will not keep such tokens backed up.  Only the full copy of the database, done after each purchase, will cause that state to be backed up.

In other words, if some tokens cannot be spent for some reason, that reason will be lost unless a purchase-triggered full backup happens after the fact.

There are similar issues with other non-unblinded-token state.  The lease maintenance spending table will not be kept up to date by the checkpoint either, for example.

Despite that, this is still a small incremental improvement (it allows a third-party like GridSync to at least back up the whole database *sometimes* whereas currently it never does) so I still think it should land.  I'm filing other tickets to get us *all* the way to a good backup scheme.
