### PR TITLE
Add flake8 linting.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203
+per-file-ignores =
+    # Allow assigning lambdas in tests.
+    # E731 do not assign a lambda expression, use a def
+    */tests/*.py: E731

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+profile = black

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -2,4 +2,4 @@ coverage
 fixtures
 testtools
 hypothesis
-pyflakes
+flake8

--- a/src/_zkapauthorizer/__init__.py
+++ b/src/_zkapauthorizer/__init__.py
@@ -17,5 +17,6 @@ __all__ = [
 ]
 
 from ._version import get_versions
-__version__ = get_versions()['version']
+
+__version__ = get_versions()["version"]
 del get_versions

--- a/src/_zkapauthorizer/_base64.py
+++ b/src/_zkapauthorizer/_base64.py
@@ -16,21 +16,11 @@
 This module implements base64 encoding-related functionality.
 """
 
-from __future__ import (
-    absolute_import,
-)
+from __future__ import absolute_import
 
-from re import (
-    compile as _compile,
-)
-
-from binascii import (
-    Error,
-)
-
-from base64 import (
-    b64decode as _b64decode,
-)
+from base64 import b64decode as _b64decode
+from binascii import Error
+from re import compile as _compile
 
 _b64decode_validator = _compile(b"^[A-Za-z0-9-_]*={0,2}$")
 

--- a/src/_zkapauthorizer/_base64.py
+++ b/src/_zkapauthorizer/_base64.py
@@ -32,12 +32,13 @@ from base64 import (
     b64decode as _b64decode,
 )
 
-_b64decode_validator = _compile(b'^[A-Za-z0-9-_]*={0,2}$')
+_b64decode_validator = _compile(b"^[A-Za-z0-9-_]*={0,2}$")
+
 
 def urlsafe_b64decode(s):
     """
     Like ``base64.b64decode`` but with validation.
     """
     if not _b64decode_validator.match(s):
-        raise Error('Non-base64 digit found')
+        raise Error("Non-base64 digit found")
     return _b64decode(s, altchars=b"-_")

--- a/src/_zkapauthorizer/_plugin.py
+++ b/src/_zkapauthorizer/_plugin.py
@@ -18,75 +18,31 @@ Tahoe-LAFS.
 """
 
 import random
-from weakref import (
-    WeakValueDictionary,
-)
-from datetime import (
-    datetime,
-    timedelta,
-)
-from functools import (
-    partial,
-)
+from datetime import datetime, timedelta
+from functools import partial
+from weakref import WeakValueDictionary
 
 import attr
+from allmydata.client import _Client
+from allmydata.interfaces import IAnnounceableStorageServer, IFoolscapStoragePlugin
+from allmydata.node import MissingConfigEntry
+from challenge_bypass_ristretto import SigningKey
+from twisted.internet.defer import succeed
+from twisted.logger import Logger
+from twisted.python.filepath import FilePath
+from zope.interface import implementer
 
-from zope.interface import (
-    implementer,
-)
-
-from twisted.logger import (
-    Logger,
-)
-from twisted.python.filepath import (
-    FilePath,
-)
-from twisted.internet.defer import (
-    succeed,
-)
-
-from allmydata.interfaces import (
-    IFoolscapStoragePlugin,
-    IAnnounceableStorageServer,
-)
-from allmydata.node import (
-    MissingConfigEntry,
-)
-from allmydata.client import (
-    _Client,
-)
-from challenge_bypass_ristretto import (
-    SigningKey,
-)
-
-from .api import (
-    ZKAPAuthorizerStorageServer,
-    ZKAPAuthorizerStorageClient,
-)
-
-from .model import (
-    VoucherStore,
-)
-
-from .resource import (
-    from_configuration as resource_from_configuration,
-)
-from .storage_common import (
-    BYTES_PER_PASS,
-    get_configured_pass_value,
-)
-from .controller import (
-    get_redeemer,
-)
-from .spending import (
-    SpendingController,
-)
-
+from .api import ZKAPAuthorizerStorageClient, ZKAPAuthorizerStorageServer
+from .controller import get_redeemer
 from .lease_maintenance import (
     SERVICE_NAME,
     lease_maintenance_service,
     maintain_leases_from_root,
 )
+from .model import VoucherStore
+from .resource import from_configuration as resource_from_configuration
+from .spending import SpendingController
+from .storage_common import BYTES_PER_PASS, get_configured_pass_value
 
 _log = Logger()
 
@@ -260,9 +216,7 @@ def _create_maintenance_service(reactor, node_config, client_node):
     def get_now():
         return datetime.utcfromtimestamp(reactor.seconds())
 
-    from twisted.plugins.zkapauthorizer import (
-        storage_server,
-    )
+    from twisted.plugins.zkapauthorizer import storage_server
 
     store = storage_server._get_store(node_config)
 

--- a/src/_zkapauthorizer/_plugin.py
+++ b/src/_zkapauthorizer/_plugin.py
@@ -90,6 +90,7 @@ from .lease_maintenance import (
 
 _log = Logger()
 
+
 @implementer(IAnnounceableStorageServer)
 @attr.s
 class AnnounceableStorageServer(object):
@@ -112,6 +113,7 @@ class ZKAPAuthorizer(object):
         forces different methods to use instance state to share a database
         connection.
     """
+
     name = attr.ib(default=u"privatestorageio-zkapauthz-v1")
     _stores = attr.ib(default=attr.Factory(WeakValueDictionary))
 
@@ -120,14 +122,13 @@ class ZKAPAuthorizer(object):
         :return VoucherStore: The database for the given node.  At most one
             connection is made to the database per ``ZKAPAuthorizer`` instance.
         """
-        key =  node_config.get_config_path()
+        key = node_config.get_config_path()
         try:
             s = self._stores[key]
         except KeyError:
             s = VoucherStore.from_node_config(node_config, datetime.now)
             self._stores[key] = s
         return s
-
 
     def _get_redeemer(self, node_config, announcement, reactor):
         """
@@ -136,7 +137,6 @@ class ZKAPAuthorizer(object):
             the redeemer interface is stateless.
         """
         return get_redeemer(self.name, node_config, announcement, reactor)
-
 
     def get_storage_server(self, configuration, get_anonymous_storage_server):
         kwargs = configuration.copy()
@@ -163,7 +163,6 @@ class ZKAPAuthorizer(object):
             ),
         )
 
-
     def get_storage_client(self, node_config, announcement, get_rref):
         """
         Create an ``IStorageClient`` that submits ZKAPs with certain requests in
@@ -172,18 +171,18 @@ class ZKAPAuthorizer(object):
         ``node_config``.
         """
         from twisted.internet import reactor
+
         redeemer = self._get_redeemer(node_config, announcement, reactor)
         store = self._get_store(node_config)
         controller = SpendingController.for_store(
             tokens_to_passes=redeemer.tokens_to_passes,
             store=store,
-       )
+        )
         return ZKAPAuthorizerStorageClient(
             get_configured_pass_value(node_config),
             get_rref,
             controller.get,
         )
-
 
     def get_client_resource(self, node_config, reactor=None):
         """
@@ -203,15 +202,20 @@ class ZKAPAuthorizer(object):
 
 
 _init_storage = _Client.__dict__["init_storage"]
+
+
 def maintenance_init_storage(self, announceable_storage_servers):
     """
     A monkey-patched version of ``_Client.init_storage`` which also
     initializes the lease maintenance service.
     """
     from twisted.internet import reactor
+
     result = _init_storage(self, announceable_storage_servers)
     _maybe_attach_maintenance_service(reactor, self)
     return result
+
+
 _Client.init_storage = maintenance_init_storage
 
 
@@ -252,12 +256,14 @@ def _create_maintenance_service(reactor, node_config, client_node):
     :param allmydata.client._Client client_node: The client node the lease
         maintenance service will be attached to.
     """
+
     def get_now():
         return datetime.utcfromtimestamp(reactor.seconds())
 
     from twisted.plugins.zkapauthorizer import (
         storage_server,
     )
+
     store = storage_server._get_store(node_config)
 
     # Create the operation which performs the lease maintenance job when
@@ -283,7 +289,9 @@ def _create_maintenance_service(reactor, node_config, client_node):
         progress=store.start_lease_maintenance,
         get_now=get_now,
     )
-    last_run_path = FilePath(node_config.get_private_path(b"last-lease-maintenance-run"))
+    last_run_path = FilePath(
+        node_config.get_private_path(b"last-lease-maintenance-run")
+    )
     # Create the service to periodically run the lease maintenance operation.
     return lease_maintenance_service(
         maintain_leases,

--- a/src/_zkapauthorizer/_stack.py
+++ b/src/_zkapauthorizer/_stack.py
@@ -25,11 +25,12 @@ try:
 except ImportError:
     # Not available on Windows, unfortunately.
     RLIMIT_STACK = object()
+
     def getrlimit(which):
         return (-1, -1)
+
     def setrlimit(which, what):
         pass
-
 
 
 @contextmanager

--- a/src/_zkapauthorizer/_stack.py
+++ b/src/_zkapauthorizer/_stack.py
@@ -12,16 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from contextlib import (
-    contextmanager,
-)
+from contextlib import contextmanager
 
 try:
-    from resource import (
-        RLIMIT_STACK,
-        getrlimit,
-        setrlimit,
-    )
+    from resource import RLIMIT_STACK, getrlimit, setrlimit
 except ImportError:
     # Not available on Windows, unfortunately.
     RLIMIT_STACK = object()

--- a/src/_zkapauthorizer/_storage_client.py
+++ b/src/_zkapauthorizer/_storage_client.py
@@ -167,7 +167,7 @@ def call_with_passes_with_manual_spend(method, num_passes, get_passes, on_succes
                 else:
                     on_success(result, pass_group)
                     break
-        except:
+        except Exception:
             # Something went wrong that we can't address with a retry.
             pass_group.reset()
             raise

--- a/src/_zkapauthorizer/_storage_client.py
+++ b/src/_zkapauthorizer/_storage_client.py
@@ -20,55 +20,29 @@ This is the client part of a storage access protocol.  The server part is
 implemented in ``_storage_server.py``.
 """
 
-from __future__ import (
-    absolute_import,
-)
+from __future__ import absolute_import
 
-from functools import (
-    partial,
-    wraps,
-)
+from functools import partial, wraps
 
 import attr
-from attr.validators import (
-    provides,
-)
+from allmydata.interfaces import IStorageServer
+from attr.validators import provides
+from eliot.twisted import inline_callbacks
+from twisted.internet.defer import returnValue
+from twisted.internet.interfaces import IReactorTime
+from twisted.python.reflect import namedAny
+from zope.interface import implementer
 
-from zope.interface import (
-    implementer,
-)
-
-from eliot.twisted import (
-    inline_callbacks,
-)
-
-from twisted.internet.interfaces import (
-    IReactorTime,
-)
-from twisted.python.reflect import (
-    namedAny,
-)
-from twisted.internet.defer import (
-    returnValue,
-)
-from allmydata.interfaces import (
-    IStorageServer,
-)
-
-from .eliot import (
-    SIGNATURE_CHECK_FAILED,
-    CALL_WITH_PASSES,
-)
-
+from .eliot import CALL_WITH_PASSES, SIGNATURE_CHECK_FAILED
 from .storage_common import (
     MorePassesRequired,
+    add_lease_message,
+    allocate_buckets_message,
+    get_required_new_passes_for_mutable_write,
+    has_writes,
     pass_value_attribute,
     required_passes,
-    allocate_buckets_message,
-    add_lease_message,
     slot_testv_and_readv_and_writev_message,
-    has_writes,
-    get_required_new_passes_for_mutable_write,
 )
 
 

--- a/src/_zkapauthorizer/_storage_client.py
+++ b/src/_zkapauthorizer/_storage_client.py
@@ -78,6 +78,7 @@ class IncorrectStorageServerReference(Exception):
     server instead references some other kind of object.  This makes the
     connection, and thus the configured storage server, unusable.
     """
+
     def __init__(self, furl, actual_name, expected_name):
         self.furl = furl
         self.actual_name = actual_name
@@ -119,7 +120,9 @@ def invalidate_rejected_passes(passes, more_passes_required):
         # suite... but let's not be so vulgar.
         return None
     SIGNATURE_CHECK_FAILED.log(count=num_failed)
-    rejected_passes, okay_passes = passes.split(more_passes_required.signature_check_failed)
+    rejected_passes, okay_passes = passes.split(
+        more_passes_required.signature_check_failed
+    )
     rejected_passes.mark_invalid(u"signature check failed")
 
     # It would be great to just expand okay_passes right here.  However, if
@@ -184,7 +187,9 @@ def call_with_passes_with_manual_spend(method, num_passes, get_passes, on_succes
                         pass_group = okay_pass_group
                         # Add the necessary number of new passes.  This might
                         # fail if we don't have enough tokens.
-                        pass_group = pass_group.expand(num_passes - len(pass_group.passes))
+                        pass_group = pass_group.expand(
+                            num_passes - len(pass_group.passes)
+                        )
                 else:
                     on_success(result, pass_group)
                     break
@@ -221,9 +226,11 @@ def with_rref(f):
     The ``RemoteReference`` is retrieved by calling ``_rref`` on the first
     argument passed to the function (expected to be ``self``).
     """
+
     @wraps(f)
     def g(self, *args, **kwargs):
         return f(self, self._rref(), *args, **kwargs)
+
     return g
 
 
@@ -233,11 +240,7 @@ def _encode_passes(group):
 
     :return list[bytes]: The encoded form of the passes in the given group.
     """
-    return list(
-        t.pass_text.encode("ascii")
-        for t
-        in group.passes
-    )
+    return list(t.pass_text.encode("ascii") for t in group.passes)
 
 
 @implementer(IStorageServer)
@@ -265,6 +268,7 @@ class ZKAPAuthorizerStorageClient(object):
         request for which they will be used.  The second gives the number of
         passes to request.
     """
+
     _expected_remote_interface_name = (
         "RIPrivacyPassAuthorizedStorageServer.tahoe.privatestorage.io"
     )
@@ -302,10 +306,10 @@ class ZKAPAuthorizerStorageClient(object):
         )
 
     def _spend_for_allocate_buckets(
-            self,
-            allocated_size,
-            result,
-            pass_group,
+        self,
+        allocated_size,
+        result,
+        pass_group,
     ):
         """
         Spend some subset of a pass group based on the results of an
@@ -336,16 +340,18 @@ class ZKAPAuthorizerStorageClient(object):
 
     @with_rref
     def allocate_buckets(
-            self,
-            rref,
-            storage_index,
-            renew_secret,
-            cancel_secret,
-            sharenums,
-            allocated_size,
-            canary,
+        self,
+        rref,
+        storage_index,
+        renew_secret,
+        cancel_secret,
+        sharenums,
+        allocated_size,
+        canary,
     ):
-        num_passes = required_passes(self._pass_value, [allocated_size] * len(sharenums))
+        num_passes = required_passes(
+            self._pass_value, [allocated_size] * len(sharenums)
+        )
         return call_with_passes_with_manual_spend(
             lambda passes: rref.callRemote(
                 "allocate_buckets",
@@ -358,15 +364,18 @@ class ZKAPAuthorizerStorageClient(object):
                 canary,
             ),
             num_passes,
-            partial(self._get_passes, allocate_buckets_message(storage_index).encode("utf-8")),
+            partial(
+                self._get_passes,
+                allocate_buckets_message(storage_index).encode("utf-8"),
+            ),
             partial(self._spend_for_allocate_buckets, allocated_size),
         )
 
     @with_rref
     def get_buckets(
-            self,
-            rref,
-            storage_index,
+        self,
+        rref,
+        storage_index,
     ):
         return rref.callRemote(
             "get_buckets",
@@ -376,17 +385,19 @@ class ZKAPAuthorizerStorageClient(object):
     @inline_callbacks
     @with_rref
     def add_lease(
-            self,
-            rref,
-            storage_index,
-            renew_secret,
-            cancel_secret,
+        self,
+        rref,
+        storage_index,
+        renew_secret,
+        cancel_secret,
     ):
-        share_sizes = (yield rref.callRemote(
-            "share_sizes",
-            storage_index,
-            None,
-        )).values()
+        share_sizes = (
+            yield rref.callRemote(
+                "share_sizes",
+                storage_index,
+                None,
+            )
+        ).values()
         num_passes = required_passes(self._pass_value, share_sizes)
 
         result = yield call_with_passes(
@@ -411,12 +422,12 @@ class ZKAPAuthorizerStorageClient(object):
 
     @with_rref
     def advise_corrupt_share(
-            self,
-            rref,
-            share_type,
-            storage_index,
-            shnum,
-            reason,
+        self,
+        rref,
+        share_type,
+        storage_index,
+        shnum,
+        reason,
     ):
         return rref.callRemote(
             "advise_corrupt_share",
@@ -429,12 +440,12 @@ class ZKAPAuthorizerStorageClient(object):
     @inline_callbacks
     @with_rref
     def slot_testv_and_readv_and_writev(
-            self,
-            rref,
-            storage_index,
-            secrets,
-            tw_vectors,
-            r_vector,
+        self,
+        rref,
+        storage_index,
+        secrets,
+        tw_vectors,
+        r_vector,
     ):
         # Read operations are free.
         num_passes = 0
@@ -459,8 +470,7 @@ class ZKAPAuthorizerStorageClient(object):
             now = self._clock.seconds()
             current_sizes = {
                 sharenum: stat.size
-                for (sharenum, stat)
-                in stats.items()
+                for (sharenum, stat) in stats.items()
                 if stat.lease_expiration > now
             }
             # Determine the cost of the new storage for the operation.
@@ -489,11 +499,11 @@ class ZKAPAuthorizerStorageClient(object):
 
     @with_rref
     def slot_readv(
-            self,
-            rref,
-            storage_index,
-            shares,
-            r_vector,
+        self,
+        rref,
+        storage_index,
+        shares,
+        r_vector,
     ):
         return rref.callRemote(
             "slot_readv",

--- a/src/_zkapauthorizer/_storage_server.py
+++ b/src/_zkapauthorizer/_storage_server.py
@@ -300,7 +300,7 @@ class ZKAPAuthorizerStorageServer(Referenceable):
             same from the perspective of pass validation.
         """
         with start_action(
-            action_type=u"zkapauthorizer:storage-server:remote:slot-testv-and-readv-and-writev",
+            action_type=u"zkapauthorizer:storage-server:remote:slot-testv-and-readv-and-writev",  # noqa: 501
             storage_index=b2a(storage_index),
             path=storage_index_to_dir(storage_index),
         ):
@@ -346,7 +346,6 @@ class ZKAPAuthorizerStorageServer(Referenceable):
                         tw_vectors.keys(),
                     )
                 )
-                # print("has writes, has active lease, current sizes: {}".format(current_sizes))
             else:
                 # None of it is.
                 current_sizes = {}

--- a/src/_zkapauthorizer/_storage_server.py
+++ b/src/_zkapauthorizer/_storage_server.py
@@ -38,11 +38,10 @@ from attr.validators import instance_of, provides
 from challenge_bypass_ristretto import SigningKey, TokenPreimage, VerificationSignature
 from eliot import start_action
 from foolscap.api import Referenceable
-from foolscap.ipb import IReferenceable, IRemotelyCallable
 from twisted.internet.defer import Deferred
 from twisted.internet.interfaces import IReactorTime
 from twisted.python.reflect import namedAny
-from zope.interface import implementer_only
+from zope.interface import implementer
 
 from .foolscap import RIPrivacyPassAuthorizedStorageServer, ShareStat
 from .storage_common import (
@@ -147,9 +146,7 @@ class LeaseRenewalRequired(Exception):
     """
 
 
-@implementer_only(
-    RIPrivacyPassAuthorizedStorageServer, IReferenceable, IRemotelyCallable
-)
+@implementer(RIPrivacyPassAuthorizedStorageServer)
 # It would be great to use `frozen=True` (value-based hashing) instead of
 # `cmp=False` (identity based hashing) but Referenceable wants to set some
 # attributes on self and it's hard to avoid that.
@@ -698,14 +695,3 @@ def get_stat(sharepath):
             return stat_slot
         else:
             return stat_bucket
-
-
-from foolscap.ipb import ISlicer
-from foolscap.referenceable import ReferenceableSlicer
-
-# I don't understand why this is required.
-# ZKAPAuthorizerStorageServer is-a Referenceable.  It seems like
-# the built in adapter should take care of this case.
-from twisted.python.components import registerAdapter
-
-registerAdapter(ReferenceableSlicer, ZKAPAuthorizerStorageServer, ISlicer)

--- a/src/_zkapauthorizer/_storage_server.py
+++ b/src/_zkapauthorizer/_storage_server.py
@@ -112,6 +112,7 @@ from .storage_common import (
 SLOT_HEADER_SIZE = 468
 LEASE_TRAILER_SIZE = 4
 
+
 @attr.s
 class _ValidationResult(object):
     """
@@ -123,6 +124,7 @@ class _ValidationResult(object):
     :ivar list[int] signature_check_failed: A list of indexes (into the
         validated list) of passes which did not have a correct signature.
     """
+
     valid = attr.ib()
     signature_check_failed = attr.ib()
 
@@ -145,7 +147,9 @@ class _ValidationResult(object):
             proposed_signature = VerificationSignature.decode_base64(signature_base64)
             unblinded_token = signing_key.rederive_unblinded_token(preimage)
             verification_key = unblinded_token.derive_verification_key_sha512()
-            invalid_pass = verification_key.invalid_sha512(proposed_signature, message.encode("utf-8"))
+            invalid_pass = verification_key.invalid_sha512(
+                proposed_signature, message.encode("utf-8")
+            )
             return invalid_pass
         except Exception:
             # It would be pretty nice to log something here, sometimes, I guess?
@@ -195,7 +199,9 @@ class LeaseRenewalRequired(Exception):
     """
 
 
-@implementer_only(RIPrivacyPassAuthorizedStorageServer, IReferenceable, IRemotelyCallable)
+@implementer_only(
+    RIPrivacyPassAuthorizedStorageServer, IReferenceable, IRemotelyCallable
+)
 # It would be great to use `frozen=True` (value-based hashing) instead of
 # `cmp=False` (identity based hashing) but Referenceable wants to set some
 # attributes on self and it's hard to avoid that.
@@ -229,7 +235,16 @@ class ZKAPAuthorizerStorageServer(Referenceable):
         """
         return self._original.remote_get_version()
 
-    def remote_allocate_buckets(self, passes, storage_index, renew_secret, cancel_secret, sharenums, allocated_size, canary):
+    def remote_allocate_buckets(
+        self,
+        passes,
+        storage_index,
+        renew_secret,
+        cancel_secret,
+        sharenums,
+        allocated_size,
+        canary,
+    ):
         """
         Pass-through after a pass check to ensure that clients can only allocate
         storage for immutable shares if they present valid passes.
@@ -310,8 +325,8 @@ class ZKAPAuthorizerStorageServer(Referenceable):
 
     def remote_share_sizes(self, storage_index_or_slot, sharenums):
         with start_action(
-                action_type=u"zkapauthorizer:storage-server:remote:share-sizes",
-                storage_index_or_slot=storage_index_or_slot,
+            action_type=u"zkapauthorizer:storage-server:remote:share-sizes",
+            storage_index_or_slot=storage_index_or_slot,
         ):
             return dict(
                 get_share_sizes(self._original, storage_index_or_slot, sharenums)
@@ -320,17 +335,16 @@ class ZKAPAuthorizerStorageServer(Referenceable):
     def remote_stat_shares(self, storage_indexes_or_slots):
         return list(
             dict(stat_share(self._original, storage_index_or_slot))
-            for storage_index_or_slot
-            in storage_indexes_or_slots
+            for storage_index_or_slot in storage_indexes_or_slots
         )
 
     def remote_slot_testv_and_readv_and_writev(
-            self,
-            passes,
-            storage_index,
-            secrets,
-            tw_vectors,
-            r_vector,
+        self,
+        passes,
+        storage_index,
+        secrets,
+        tw_vectors,
+        r_vector,
     ):
         """
         Pass-through after a pass check to ensure clients can only allocate
@@ -341,9 +355,9 @@ class ZKAPAuthorizerStorageServer(Referenceable):
             same from the perspective of pass validation.
         """
         with start_action(
-                action_type=u"zkapauthorizer:storage-server:remote:slot-testv-and-readv-and-writev",
-                storage_index=b2a(storage_index),
-                path=storage_index_to_dir(storage_index),
+            action_type=u"zkapauthorizer:storage-server:remote:slot-testv-and-readv-and-writev",
+            storage_index=b2a(storage_index),
+            path=storage_index_to_dir(storage_index),
         ):
             result = self._slot_testv_and_readv_and_writev(
                 passes,
@@ -357,12 +371,12 @@ class ZKAPAuthorizerStorageServer(Referenceable):
             return result
 
     def _slot_testv_and_readv_and_writev(
-            self,
-            passes,
-            storage_index,
-            secrets,
-            tw_vectors,
-            r_vector,
+        self,
+        passes,
+        storage_index,
+        secrets,
+        tw_vectors,
+        r_vector,
     ):
         # Only writes to shares without an active lease will result in a lease
         # renewal.
@@ -380,11 +394,13 @@ class ZKAPAuthorizerStorageServer(Referenceable):
             )
             if has_active_lease(self._original, storage_index, self._clock.seconds()):
                 # Some of the storage is paid for already.
-                current_sizes = dict(get_share_sizes(
-                    self._original,
-                    storage_index,
-                    tw_vectors.keys(),
-                ))
+                current_sizes = dict(
+                    get_share_sizes(
+                        self._original,
+                        storage_index,
+                        tw_vectors.keys(),
+                    )
+                )
                 # print("has writes, has active lease, current sizes: {}".format(current_sizes))
             else:
                 # None of it is.
@@ -434,11 +450,7 @@ def has_active_lease(storage_server, storage_index, now):
         with an expiration time after ``now``.
     """
     leases = storage_server.get_slot_leases(storage_index)
-    return any(
-        lease.get_expiration_time() > now
-        for lease
-        in leases
-    )
+    return any(lease.get_expiration_time() > now for lease in leases)
 
 
 def check_pass_quantity(pass_value, validation, share_sizes):
@@ -463,7 +475,9 @@ def check_pass_quantity(pass_value, validation, share_sizes):
         validation.raise_for(required_pass_count)
 
 
-def check_pass_quantity_for_lease(pass_value, storage_index, validation, storage_server):
+def check_pass_quantity_for_lease(
+    pass_value, storage_index, validation, storage_server
+):
     """
     Check that the given number of passes is sufficient to add or renew a
     lease for one period for the given storage index.
@@ -567,8 +581,9 @@ def get_share_sizes(storage_server, storage_index_or_slot, sharenums):
     """
     return (
         (sharenum, stat.size)
-        for (sharenum, stat)
-        in get_share_stats(storage_server, storage_index_or_slot, sharenums)
+        for (sharenum, stat) in get_share_stats(
+            storage_server, storage_index_or_slot, sharenums
+        )
     )
 
 
@@ -592,7 +607,9 @@ def get_share_stats(storage_server, storage_index_or_slot, sharenums):
         is a share number and the second element gives stats about that share.
     """
     stat = None
-    for sharenum, sharepath in get_all_share_paths(storage_server, storage_index_or_slot):
+    for sharenum, sharepath in get_all_share_paths(
+        storage_server, storage_index_or_slot
+    ):
         if stat is None:
             stat = get_stat(sharepath)
         if sharenums is None or sharenum in sharenums:
@@ -699,7 +716,7 @@ def get_slot_share_size(sharepath):
     """
     with open(sharepath, "rb") as share_file:
         share_data_length_bytes = share_file.read(92)[-8:]
-        (share_data_length,) = unpack('>Q', share_data_length_bytes)
+        (share_data_length,) = unpack(">Q", share_data_length_bytes)
         return share_data_length
 
 
@@ -711,7 +728,9 @@ def stat_share(storage_server, storage_index_or_slot):
         ``ShareStat``.
     """
     stat = None
-    for sharenum, sharepath in get_all_share_paths(storage_server, storage_index_or_slot):
+    for sharenum, sharepath in get_all_share_paths(
+        storage_server, storage_index_or_slot
+    ):
         if stat is None:
             stat = get_stat(sharepath)
         yield (sharenum, stat(storage_server, storage_index_or_slot, sharepath))
@@ -745,4 +764,5 @@ from foolscap.referenceable import (
 from foolscap.ipb import (
     ISlicer,
 )
+
 registerAdapter(ReferenceableSlicer, ZKAPAuthorizerStorageServer, ISlicer)

--- a/src/_zkapauthorizer/_version.py
+++ b/src/_zkapauthorizer/_version.py
@@ -1,4 +1,3 @@
-
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -58,17 +57,18 @@ HANDLERS = {}
 
 def register_vcs_handler(vcs, method):  # decorator
     """Decorator to mark a method as the handler for a particular VCS."""
+
     def decorate(f):
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:
             HANDLERS[vcs] = {}
         HANDLERS[vcs][method] = f
         return f
+
     return decorate
 
 
-def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
-                env=None):
+def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=None):
     """Call the given command(s)."""
     assert isinstance(commands, list)
     p = None
@@ -76,10 +76,13 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
         try:
             dispcmd = str([c] + args)
             # remember shell=False, so use git.cmd on windows, not just git
-            p = subprocess.Popen([c] + args, cwd=cwd, env=env,
-                                 stdout=subprocess.PIPE,
-                                 stderr=(subprocess.PIPE if hide_stderr
-                                         else None))
+            p = subprocess.Popen(
+                [c] + args,
+                cwd=cwd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=(subprocess.PIPE if hide_stderr else None),
+            )
             break
         except EnvironmentError:
             e = sys.exc_info()[1]
@@ -116,16 +119,22 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
     for i in range(3):
         dirname = os.path.basename(root)
         if dirname.startswith(parentdir_prefix):
-            return {"version": dirname[len(parentdir_prefix):],
-                    "full-revisionid": None,
-                    "dirty": False, "error": None, "date": None}
+            return {
+                "version": dirname[len(parentdir_prefix) :],
+                "full-revisionid": None,
+                "dirty": False,
+                "error": None,
+                "date": None,
+            }
         else:
             rootdirs.append(root)
             root = os.path.dirname(root)  # up a level
 
     if verbose:
-        print("Tried directories %s but none started with prefix %s" %
-              (str(rootdirs), parentdir_prefix))
+        print(
+            "Tried directories %s but none started with prefix %s"
+            % (str(rootdirs), parentdir_prefix)
+        )
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
 
@@ -181,7 +190,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = set([r[len(TAG):] for r in refs if r.startswith(TAG)])
+    tags = set([r[len(TAG) :] for r in refs if r.startswith(TAG)])
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -190,7 +199,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = set([r for r in refs if re.search(r'\d', r)])
+        tags = set([r for r in refs if re.search(r"\d", r)])
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
@@ -198,19 +207,26 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
-            r = ref[len(tag_prefix):]
+            r = ref[len(tag_prefix) :]
             if verbose:
                 print("picking %s" % r)
-            return {"version": r,
-                    "full-revisionid": keywords["full"].strip(),
-                    "dirty": False, "error": None,
-                    "date": date}
+            return {
+                "version": r,
+                "full-revisionid": keywords["full"].strip(),
+                "dirty": False,
+                "error": None,
+                "date": date,
+            }
     # no suitable tags, so version is "0+unknown", but full hex is still there
     if verbose:
         print("no suitable tags, using unknown + full revision id")
-    return {"version": "0+unknown",
-            "full-revisionid": keywords["full"].strip(),
-            "dirty": False, "error": "no suitable tags", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": keywords["full"].strip(),
+        "dirty": False,
+        "error": "no suitable tags",
+        "date": None,
+    }
 
 
 @register_vcs_handler("git", "pieces_from_vcs")
@@ -225,8 +241,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
 
-    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root,
-                          hide_stderr=True)
+    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root, hide_stderr=True)
     if rc != 0:
         if verbose:
             print("Directory %s not under git control" % root)
@@ -234,10 +249,19 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
-    describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty",
-                                          "--always", "--long",
-                                          "--match", "%s*" % tag_prefix],
-                                   cwd=root)
+    describe_out, rc = run_command(
+        GITS,
+        [
+            "describe",
+            "--tags",
+            "--dirty",
+            "--always",
+            "--long",
+            "--match",
+            "%s*" % tag_prefix,
+        ],
+        cwd=root,
+    )
     # --long was added in git-1.5.5
     if describe_out is None:
         raise NotThisMethod("'git describe' failed")
@@ -260,17 +284,16 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     dirty = git_describe.endswith("-dirty")
     pieces["dirty"] = dirty
     if dirty:
-        git_describe = git_describe[:git_describe.rindex("-dirty")]
+        git_describe = git_describe[: git_describe.rindex("-dirty")]
 
     # now we have TAG-NUM-gHEX or HEX
 
     if "-" in git_describe:
         # TAG-NUM-gHEX
-        mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
+        mo = re.search(r"^(.+)-(\d+)-g([0-9a-f]+)$", git_describe)
         if not mo:
             # unparseable. Maybe git-describe is misbehaving?
-            pieces["error"] = ("unable to parse git-describe output: '%s'"
-                               % describe_out)
+            pieces["error"] = "unable to parse git-describe output: '%s'" % describe_out
             return pieces
 
         # tag
@@ -279,10 +302,12 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = ("tag '%s' doesn't start with prefix '%s'"
-                               % (full_tag, tag_prefix))
+            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (
+                full_tag,
+                tag_prefix,
+            )
             return pieces
-        pieces["closest-tag"] = full_tag[len(tag_prefix):]
+        pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 
         # distance: number of commits since tag
         pieces["distance"] = int(mo.group(2))
@@ -293,13 +318,13 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     else:
         # HEX: no tags
         pieces["closest-tag"] = None
-        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"],
-                                    cwd=root)
+        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"], cwd=root)
         pieces["distance"] = int(count_out)  # total number of commits
 
     # commit date: see ISO-8601 comment in git_versions_from_keywords()
-    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"],
-                       cwd=root)[0].strip()
+    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"], cwd=root)[
+        0
+    ].strip()
     pieces["date"] = date.strip().replace(" ", "T", 1).replace(" ", "", 1)
 
     return pieces
@@ -330,8 +355,7 @@ def render_pep440(pieces):
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = "0+untagged.%d.g%s" % (pieces["distance"],
-                                          pieces["short"])
+        rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -445,11 +469,13 @@ def render_git_describe_long(pieces):
 def render(pieces, style):
     """Render the given version pieces into the requested style."""
     if pieces["error"]:
-        return {"version": "unknown",
-                "full-revisionid": pieces.get("long"),
-                "dirty": None,
-                "error": pieces["error"],
-                "date": None}
+        return {
+            "version": "unknown",
+            "full-revisionid": pieces.get("long"),
+            "dirty": None,
+            "error": pieces["error"],
+            "date": None,
+        }
 
     if not style or style == "default":
         style = "pep440"  # the default
@@ -469,9 +495,13 @@ def render(pieces, style):
     else:
         raise ValueError("unknown style '%s'" % style)
 
-    return {"version": rendered, "full-revisionid": pieces["long"],
-            "dirty": pieces["dirty"], "error": None,
-            "date": pieces.get("date")}
+    return {
+        "version": rendered,
+        "full-revisionid": pieces["long"],
+        "dirty": pieces["dirty"],
+        "error": None,
+        "date": pieces.get("date"),
+    }
 
 
 def get_versions():
@@ -485,8 +515,7 @@ def get_versions():
     verbose = cfg.verbose
 
     try:
-        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix,
-                                          verbose)
+        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix, verbose)
     except NotThisMethod:
         pass
 
@@ -495,13 +524,16 @@ def get_versions():
         # versionfile_source is the relative path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.
-        for i in cfg.versionfile_source.split('/'):
+        for i in cfg.versionfile_source.split("/"):
             root = os.path.dirname(root)
     except NameError:
-        return {"version": "0+unknown", "full-revisionid": None,
-                "dirty": None,
-                "error": "unable to find root of source tree",
-                "date": None}
+        return {
+            "version": "0+unknown",
+            "full-revisionid": None,
+            "dirty": None,
+            "error": "unable to find root of source tree",
+            "date": None,
+        }
 
     try:
         pieces = git_pieces_from_vcs(cfg.tag_prefix, root, verbose)
@@ -515,6 +547,10 @@ def get_versions():
     except NotThisMethod:
         pass
 
-    return {"version": "0+unknown", "full-revisionid": None,
-            "dirty": None,
-            "error": "unable to compute version", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": None,
+        "dirty": None,
+        "error": "unable to compute version",
+        "date": None,
+    }

--- a/src/_zkapauthorizer/api.py
+++ b/src/_zkapauthorizer/api.py
@@ -20,7 +20,10 @@ __all__ = [
     "ZKAPAuthorizer",
 ]
 
-from ._plugin import ZKAPAuthorizer
 from ._storage_client import ZKAPAuthorizerStorageClient
 from ._storage_server import LeaseRenewalRequired, ZKAPAuthorizerStorageServer
 from .storage_common import MorePassesRequired
+
+# This needs to be imported after the above, since it imports those things from here.
+# isort: split
+from ._plugin import ZKAPAuthorizer

--- a/src/_zkapauthorizer/api.py
+++ b/src/_zkapauthorizer/api.py
@@ -20,17 +20,7 @@ __all__ = [
     "ZKAPAuthorizer",
 ]
 
-from .storage_common import (
-    MorePassesRequired,
-)
-from ._storage_server import (
-    LeaseRenewalRequired,
-    ZKAPAuthorizerStorageServer,
-)
-from ._storage_client import (
-    ZKAPAuthorizerStorageClient,
-)
-
-from ._plugin import (
-    ZKAPAuthorizer,
-)
+from ._plugin import ZKAPAuthorizer
+from ._storage_client import ZKAPAuthorizerStorageClient
+from ._storage_server import LeaseRenewalRequired, ZKAPAuthorizerStorageServer
+from .storage_common import MorePassesRequired

--- a/src/_zkapauthorizer/configutil.py
+++ b/src/_zkapauthorizer/configutil.py
@@ -16,12 +16,7 @@
 Basic utilities related to the Tahoe configuration file.
 """
 
-from __future__ import (
-    division,
-    absolute_import,
-    print_function,
-    unicode_literals,
-)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 
 def _merge_dictionaries(dictionaries):

--- a/src/_zkapauthorizer/configutil.py
+++ b/src/_zkapauthorizer/configutil.py
@@ -62,14 +62,15 @@ def config_string_from_sections(divided_sections):
         last value wins).
     """
     sections = _merge_dictionaries(divided_sections)
-    return "".join(list(
-        "[{name}]\n{items}\n".format(
-            name=name,
-            items="\n".join(
-                "{key} = {value}".format(key=key, value=_tahoe_config_quote(value))
-                for (key, value)
-                in contents.items()
+    return "".join(
+        list(
+            "[{name}]\n{items}\n".format(
+                name=name,
+                items="\n".join(
+                    "{key} = {value}".format(key=key, value=_tahoe_config_quote(value))
+                    for (key, value) in contents.items()
+                ),
             )
+            for (name, contents) in sections.items()
         )
-        for (name, contents) in sections.items()
-    ))
+    )

--- a/src/_zkapauthorizer/controller.py
+++ b/src/_zkapauthorizer/controller.py
@@ -17,90 +17,38 @@ This module implements controllers (in the MVC sense) for the web interface
 for the client side of the storage plugin.
 """
 
-from __future__ import (
-    absolute_import,
-)
+from __future__ import absolute_import
 
-from sys import (
-    exc_info,
-)
-from operator import (
-    setitem,
-    delitem,
-)
-from functools import (
-    partial,
-)
-from json import (
-    dumps,
-    loads,
-)
-from datetime import (
-    timedelta,
-)
-from base64 import (
-    b64encode,
-    b64decode,
-)
-from hashlib import (
-    sha256,
-)
+from base64 import b64decode, b64encode
+from datetime import timedelta
+from functools import partial
+from hashlib import sha256
+from json import dumps, loads
+from operator import delitem, setitem
+from sys import exc_info
 
 import attr
-
-from zope.interface import (
-    Interface,
-    implementer,
-)
-
-from twisted.python.reflect import (
-    namedAny,
-)
-from twisted.logger import (
-    Logger,
-)
-from twisted.python.url import (
-    URL,
-)
-from twisted.internet.defer import (
-    Deferred,
-    succeed,
-    fail,
-    inlineCallbacks,
-    returnValue,
-)
-from twisted.internet.task import (
-    LoopingCall,
-)
-from twisted.web.client import (
-    Agent,
-)
-from treq import (
-    content,
-)
-from treq.client import (
-    HTTPClient,
-)
-
 import challenge_bypass_ristretto
+from treq import content
+from treq.client import HTTPClient
+from twisted.internet.defer import Deferred, fail, inlineCallbacks, returnValue, succeed
+from twisted.internet.task import LoopingCall
+from twisted.logger import Logger
+from twisted.python.reflect import namedAny
+from twisted.python.url import URL
+from twisted.web.client import Agent
+from zope.interface import Interface, implementer
 
-from ._base64 import (
-    urlsafe_b64decode,
-)
-from ._stack import (
-    less_limited_stack,
-)
-
-from .model import (
-    RandomToken,
-    UnblindedToken,
-    Voucher,
-    Pass,
-    Pending as model_Pending,
-    Unpaid as model_Unpaid,
-    Redeeming as model_Redeeming,
-    Error as model_Error,
-)
+from ._base64 import urlsafe_b64decode
+from ._stack import less_limited_stack
+from .model import Error as model_Error
+from .model import Pass
+from .model import Pending as model_Pending
+from .model import RandomToken
+from .model import Redeeming as model_Redeeming
+from .model import UnblindedToken
+from .model import Unpaid as model_Unpaid
+from .model import Voucher
 
 RETRY_INTERVAL = timedelta(milliseconds=1000)
 

--- a/src/_zkapauthorizer/controller.py
+++ b/src/_zkapauthorizer/controller.py
@@ -743,13 +743,15 @@ class PaymentController(object):
         for voucher in vouchers:
             if voucher.state.should_start_redemption():
                 self._log.info(
-                    "Controller found voucher ({voucher}) at startup that needs redemption.",
+                    "Controller found voucher ({voucher}) at startup "
+                    "that needs redemption.",
                     voucher=voucher.number,
                 )
                 self.redeem(voucher.number)
             else:
                 self._log.info(
-                    "Controller found voucher ({voucher}) at startup that does not need redemption.",
+                    "Controller found voucher ({voucher}) at startup "
+                    "that does not need redemption.",
                     voucher=voucher.number,
                 )
 
@@ -849,7 +851,8 @@ class PaymentController(object):
             succeeded = yield self._perform_redeem(voucher_obj, counter, tokens)
             if not succeeded:
                 self._log.info(
-                    "Temporarily suspending redemption of {voucher} after non-success result.",
+                    "Temporarily suspending redemption of {voucher} "
+                    "after non-success result.",
                     voucher=voucher,
                 )
                 break
@@ -1019,7 +1022,7 @@ def bracket(first, last, between):
         result = yield between()
     except GeneratorExit:
         raise
-    except:
+    except Exception:
         info = exc_info()
         yield last()
         raise info[0], info[1], info[2]

--- a/src/_zkapauthorizer/eliot.py
+++ b/src/_zkapauthorizer/eliot.py
@@ -16,15 +16,9 @@
 Eliot field, message, and action definitions for ZKAPAuthorizer.
 """
 
-from __future__ import (
-    absolute_import,
-)
+from __future__ import absolute_import
 
-from eliot import (
-    Field,
-    MessageType,
-    ActionType,
-)
+from eliot import ActionType, Field, MessageType
 
 PRIVACYPASS_MESSAGE = Field(
     u"message",

--- a/src/_zkapauthorizer/eliot.py
+++ b/src/_zkapauthorizer/eliot.py
@@ -59,7 +59,8 @@ INVALID_PASSES = MessageType(
 RESET_PASSES = MessageType(
     u"zkapauthorizer:reset-passes",
     [PASS_COUNT],
-    u"Some passes involved in a failed spending attempt have not definitely been spent and are being returned for future use.",
+    u"Some passes involved in a failed spending attempt have not definitely been spent "
+    u"and are being returned for future use.",
 )
 
 SIGNATURE_CHECK_FAILED = MessageType(
@@ -84,13 +85,15 @@ CURRENT_SIZES = Field(
 TW_VECTORS_SUMMARY = Field(
     u"tw_vectors_summary",
     dict,
-    u"A dictionary mapping share numbers from tw_vectors to test and write vector summaries.",
+    u"A dictionary mapping share numbers from tw_vectors "
+    u"to test and write vector summaries.",
 )
 
 NEW_SIZES = Field(
     u"new_sizes",
     dict,
-    u"A dictionary like that of CURRENT_SIZES but for the sizes computed for the shares after applying tw_vectors.",
+    u"A dictionary like that of CURRENT_SIZES but for the sizes computed for the "
+    u"shares after applying tw_vectors.",
 )
 
 NEW_PASSES = Field(

--- a/src/_zkapauthorizer/foolscap.py
+++ b/src/_zkapauthorizer/foolscap.py
@@ -17,32 +17,13 @@ Definitions related to the Foolscap-based protocol used by ZKAPAuthorizer
 to communicate between storage clients and servers.
 """
 
-from __future__ import (
-    absolute_import,
-)
+from __future__ import absolute_import
 
 import attr
-
-from foolscap.constraint import (
-    ByteStringConstraint,
-)
-from foolscap.api import (
-    Any,
-    DictOf,
-    ListOf,
-    Copyable,
-    RemoteCopy,
-)
-from foolscap.remoteinterface import (
-    RemoteMethodSchema,
-    RemoteInterface,
-)
-
-from allmydata.interfaces import (
-    StorageIndex,
-    RIStorageServer,
-    Offset,
-)
+from allmydata.interfaces import Offset, RIStorageServer, StorageIndex
+from foolscap.api import Any, Copyable, DictOf, ListOf, RemoteCopy
+from foolscap.constraint import ByteStringConstraint
+from foolscap.remoteinterface import RemoteInterface, RemoteMethodSchema
 
 
 @attr.s

--- a/src/_zkapauthorizer/foolscap.py
+++ b/src/_zkapauthorizer/foolscap.py
@@ -44,6 +44,7 @@ from allmydata.interfaces import (
     Offset,
 )
 
+
 @attr.s
 class ShareStat(Copyable, RemoteCopy):
     """
@@ -54,6 +55,7 @@ class ShareStat(Copyable, RemoteCopy):
     :ivar int lease_expiration: The POSIX timestamp of the time at which the
         lease on this share expires, or None if there is no lease.
     """
+
     typeToCopy = copytype = "ShareStat"
 
     # To be a RemoteCopy it must be possible to instantiate this with no
@@ -134,7 +136,8 @@ def add_arguments(schema, kwargs):
     # arguments.
     modified_schema.argumentNames = (
         # The new arguments
-        list(argName for (argName, _) in kwargs) +
+        list(argName for (argName, _) in kwargs)
+        +
         # The original arguments in the original order
         schema.argumentNames
     )
@@ -151,9 +154,8 @@ class RIPrivacyPassAuthorizedStorageServer(RemoteInterface):
     are expected to supply suitable passes and only after the passes have been
     validated is service provided.
     """
-    __remote_name__ = (
-        "RIPrivacyPassAuthorizedStorageServer.tahoe.privatestorage.io"
-    )
+
+    __remote_name__ = "RIPrivacyPassAuthorizedStorageServer.tahoe.privatestorage.io"
 
     get_version = RIStorageServer["get_version"]
 
@@ -164,11 +166,11 @@ class RIPrivacyPassAuthorizedStorageServer(RemoteInterface):
     get_buckets = RIStorageServer["get_buckets"]
 
     def share_sizes(
-            storage_index_or_slot=StorageIndex,
-            # Notionally, ChoiceOf(None, SetOf(int, maxLength=MAX_BUCKETS)).
-            # However, support for such a construction appears to be
-            # unimplemented in Foolscap.  So, instead...
-            sharenums=Any(),
+        storage_index_or_slot=StorageIndex,
+        # Notionally, ChoiceOf(None, SetOf(int, maxLength=MAX_BUCKETS)).
+        # However, support for such a construction appears to be
+        # unimplemented in Foolscap.  So, instead...
+        sharenums=Any(),
     ):
         """
         Get the size of the given shares in the given storage index or slot.  If a
@@ -177,7 +179,7 @@ class RIPrivacyPassAuthorizedStorageServer(RemoteInterface):
         return DictOf(int, Offset)
 
     def stat_shares(
-            storage_indexes_or_slots=ListOf(StorageIndex),
+        storage_indexes_or_slots=ListOf(StorageIndex),
     ):
         """
         Get various metadata about shares in the given storage index or slot.

--- a/src/_zkapauthorizer/lease_maintenance.py
+++ b/src/_zkapauthorizer/lease_maintenance.py
@@ -17,55 +17,26 @@ This module implements a service which periodically spends ZKAPs to
 refresh leases on all shares reachable from a root.
 """
 
-from functools import (
-    partial,
-)
-from datetime import (
-    datetime,
-    timedelta,
-)
-from errno import (
-    ENOENT,
-)
+from datetime import datetime, timedelta
+from errno import ENOENT
+from functools import partial
+
 import attr
-
-from zope.interface import (
-    implementer,
-)
-
-from aniso8601 import (
-    parse_datetime,
-)
-
-from twisted.internet.defer import (
-    inlineCallbacks,
-    maybeDeferred,
-)
-from twisted.application.service import (
-    Service,
-)
-from twisted.python.log import (
-    err,
-)
-
-from allmydata.interfaces import (
-    IDirectoryNode,
-    IFilesystemNode,
-)
+from allmydata.interfaces import IDirectoryNode, IFilesystemNode
 from allmydata.util.hashutil import (
-    file_renewal_secret_hash,
+    bucket_cancel_secret_hash,
     bucket_renewal_secret_hash,
     file_cancel_secret_hash,
-    bucket_cancel_secret_hash,
+    file_renewal_secret_hash,
 )
+from aniso8601 import parse_datetime
+from twisted.application.service import Service
+from twisted.internet.defer import inlineCallbacks, maybeDeferred
+from twisted.python.log import err
+from zope.interface import implementer
 
-from .controller import (
-    bracket,
-)
-
-from .model import (
-    ILeaseMaintenanceObserver,
-)
+from .controller import bracket
+from .model import ILeaseMaintenanceObserver
 
 SERVICE_NAME = u"lease maintenance service"
 

--- a/src/_zkapauthorizer/lease_maintenance.py
+++ b/src/_zkapauthorizer/lease_maintenance.py
@@ -85,14 +85,18 @@ def visit_storage_indexes(root_nodes, visit):
         visited.
     """
     if not isinstance(root_nodes, list):
-        raise TypeError("root_nodes must be a list, not {!r}".format(
-            root_nodes,
-        ))
+        raise TypeError(
+            "root_nodes must be a list, not {!r}".format(
+                root_nodes,
+            )
+        )
     for node in root_nodes:
         if not IFilesystemNode.providedBy(node):
-            raise TypeError("Root nodes must provide IFilesystemNode, {!r} does not".format(
-                node,
-            ))
+            raise TypeError(
+                "Root nodes must provide IFilesystemNode, {!r} does not".format(
+                    node,
+                )
+            )
 
     stack = root_nodes[:]
     while stack:
@@ -130,12 +134,12 @@ def iter_storage_indexes(visit_assets):
 
 @inlineCallbacks
 def renew_leases(
-        visit_assets,
-        storage_broker,
-        secret_holder,
-        min_lease_remaining,
-        get_activity_observer,
-        now,
+    visit_assets,
+    storage_broker,
+    secret_holder,
+    min_lease_remaining,
+    get_activity_observer,
+    now,
 ):
     """
     Check the leases on a group of nodes for those which are expired or close
@@ -169,9 +173,7 @@ def renew_leases(
     renewal_secret = secret_holder.get_renewal_secret()
     cancel_secret = secret_holder.get_cancel_secret()
     servers = list(
-        server.get_storage_server()
-        for server
-        in storage_broker.get_connected_servers()
+        server.get_storage_server() for server in storage_broker.get_connected_servers()
     )
 
     for server in servers:
@@ -191,13 +193,13 @@ def renew_leases(
 
 @inlineCallbacks
 def renew_leases_on_server(
-        min_lease_remaining,
-        renewal_secret,
-        cancel_secret,
-        storage_indexes,
-        server,
-        activity,
-        now,
+    min_lease_remaining,
+    renewal_secret,
+    cancel_secret,
+    storage_indexes,
+    server,
+    activity,
+    now,
 ):
     """
     Check leases on the shares for the given storage indexes on the given
@@ -318,6 +320,7 @@ class _FuzzyTimerService(Service):
     :ivar IReactorTime reactor: A Twisted reactor to use to schedule runs of
         the operation.
     """
+
     name = attr.ib()
     operation = attr.ib()
     initial_interval = attr.ib()
@@ -355,12 +358,12 @@ class _FuzzyTimerService(Service):
 
 
 def lease_maintenance_service(
-        maintain_leases,
-        reactor,
-        last_run_path,
-        random,
-        interval_mean=None,
-        interval_range=None,
+    maintain_leases,
+    reactor,
+    last_run_path,
+    random,
+    interval_mean=None,
+    interval_range=None,
 ):
     """
     Get an ``IService`` which will maintain leases on ``root_node`` and any
@@ -400,6 +403,7 @@ def lease_maintenance_service(
                 (interval_mean + halfrange).total_seconds(),
             ),
         )
+
     # Rather than an all-or-nothing last-run time we probably eventually want
     # to have a more comprehensive record of the state when we were last
     # interrupted.  This would remove the unfortunate behavior of restarting
@@ -419,7 +423,6 @@ def lease_maintenance_service(
             initial_interval,
             timedelta(0),
         )
-
 
     return _FuzzyTimerService(
         SERVICE_NAME,
@@ -496,6 +499,7 @@ class NoopMaintenanceObserver(object):
     """
     A lease maintenance observer that does nothing.
     """
+
     def observe(self, sizes):
         pass
 
@@ -509,6 +513,7 @@ class MemoryMaintenanceObserver(object):
     """
     A lease maintenance observer that records observations in memory.
     """
+
     observed = attr.ib(default=attr.Factory(list))
     finished = attr.ib(default=False)
 
@@ -520,12 +525,12 @@ class MemoryMaintenanceObserver(object):
 
 
 def maintain_leases_from_root(
-        get_root_nodes,
-        storage_broker,
-        secret_holder,
-        min_lease_remaining,
-        progress,
-        get_now,
+    get_root_nodes,
+    storage_broker,
+    secret_holder,
+    min_lease_remaining,
+    progress,
+    get_now,
 ):
     """
     An operation for ``lease_maintenance_service`` which visits ``root_node``
@@ -552,6 +557,7 @@ def maintain_leases_from_root(
 
     :return: A no-argument callable to perform the maintenance.
     """
+
     def visitor(visit_assets):
         return renew_leases(
             visit_assets,

--- a/src/_zkapauthorizer/model.py
+++ b/src/_zkapauthorizer/model.py
@@ -17,59 +17,26 @@ This module implements models (in the MVC sense) for the client side of
 the storage plugin.
 """
 
-from functools import (
-    wraps,
-)
-from json import (
-    loads,
-    dumps,
-)
-from datetime import (
-    datetime,
-)
-from zope.interface import (
-    Interface,
-    implementer,
-)
-
-from sqlite3 import (
-    OperationalError,
-    connect as _connect,
-)
+from datetime import datetime
+from functools import wraps
+from json import dumps, loads
+from sqlite3 import OperationalError
+from sqlite3 import connect as _connect
 
 import attr
+from aniso8601 import parse_datetime as _parse_datetime
+from twisted.logger import Logger
+from twisted.python.filepath import FilePath
+from zope.interface import Interface, implementer
 
-from aniso8601 import (
-    parse_datetime as _parse_datetime,
-)
-from twisted.logger import (
-    Logger,
-)
-from twisted.python.filepath import (
-    FilePath,
-)
-
-from ._base64 import (
-    urlsafe_b64decode,
-)
-
-from .validators import (
-    is_base64_encoded,
-    has_length,
-    greater_than,
-)
-
+from ._base64 import urlsafe_b64decode
+from .schema import get_schema_upgrades, get_schema_version, run_schema_upgrades
 from .storage_common import (
-    pass_value_attribute,
     get_configured_pass_value,
+    pass_value_attribute,
     required_passes,
 )
-
-from .schema import (
-    get_schema_version,
-    get_schema_upgrades,
-    run_schema_upgrades,
-)
+from .validators import greater_than, has_length, is_base64_encoded
 
 
 def parse_datetime(s, **kw):

--- a/src/_zkapauthorizer/model.py
+++ b/src/_zkapauthorizer/model.py
@@ -89,6 +89,7 @@ class ILeaseMaintenanceObserver(Interface):
     An object which is interested in receiving events related to the progress
     of lease maintenance activity.
     """
+
     def observe(sizes):
         """
         Observe some shares encountered during lease maintenance.
@@ -106,6 +107,7 @@ class StoreOpenError(Exception):
     """
     There was a problem opening the underlying data store.
     """
+
     def __init__(self, reason):
         self.reason = reason
 
@@ -118,6 +120,7 @@ class NotEnoughTokens(Exception):
 
 
 CONFIG_DB_NAME = u"privatestorageio-zkapauthz-v1.sqlite3"
+
 
 def open_and_initialize(path, connect=None):
     """
@@ -204,12 +207,14 @@ def with_cursor(f):
     normally then the transaction will be committed.  Otherwise, the
     transaction will be rolled back.
     """
+
     @wraps(f)
     def with_cursor(self, *a, **kw):
         with self._connection:
             cursor = self._connection.cursor()
             cursor.execute("BEGIN IMMEDIATE TRANSACTION")
             return f(self, cursor, *a, **kw)
+
     return with_cursor
 
 
@@ -236,6 +241,7 @@ class VoucherStore(object):
     :ivar now: A no-argument callable that returns the time of the call as a
         ``datetime`` instance.
     """
+
     _log = Logger()
 
     pass_value = pass_value_attribute()
@@ -339,11 +345,7 @@ class VoucherStore(object):
                 voucher=voucher,
                 counter=counter,
             )
-            tokens = list(
-                RandomToken(token_value)
-                for (token_value,)
-                in rows
-            )
+            tokens = list(RandomToken(token_value) for (token_value,) in rows)
         else:
             tokens = get_tokens()
             self._log.info(
@@ -356,17 +358,13 @@ class VoucherStore(object):
                 """
                 INSERT OR IGNORE INTO [vouchers] ([number], [expected-tokens], [created]) VALUES (?, ?, ?)
                 """,
-                (voucher, expected_tokens, self.now())
+                (voucher, expected_tokens, self.now()),
             )
             cursor.executemany(
                 """
                 INSERT INTO [tokens] ([voucher], [counter], [text]) VALUES (?, ?, ?)
                 """,
-                list(
-                    (voucher, counter, token.token_value)
-                    for token
-                    in tokens
-                ),
+                list((voucher, counter, token.token_value) for token in tokens),
             )
         return tokens
 
@@ -387,11 +385,7 @@ class VoucherStore(object):
         )
         refs = cursor.fetchall()
 
-        return list(
-            Voucher.from_row(row)
-            for row
-            in refs
-        )
+        return list(Voucher.from_row(row) for row in refs)
 
     def _insert_unblinded_tokens(self, cursor, unblinded_tokens, group_id):
         """
@@ -401,11 +395,7 @@ class VoucherStore(object):
             """
             INSERT INTO [unblinded-tokens] ([token], [redemption-group]) VALUES (?, ?)
             """,
-            list(
-                (token, group_id)
-                for token
-                in unblinded_tokens
-            ),
+            list((token, group_id) for token in unblinded_tokens),
         )
 
     @with_cursor
@@ -422,7 +412,9 @@ class VoucherStore(object):
         self._insert_unblinded_tokens(cursor, unblinded_tokens, group_id)
 
     @with_cursor
-    def insert_unblinded_tokens_for_voucher(self, cursor, voucher, public_key, unblinded_tokens, completed, spendable):
+    def insert_unblinded_tokens_for_voucher(
+        self, cursor, voucher, public_key, unblinded_tokens, completed, spendable
+    ):
         """
         Store some unblinded tokens received from redemption of a voucher.
 
@@ -442,7 +434,7 @@ class VoucherStore(object):
         :param bool spendable: ``True`` if it should be possible to spend the
             inserted tokens, ``False`` otherwise.
         """
-        if  completed:
+        if completed:
             voucher_state = u"redeemed"
         else:
             voucher_state = u"pending"
@@ -488,15 +480,13 @@ class VoucherStore(object):
             ),
         )
         if cursor.rowcount == 0:
-            raise ValueError("Cannot insert tokens for unknown voucher; add voucher first")
+            raise ValueError(
+                "Cannot insert tokens for unknown voucher; add voucher first"
+            )
 
         self._insert_unblinded_tokens(
             cursor,
-            list(
-                t.unblinded_token
-                for t
-                in unblinded_tokens
-            ),
+            list(t.unblinded_token for t in unblinded_tokens),
             group_id,
         )
 
@@ -524,7 +514,7 @@ class VoucherStore(object):
                 FROM [vouchers]
                 WHERE [number] = ?
                 """,
-                (voucher,)
+                (voucher,),
             )
             rows = cursor.fetchall()
             if len(rows) == 0:
@@ -584,11 +574,7 @@ class VoucherStore(object):
             """,
             texts,
         )
-        return list(
-            UnblindedToken(t)
-            for (t,)
-            in texts
-        )
+        return list(UnblindedToken(t) for (t,) in texts)
 
     @with_cursor
     def count_unblinded_tokens(self, cursor):
@@ -661,11 +647,7 @@ class VoucherStore(object):
             """
             INSERT INTO [invalid-unblinded-tokens] VALUES (?, ?)
             """,
-            list(
-                (token.unblinded_token, reason)
-                for token
-                in unblinded_tokens
-            ),
+            list((token.unblinded_token, reason) for token in unblinded_tokens),
         )
         cursor.execute(
             """
@@ -784,6 +766,7 @@ class LeaseMaintenance(object):
         objects, the database row id that corresponds to the started run.
         This is used to make sure future updates go to the right row.
     """
+
     _pass_value = pass_value_attribute()
     _now = attr.ib()
     _connection = attr.ib()
@@ -854,6 +837,7 @@ class LeaseMaintenanceActivity(object):
 # x = store.get_latest_lease_maintenance_activity()
 # xs.started, xs.passes_required, xs.finished
 
+
 @attr.s(frozen=True)
 class UnblindedToken(object):
     """
@@ -867,6 +851,7 @@ class UnblindedToken(object):
         ``challenge_bypass_ristretto.UnblindedToken`` using that class's
         ``decode_base64`` method.
     """
+
     unblinded_token = attr.ib(
         validator=attr.validators.and_(
             attr.validators.instance_of(unicode),
@@ -888,6 +873,7 @@ class Pass(object):
         text should be kept secret.  If pass text is divulged to third-parties
         the anonymity property may be compromised.
     """
+
     preimage = attr.ib(
         validator=attr.validators.and_(
             attr.validators.instance_of(unicode),
@@ -915,6 +901,7 @@ class RandomToken(object):
     :ivar unicode token_value: The base64-encoded representation of the random
         token.
     """
+
     token_value = attr.ib(
         validator=attr.validators.and_(
             attr.validators.instance_of(unicode),
@@ -941,6 +928,7 @@ class Pending(object):
     :ivar int counter: The number of partial redemptions which have been
         successfully performed for the voucher.
     """
+
     counter = _counter_attribute()
 
     def should_start_redemption(self):
@@ -960,6 +948,7 @@ class Redeeming(object):
     state is **pending** but for which there is a redemption operation in
     progress.
     """
+
     started = attr.ib(validator=attr.validators.instance_of(datetime))
     counter = _counter_attribute()
 
@@ -984,6 +973,7 @@ class Redeemed(object):
 
     :ivar int token_count: The number of tokens the voucher was redeemed for.
     """
+
     finished = attr.ib(validator=attr.validators.instance_of(datetime))
     token_count = attr.ib(validator=attr.validators.instance_of((int, long)))
 
@@ -1019,6 +1009,7 @@ class Unpaid(object):
     state is **pending** but the most recent redemption attempt has failed due
     to lack of payment.
     """
+
     finished = attr.ib(validator=attr.validators.instance_of(datetime))
 
     def should_start_redemption(self):
@@ -1038,6 +1029,7 @@ class Error(object):
     state is **pending** but the most recent redemption attempt has failed due
     to an error that is not handled by any other part of the system.
     """
+
     finished = attr.ib(validator=attr.validators.instance_of(datetime))
     details = attr.ib(validator=attr.validators.instance_of(unicode))
 
@@ -1070,6 +1062,7 @@ class Voucher(object):
         an instance of ``Pending``, ``Redeeming``, ``Redeemed``,
         ``DoubleSpend``, ``Unpaid``, or ``Error``.
     """
+
     number = attr.ib(
         validator=attr.validators.and_(
             attr.validators.instance_of(unicode),
@@ -1094,14 +1087,16 @@ class Voucher(object):
 
     state = attr.ib(
         default=Pending(counter=0),
-        validator=attr.validators.instance_of((
-            Pending,
-            Redeeming,
-            Redeemed,
-            DoubleSpend,
-            Unpaid,
-            Error,
-        )),
+        validator=attr.validators.instance_of(
+            (
+                Pending,
+                Redeeming,
+                Redeemed,
+                DoubleSpend,
+                Unpaid,
+                Error,
+            )
+        ),
     )
 
     @classmethod
@@ -1140,7 +1135,6 @@ class Voucher(object):
         version = values.pop(u"version")
         return getattr(cls, "from_json_v{}".format(version))(values)
 
-
     @classmethod
     def from_json_v1(cls, values):
         state_json = values[u"state"]
@@ -1176,18 +1170,17 @@ class Voucher(object):
         return cls(
             number=values[u"number"],
             expected_tokens=values[u"expected-tokens"],
-            created=None if values[u"created"] is None else parse_datetime(values[u"created"]),
+            created=None
+            if values[u"created"] is None
+            else parse_datetime(values[u"created"]),
             state=state,
         )
-
 
     def to_json(self):
         return dumps(self.marshal())
 
-
     def marshal(self):
         return self.to_json_v1()
-
 
     def to_json_v1(self):
         state = self.state.to_json_v1()

--- a/src/_zkapauthorizer/model.py
+++ b/src/_zkapauthorizer/model.py
@@ -202,8 +202,8 @@ class VoucherStore(object):
     """
     This class implements persistence for vouchers.
 
-    :ivar allmydata.node._Config node_config: The Tahoe-LAFS node configuration object for
-        the node that owns the persisted vouchers.
+    :ivar allmydata.node._Config node_config: The Tahoe-LAFS node configuration object
+        for the node that owns the persisted vouchers.
 
     :ivar now: A no-argument callable that returns the time of the call as a
         ``datetime`` instance.
@@ -254,7 +254,8 @@ class VoucherStore(object):
         cursor.execute(
             """
             SELECT
-                [number], [created], [expected-tokens], [state], [finished], [token-count], [public-key], [counter]
+                [number], [created], [expected-tokens], [state], [finished],
+                [token-count], [public-key], [counter]
             FROM
                 [vouchers]
             WHERE
@@ -316,14 +317,17 @@ class VoucherStore(object):
         else:
             tokens = get_tokens()
             self._log.info(
-                "Persisting {count} random tokens for a voucher ({voucher}[{counter}]).",
+                "Persisting {count} random tokens for a voucher "
+                "({voucher}[{counter}]).",
                 count=len(tokens),
                 voucher=voucher,
                 counter=counter,
             )
             cursor.execute(
                 """
-                INSERT OR IGNORE INTO [vouchers] ([number], [expected-tokens], [created]) VALUES (?, ?, ?)
+                INSERT OR IGNORE INTO [vouchers]
+                ([number], [expected-tokens], [created])
+                VALUES (?, ?, ?)
                 """,
                 (voucher, expected_tokens, self.now()),
             )
@@ -345,7 +349,8 @@ class VoucherStore(object):
         cursor.execute(
             """
             SELECT
-                [number], [created], [expected-tokens], [state], [finished], [token-count], [public-key], [counter]
+                [number], [created], [expected-tokens], [state], [finished],
+                [token-count], [public-key], [counter]
             FROM
                 [vouchers]
             """,
@@ -415,14 +420,17 @@ class VoucherStore(object):
 
         cursor.execute(
             """
-            INSERT INTO [redemption-groups] ([voucher], [public-key], [spendable]) VALUES (?, ?, ?)
+            INSERT INTO [redemption-groups]
+            ([voucher], [public-key], [spendable])
+            VALUES (?, ?, ?)
             """,
             (voucher, public_key, spendable),
         )
         group_id = cursor.lastrowid
 
         self._log.info(
-            "Recording {count} {unspendable}spendable unblinded tokens from public key {public_key}.",
+            "Recording {count} {unspendable}spendable unblinded tokens "
+            "from public key {public_key}.",
             count=len(unblinded_tokens),
             unspendable="" if spendable else "un",
             public_key=public_key,

--- a/src/_zkapauthorizer/pricecalculator.py
+++ b/src/_zkapauthorizer/pricecalculator.py
@@ -29,10 +29,7 @@ calculator).
 
 import attr
 
-from .storage_common import (
-    required_passes,
-    share_size_for_data,
-)
+from .storage_common import required_passes, share_size_for_data
 
 
 @attr.s

--- a/src/_zkapauthorizer/pricecalculator.py
+++ b/src/_zkapauthorizer/pricecalculator.py
@@ -34,6 +34,7 @@ from .storage_common import (
     share_size_for_data,
 )
 
+
 @attr.s
 class PriceCalculator(object):
     """
@@ -46,6 +47,7 @@ class PriceCalculator(object):
     :ivar int _pass_value: The bytes component of the bytes×time value of a
         single pass.
     """
+
     _shares_needed = attr.ib()
     _shares_total = attr.ib()
     _pass_value = attr.ib()
@@ -59,15 +61,10 @@ class PriceCalculator(object):
 
         :return int: The number of ZKAPs required.
         """
-        share_sizes = (
-            share_size_for_data(self._shares_needed, size)
-            for size
-            in sizes
-        )
+        share_sizes = (share_size_for_data(self._shares_needed, size) for size in sizes)
         all_required_passes = (
             required_passes(self._pass_value, [share_size] * self._shares_total)
-            for share_size
-            in share_sizes
+            for share_size in share_sizes
         )
         price = sum(all_required_passes, 0)
         return price

--- a/src/_zkapauthorizer/private.py
+++ b/src/_zkapauthorizer/private.py
@@ -64,9 +64,11 @@ from cryptography.hazmat.primitives.constant_time import (
 # public but we do want to make sure that hotfix is applied.  This seems like
 # an alright compromise.
 import allmydata.web.private as awp
+
 del awp
 
 SCHEME = b"tahoe-lafs"
+
 
 class IToken(ICredentials):
     def check(auth_token):

--- a/src/_zkapauthorizer/private.py
+++ b/src/_zkapauthorizer/private.py
@@ -10,52 +10,7 @@ Support code for applying token-based HTTP authorization rules to a
 Twisted Web resource hierarchy.
 """
 
-from __future__ import (
-    print_function,
-    unicode_literals,
-    absolute_import,
-    division,
-)
-
-import attr
-
-from zope.interface import (
-    implementer,
-)
-
-from twisted.python.failure import (
-    Failure,
-)
-from twisted.internet.defer import (
-    succeed,
-    fail,
-)
-from twisted.cred.credentials import (
-    ICredentials,
-)
-from twisted.cred.portal import (
-    IRealm,
-    Portal,
-)
-from twisted.cred.checkers import (
-    ANONYMOUS,
-)
-from twisted.cred.error import (
-    UnauthorizedLogin,
-)
-from twisted.web.iweb import (
-    ICredentialFactory,
-)
-from twisted.web.resource import (
-    IResource,
-)
-from twisted.web.guard import (
-    HTTPAuthSessionWrapper,
-)
-
-from cryptography.hazmat.primitives.constant_time import (
-    bytes_eq,
-)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 # https://github.com/twisted/nevow/issues/106 may affect this code but if so
 # then the hotfix Tahoe-LAFS applies should deal with it.
@@ -64,6 +19,18 @@ from cryptography.hazmat.primitives.constant_time import (
 # public but we do want to make sure that hotfix is applied.  This seems like
 # an alright compromise.
 import allmydata.web.private as awp
+import attr
+from cryptography.hazmat.primitives.constant_time import bytes_eq
+from twisted.cred.checkers import ANONYMOUS
+from twisted.cred.credentials import ICredentials
+from twisted.cred.error import UnauthorizedLogin
+from twisted.cred.portal import IRealm, Portal
+from twisted.internet.defer import fail, succeed
+from twisted.python.failure import Failure
+from twisted.web.guard import HTTPAuthSessionWrapper
+from twisted.web.iweb import ICredentialFactory
+from twisted.web.resource import IResource
+from zope.interface import implementer
 
 del awp
 

--- a/src/_zkapauthorizer/resource.py
+++ b/src/_zkapauthorizer/resource.py
@@ -259,7 +259,7 @@ class _CalculatePrice(Resource):
             request.setResponseCode(BAD_REQUEST)
             return dumps(
                 {
-                    "error": "did not find required positive integer sizes list in request",
+                    "error": "did not find required positive integer sizes list in request",  # noqa: E501
                 }
             )
 

--- a/src/_zkapauthorizer/resource.py
+++ b/src/_zkapauthorizer/resource.py
@@ -21,63 +21,27 @@ vouchers for fresh tokens.
 In the future it should also allow users to read statistics about token usage.
 """
 
-from sys import (
-    maxint,
-)
-from itertools import (
-    islice,
-)
-from json import (
-    loads,
-    load,
-    dumps,
-)
-from zope.interface import (
-    Attribute,
-)
-from twisted.logger import (
-    Logger,
-)
-from twisted.web.http import (
-    BAD_REQUEST,
-)
-from twisted.web.server import (
-    NOT_DONE_YET,
-)
-from twisted.web.resource import (
-    IResource,
-    ErrorPage,
-    NoResource,
-    Resource,
-)
+from itertools import islice
+from json import dumps, load, loads
+from sys import maxint
 
-from . import (
-    __version__ as _zkapauthorizer_version,
-)
+from twisted.logger import Logger
+from twisted.web.http import BAD_REQUEST
+from twisted.web.resource import ErrorPage, IResource, NoResource, Resource
+from twisted.web.server import NOT_DONE_YET
+from zope.interface import Attribute
 
-from ._base64 import (
-    urlsafe_b64decode,
-)
-
+from . import __version__ as _zkapauthorizer_version
+from ._base64 import urlsafe_b64decode
+from .controller import PaymentController, get_redeemer
+from .pricecalculator import PriceCalculator
+from .private import create_private_tree
 from .storage_common import (
+    get_configured_allowed_public_keys,
+    get_configured_lease_duration,
+    get_configured_pass_value,
     get_configured_shares_needed,
     get_configured_shares_total,
-    get_configured_pass_value,
-    get_configured_lease_duration,
-    get_configured_allowed_public_keys,
-)
-
-from .pricecalculator import (
-    PriceCalculator,
-)
-
-from .controller import (
-    PaymentController,
-    get_redeemer,
-)
-
-from .private import (
-    create_private_tree,
 )
 
 # The number of tokens to submit with a voucher redemption.

--- a/src/_zkapauthorizer/schema.py
+++ b/src/_zkapauthorizer/schema.py
@@ -74,15 +74,15 @@ _UPGRADES = {
         """
         CREATE TABLE [vouchers] (
             [number] text,
-            [created] text,                     -- An ISO8601 date+time string.
-            [state] text DEFAULT "pending",     -- pending, double-spend, redeemed
+            [created] text,                   -- An ISO8601 date+time string.
+            [state] text DEFAULT "pending",   -- pending, double-spend, redeemed
 
-            [finished] text DEFAULT NULL,       -- ISO8601 date+time string when
-                                                -- the current terminal state was entered.
+            [finished] text DEFAULT NULL,     -- ISO8601 date+time string when
+                                              -- the current terminal state was entered.
 
-            [token-count] num DEFAULT NULL,     -- Set in the redeemed state to the number
-                                                -- of tokens received on this voucher's
-                                                -- redemption.
+            [token-count] num DEFAULT NULL,   -- Set in the redeemed state to the number
+                                              -- of tokens received on this voucher's
+                                              -- redemption.
 
             PRIMARY KEY([number])
         )
@@ -105,9 +105,12 @@ _UPGRADES = {
         """,
         """
         CREATE TABLE [lease-maintenance-spending] (
-            [id] integer, -- A unique identifier for a group of activity.
-            [started] text, -- ISO8601 date+time string when the activity began.
-            [finished] text, -- ISO8601 date+time string when the activity completed (or null).
+             -- A unique identifier for a group of activity.
+            [id] integer,
+            -- ISO8601 date+time string when the activity began.
+            [started] text,
+            -- ISO8601 date+time string when the activity completed (or null).
+            [finished] text,
 
             -- The number of passes that would be required to renew all
             -- shares encountered during this activity.  Note that because
@@ -149,7 +152,8 @@ _UPGRADES = {
         -- time of this upgrade we'll just make up some value.  It doesn't
         -- particularly matter if it is wrong for some testing voucher someone
         -- used.
-        ALTER TABLE [vouchers] ADD COLUMN [expected-tokens] integer NOT NULL DEFAULT 32768
+        ALTER TABLE [vouchers]
+        ADD COLUMN [expected-tokens] integer NOT NULL DEFAULT 32768
         """,
     ],
     4: [
@@ -188,7 +192,9 @@ _UPGRADES = {
         -- we've only preserved one public key for them so we can't do much
         -- better than this.
         INSERT INTO [redemption-groups] ([voucher], [public-key], [spendable])
-            SELECT DISTINCT([number]), [public-key], 1 FROM [vouchers] WHERE [state] = "redeemed"
+            SELECT DISTINCT([number]), [public-key], 1
+            FROM [vouchers]
+            WHERE [state] = "redeemed"
         """,
         """
         -- Give each voucher a count of "sequestered" tokens.  Currently,

--- a/src/_zkapauthorizer/schema.py
+++ b/src/_zkapauthorizer/schema.py
@@ -20,6 +20,7 @@ from __future__ import (
 This module defines the database schema used by the model interface.
 """
 
+
 def get_schema_version(cursor):
     cursor.execute(
         """
@@ -63,12 +64,10 @@ def run_schema_upgrades(upgrades, cursor):
         cursor.execute(upgrade)
 
 
-_INCREMENT_VERSION = (
-    """
+_INCREMENT_VERSION = """
     UPDATE [version]
     SET [version] = [version] + 1
     """
-)
 
 # A mapping from old schema versions to lists of unicode strings of SQL to
 # execute against that version of the schema to create the successor schema.
@@ -125,7 +124,6 @@ _UPGRADES = {
         )
         """,
     ],
-
     1: [
         """
         -- Incorrectly track a single public-key for all.  Later version of
@@ -133,14 +131,12 @@ _UPGRADES = {
         ALTER TABLE [vouchers] ADD COLUMN [public-key] text
         """,
     ],
-
     2: [
         """
         -- Keep track of progress through redemption of each voucher.
         ALTER TABLE [vouchers] ADD COLUMN [counter] integer DEFAULT 0
         """,
     ],
-
     3: [
         """
         -- Reference to the counter these tokens go with.
@@ -158,7 +154,6 @@ _UPGRADES = {
         ALTER TABLE [vouchers] ADD COLUMN [expected-tokens] integer NOT NULL DEFAULT 32768
         """,
     ],
-
     4: [
         """
         CREATE TABLE [invalid-unblinded-tokens] (
@@ -169,7 +164,6 @@ _UPGRADES = {
         )
         """,
     ],
-
     5: [
         """
         -- Create a table where rows represent a single group of unblinded
@@ -190,7 +184,6 @@ _UPGRADES = {
             [public-key] text
         )
         """,
-
         """
         -- Create one redemption group for every existing, redeemed voucher.
         -- These tokens were probably *not* all redeemed in one group but
@@ -199,14 +192,12 @@ _UPGRADES = {
         INSERT INTO [redemption-groups] ([voucher], [public-key], [spendable])
             SELECT DISTINCT([number]), [public-key], 1 FROM [vouchers] WHERE [state] = "redeemed"
         """,
-
         """
         -- Give each voucher a count of "sequestered" tokens.  Currently,
         -- these are unspendable tokens that were issued using a disallowed
         -- public key.
         ALTER TABLE [vouchers] ADD COLUMN [sequestered-count] integer NOT NULL DEFAULT 0
         """,
-
         """
         -- Give each unblinded token a reference to the [redemption-groups]
         -- table identifying the group that token arrived with.  This lets us

--- a/src/_zkapauthorizer/schema.py
+++ b/src/_zkapauthorizer/schema.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import (
-    unicode_literals,
-)
+from __future__ import unicode_literals
 
 """
 This module defines the database schema used by the model interface.

--- a/src/_zkapauthorizer/spending.py
+++ b/src/_zkapauthorizer/spending.py
@@ -16,20 +16,10 @@
 A module for logic controlling the manner in which ZKAPs are spent.
 """
 
-from zope.interface import (
-    Interface,
-    Attribute,
-    implementer,
-)
-
 import attr
+from zope.interface import Attribute, Interface, implementer
 
-from .eliot import (
-    GET_PASSES,
-    SPENT_PASSES,
-    INVALID_PASSES,
-    RESET_PASSES,
-)
+from .eliot import GET_PASSES, INVALID_PASSES, RESET_PASSES, SPENT_PASSES
 
 
 class IPassGroup(Interface):

--- a/src/_zkapauthorizer/spending.py
+++ b/src/_zkapauthorizer/spending.py
@@ -31,10 +31,12 @@ from .eliot import (
     RESET_PASSES,
 )
 
+
 class IPassGroup(Interface):
     """
     A group of passed meant to be spent together.
     """
+
     passes = Attribute(":ivar list[Pass] passes: The passes themselves.")
 
     def split(select_indices):
@@ -91,6 +93,7 @@ class IPassFactory(Interface):
     """
     An object which can create passes.
     """
+
     def get(message, num_passes):
         """
         :param unicode message: A request-binding message for the resulting passes.
@@ -115,25 +118,18 @@ class PassGroup(object):
 
     :ivar list[Pass] passes: The passes of which this group consists.
     """
+
     _message = attr.ib()
     _factory = attr.ib()
     _tokens = attr.ib()
 
     @property
     def passes(self):
-        return list(
-            pass_
-            for (unblinded_token, pass_)
-            in self._tokens
-        )
+        return list(pass_ for (unblinded_token, pass_) in self._tokens)
 
     @property
     def unblinded_tokens(self):
-        return list(
-            unblinded_token
-            for (unblinded_token, pass_)
-            in self._tokens
-        )
+        return list(unblinded_token for (unblinded_token, pass_) in self._tokens)
 
     def split(self, select_indices):
         selected = []
@@ -171,6 +167,7 @@ class SpendingController(object):
     A ``SpendingController`` gives out ZKAPs and arranges for re-spend
     attempts when necessary.
     """
+
     get_unblinded_tokens = attr.ib()
     discard_unblinded_tokens = attr.ib()
     invalidate_unblinded_tokens = attr.ib()

--- a/src/_zkapauthorizer/storage_common.py
+++ b/src/_zkapauthorizer/storage_common.py
@@ -16,27 +16,15 @@
 Functionality shared between the storage client and server.
 """
 
-from __future__ import (
-    division,
-)
+from __future__ import division
 
-from base64 import (
-    b64encode,
-)
+from base64 import b64encode
 
 import attr
+from pyutil.mathutil import div_ceil
 
-from .validators import (
-    greater_than,
-)
-
-from .eliot import (
-    MUTABLE_PASSES_REQUIRED,
-)
-
-from pyutil.mathutil import (
-    div_ceil,
-)
+from .eliot import MUTABLE_PASSES_REQUIRED
+from .validators import greater_than
 
 
 @attr.s(frozen=True, str=True)

--- a/src/_zkapauthorizer/storage_common.py
+++ b/src/_zkapauthorizer/storage_common.py
@@ -208,7 +208,8 @@ def get_sharenums(tw_vectors):
     :param tw_vectors: See
         ``allmydata.interfaces.TestAndWriteVectorsForShares``.
 
-    :return set[int]: The share numbers which the given test/write vectors would write to.
+    :return set[int]: The share numbers which the given test/write vectors
+        would write to.
     """
     return set(
         sharenum for (sharenum, (test, data, new_length)) in tw_vectors.items() if data

--- a/src/_zkapauthorizer/tests/__init__.py
+++ b/src/_zkapauthorizer/tests/__init__.py
@@ -16,6 +16,7 @@
 The automated unit test suite.
 """
 
+
 def _configure_hypothesis():
     """
     Select define Hypothesis profiles and select one based on environment
@@ -41,10 +42,7 @@ def _configure_hypothesis():
         deadline=None,
     )
 
-    settings.register_profile(
-        "default",
-        **base
-    )
+    settings.register_profile("default", **base)
 
     settings.register_profile(
         "ci",
@@ -69,5 +67,6 @@ def _configure_hypothesis():
     profile_name = environ.get("ZKAPAUTHORIZER_HYPOTHESIS_PROFILE", "default")
     settings.load_profile(profile_name)
     print("Loaded profile {}".format(profile_name))
+
 
 _configure_hypothesis()

--- a/src/_zkapauthorizer/tests/__init__.py
+++ b/src/_zkapauthorizer/tests/__init__.py
@@ -24,10 +24,7 @@ def _configure_hypothesis():
     """
     from os import environ
 
-    from hypothesis import (
-        HealthCheck,
-        settings,
-    )
+    from hypothesis import HealthCheck, settings
 
     base = dict(
         suppress_health_check=[

--- a/src/_zkapauthorizer/tests/_exception.py
+++ b/src/_zkapauthorizer/tests/_exception.py
@@ -15,10 +15,10 @@
 # limitations under the License.
 
 __all__ = [
-    'MatchesExceptionType',
-    'Raises',
-    'raises',
-    ]
+    "MatchesExceptionType",
+    "Raises",
+    "raises",
+]
 
 import sys
 
@@ -55,7 +55,7 @@ class MatchesExceptionType(Matcher):
 
     def match(self, other):
         if type(other) != tuple:
-            return Mismatch('{!r} is not an exc_info tuple'.format(other))
+            return Mismatch("{!r} is not an exc_info tuple".format(other))
         expected_class = self.expected
         etype, evalue, etb = other
         if not issubclass(etype, expected_class):
@@ -94,7 +94,7 @@ class Raises(Matcher):
     def match(self, matchee):
         try:
             result = matchee()
-            return Mismatch('%r returned %r' % (matchee, result))
+            return Mismatch("%r returned %r" % (matchee, result))
         # Catch all exceptions: Raises() should be able to match a
         # KeyboardInterrupt or SystemExit.
         except:
@@ -113,7 +113,7 @@ class Raises(Matcher):
         return None
 
     def __str__(self):
-        return 'Raises()'
+        return "Raises()"
 
 
 def raises(exception_type):

--- a/src/_zkapauthorizer/tests/_exception.py
+++ b/src/_zkapauthorizer/tests/_exception.py
@@ -22,13 +22,8 @@ __all__ = [
 
 import sys
 
-from testtools.matchers import (
-    Matcher,
-    Mismatch,
-)
-from testtools.content import (
-    TracebackContent,
-)
+from testtools.content import TracebackContent
+from testtools.matchers import Matcher, Mismatch
 
 
 def _is_exception(exc):

--- a/src/_zkapauthorizer/tests/_exception.py
+++ b/src/_zkapauthorizer/tests/_exception.py
@@ -92,7 +92,7 @@ class Raises(Matcher):
             return Mismatch("%r returned %r" % (matchee, result))
         # Catch all exceptions: Raises() should be able to match a
         # KeyboardInterrupt or SystemExit.
-        except:
+        except Exception:
             exc_info = sys.exc_info()
             mismatch = self.exception_matcher.match(exc_info)
             exc_type = exc_info[1]

--- a/src/_zkapauthorizer/tests/common.py
+++ b/src/_zkapauthorizer/tests/common.py
@@ -37,5 +37,7 @@ def _skipper(reason):
     def wrapper(f):
         def skipIt(self, *a, **kw):
             self.skipTest(reason)
+
         return skipIt
+
     return wrapper

--- a/src/_zkapauthorizer/tests/eliot.py
+++ b/src/_zkapauthorizer/tests/eliot.py
@@ -16,26 +16,14 @@
 Eliot testing helpers.
 """
 
-from __future__ import (
-    absolute_import,
-)
+from __future__ import absolute_import
 
-from functools import (
-    wraps,
-)
+from functools import wraps
+from unittest import SkipTest
 
-from unittest import (
-    SkipTest,
-)
+from eliot import MemoryLogger
+from eliot.testing import check_for_errors, swap_logger
 
-from eliot import (
-    MemoryLogger,
-)
-
-from eliot.testing import (
-    swap_logger,
-    check_for_errors,
-)
 
 # validate_logging and capture_logging copied from Eliot around 1.11.  We
 # can't upgrade past 1.7 because we're not Python 3 compatible.

--- a/src/_zkapauthorizer/tests/fixtures.py
+++ b/src/_zkapauthorizer/tests/fixtures.py
@@ -16,41 +16,19 @@
 Common fixtures to let the test suite focus on application logic.
 """
 
-from __future__ import (
-    absolute_import,
-)
+from __future__ import absolute_import
 
-from base64 import (
-    b64encode,
-)
+from base64 import b64encode
 
 import attr
-
-from fixtures import (
-    Fixture,
-    TempDir,
-)
-
-from twisted.python.filepath import (
-    FilePath,
-)
-from twisted.internet.task import (
-    Clock,
-)
 from allmydata import __version__ as allmydata_version
-from allmydata.storage.server import (
-    StorageServer,
-)
+from allmydata.storage.server import StorageServer
+from fixtures import Fixture, TempDir
+from twisted.internet.task import Clock
+from twisted.python.filepath import FilePath
 
-from ..model import (
-    VoucherStore,
-    open_and_initialize,
-    memory_connect,
-)
-from ..controller import (
-    DummyRedeemer,
-    PaymentController,
-)
+from ..controller import DummyRedeemer, PaymentController
+from ..model import VoucherStore, memory_connect, open_and_initialize
 
 
 @attr.s

--- a/src/_zkapauthorizer/tests/fixtures.py
+++ b/src/_zkapauthorizer/tests/fixtures.py
@@ -52,6 +52,7 @@ from ..controller import (
     PaymentController,
 )
 
+
 @attr.s
 class AnonymousStorageServer(Fixture):
     """
@@ -67,6 +68,7 @@ class AnonymousStorageServer(Fixture):
     :ivar twisted.internet.task.Clock clock: The ``IReactorTime`` provider to
         supply to ``StorageServer`` for its time-checking needs.
     """
+
     clock = attr.ib()
 
     def _setUp(self):
@@ -82,9 +84,7 @@ class AnonymousStorageServer(Fixture):
             timeargs = {}
 
         self.storage_server = StorageServer(
-            self.tempdir.asBytesMode().path,
-            b"x" * 20,
-            **timeargs
+            self.tempdir.asBytesMode().path, b"x" * 20, **timeargs
         )
 
 
@@ -100,6 +100,7 @@ class TemporaryVoucherStore(Fixture):
 
     :ivar store: A newly created temporary store.
     """
+
     get_config = attr.ib()
     get_now = attr.ib()
 
@@ -122,6 +123,7 @@ class ConfiglessMemoryVoucherStore(Fixture):
     This is like ``TemporaryVoucherStore`` but faster because it skips the
     Tahoe-LAFS parts.
     """
+
     get_now = attr.ib()
     _public_key = attr.ib(default=b64encode(b"A" * 32).decode("utf-8"))
     redeemer = attr.ib(default=None, init=False)

--- a/src/_zkapauthorizer/tests/foolscap.py
+++ b/src/_zkapauthorizer/tests/foolscap.py
@@ -130,7 +130,7 @@ class LocalRemote(object):
             schema.checkResults(result, inbound=False)
             _check_copyables([result])
             return succeed(result)
-        except:
+        except Exception:
             return fail()
 
 

--- a/src/_zkapauthorizer/tests/foolscap.py
+++ b/src/_zkapauthorizer/tests/foolscap.py
@@ -16,35 +16,14 @@
 Testing helpers related to Foolscap.
 """
 
-from __future__ import (
-    absolute_import,
-)
-
-from zope.interface import (
-    implementer,
-)
+from __future__ import absolute_import
 
 import attr
-
-from twisted.internet.defer import (
-    succeed,
-    fail,
-)
-
-from foolscap.api import (
-    RemoteInterface,
-    Referenceable,
-    Copyable,
-    Any,
-)
-from foolscap.copyable import (
-    ICopyable,
-    CopyableSlicer,
-)
-
-from allmydata.interfaces import (
-    RIStorageServer,
-)
+from allmydata.interfaces import RIStorageServer
+from foolscap.api import Any, Copyable, Referenceable, RemoteInterface
+from foolscap.copyable import CopyableSlicer, ICopyable
+from twisted.internet.defer import fail, succeed
+from zope.interface import implementer
 
 
 class RIStub(RemoteInterface):

--- a/src/_zkapauthorizer/tests/foolscap.py
+++ b/src/_zkapauthorizer/tests/foolscap.py
@@ -46,6 +46,7 @@ from allmydata.interfaces import (
     RIStorageServer,
 )
 
+
 class RIStub(RemoteInterface):
     pass
 
@@ -53,6 +54,7 @@ class RIStub(RemoteInterface):
 class RIEcho(RemoteInterface):
     def echo(argument=Any()):
         return Any()
+
 
 @implementer(RIStorageServer)
 class StubStorageServer(object):
@@ -85,11 +87,13 @@ class DummyReferenceable(object):
     def doRemoteCall(self, *a, **kw):
         return None
 
+
 @attr.s
 class LocalTracker(object):
     """
     Pretend to be a tracker for a ``LocalRemote``.
     """
+
     interface = attr.ib()
     interfaceName = attr.ib(default=None)
 
@@ -115,6 +119,7 @@ class LocalRemote(object):
     :ivar foolscap.ipb.IReferenceable _referenceable: The object to which this
         provides a simulated remote interface.
     """
+
     _referenceable = attr.ib()
     check_args = attr.ib(default=True)
     tracker = attr.ib(default=None)

--- a/src/_zkapauthorizer/tests/json.py
+++ b/src/_zkapauthorizer/tests/json.py
@@ -24,6 +24,7 @@ from json import (
     loads as _loads,
 )
 
+
 def loads(data):
     """
     Load a JSON object from a byte string.

--- a/src/_zkapauthorizer/tests/json.py
+++ b/src/_zkapauthorizer/tests/json.py
@@ -16,13 +16,9 @@
 A better JSON module.
 """
 
-from __future__ import (
-    absolute_import,
-)
+from __future__ import absolute_import
 
-from json import (
-    loads as _loads,
-)
+from json import loads as _loads
 
 
 def loads(data):

--- a/src/_zkapauthorizer/tests/matchers.py
+++ b/src/_zkapauthorizer/tests/matchers.py
@@ -25,37 +25,27 @@ __all__ = [
     "leases_current",
 ]
 
-from datetime import (
-    datetime,
-)
+from datetime import datetime
 
 import attr
-
 from testtools.matchers import (
-    Matcher,
-    Mismatch,
-    ContainsDict,
+    AfterPreprocessing,
+    AllMatch,
     Always,
+    ContainsDict,
+    Equals,
+    GreaterThan,
+    LessThan,
+    Matcher,
     MatchesAll,
     MatchesAny,
     MatchesStructure,
-    GreaterThan,
-    LessThan,
-    Equals,
-    AfterPreprocessing,
-    AllMatch,
+    Mismatch,
 )
-from testtools.twistedsupport import (
-    succeeded,
-)
+from testtools.twistedsupport import succeeded
+from treq import content
 
-from treq import (
-    content,
-)
-
-from ._exception import (
-    raises,
-)
+from ._exception import raises
 
 
 @attr.s

--- a/src/_zkapauthorizer/tests/matchers.py
+++ b/src/_zkapauthorizer/tests/matchers.py
@@ -57,11 +57,13 @@ from ._exception import (
     raises,
 )
 
+
 @attr.s
 class Provides(object):
     """
     Match objects that provide all of a list of Zope Interface interfaces.
     """
+
     interfaces = attr.ib(validator=attr.validators.instance_of(list))
 
     def match(self, obj):
@@ -70,9 +72,12 @@ class Provides(object):
             if not iface.providedBy(obj):
                 missing.add(iface)
         if missing:
-            return Mismatch("{} does not provide expected {}".format(
-                obj, ", ".join(str(iface) for iface in missing),
-            ))
+            return Mismatch(
+                "{} does not provide expected {}".format(
+                    obj,
+                    ", ".join(str(iface) for iface in missing),
+                )
+            )
 
 
 def matches_version_dictionary():
@@ -81,13 +86,14 @@ def matches_version_dictionary():
     ``RIStorageServer.get_version`` which is also the dictionary returned by
     our own ``RIPrivacyPassAuthorizedStorageServer.get_version``.
     """
-    return ContainsDict({
-        # It has these two top-level keys, at least.  Try not to be too
-        # fragile by asserting much more than that they are present.
-        b'application-version': Always(),
-        b'http://allmydata.org/tahoe/protocols/storage/v1': Always(),
-    })
-
+    return ContainsDict(
+        {
+            # It has these two top-level keys, at least.  Try not to be too
+            # fragile by asserting much more than that they are present.
+            b"application-version": Always(),
+            b"http://allmydata.org/tahoe/protocols/storage/v1": Always(),
+        }
+    )
 
 
 def returns(matcher):
@@ -98,15 +104,12 @@ def returns(matcher):
     return _Returns(matcher)
 
 
-
 class _Returns(Matcher):
     def __init__(self, result_matcher):
         self.result_matcher = result_matcher
 
-
     def match(self, matchee):
         return self.result_matcher.match(matchee())
-
 
     def __str__(self):
         return "Returns({})".format(self.result_matcher)
@@ -147,8 +150,7 @@ def leases_current(relevant_storage_indexes, now, min_lease_remaining):
         # visited and maintained.
         lambda storage_server: list(
             stat
-            for (storage_index, stat)
-            in storage_server.buckets.items()
+            for (storage_index, stat) in storage_server.buckets.items()
             if storage_index in relevant_storage_indexes
         ),
         AllMatch(
@@ -157,7 +159,9 @@ def leases_current(relevant_storage_indexes, now, min_lease_remaining):
                 # further in the future than min_lease_remaining,
                 # either because it had time left or because we
                 # renewed it.
-                lambda share_stat: datetime.utcfromtimestamp(share_stat.lease_expiration),
+                lambda share_stat: datetime.utcfromtimestamp(
+                    share_stat.lease_expiration
+                ),
                 GreaterThan(now + min_lease_remaining),
             ),
         ),
@@ -184,7 +188,9 @@ def odd():
     )
 
 
-def matches_response(code_matcher=Always(), headers_matcher=Always(), body_matcher=Always()):
+def matches_response(
+    code_matcher=Always(), headers_matcher=Always(), body_matcher=Always()
+):
     """
     Match a Treq response object with certain code and body.
 

--- a/src/_zkapauthorizer/tests/privacypass.py
+++ b/src/_zkapauthorizer/tests/privacypass.py
@@ -25,6 +25,7 @@ from challenge_bypass_ristretto import (
     PublicKey,
 )
 
+
 def make_passes(signing_key, for_message, random_tokens):
     """
     Create a number of cryptographically correct privacy passes.
@@ -41,15 +42,9 @@ def make_passes(signing_key, for_message, random_tokens):
     :return list[unicode]: The privacy passes.  The returned list has one
         element for each element of ``random_tokens``.
     """
-    blinded_tokens = list(
-        token.blind()
-        for token
-        in random_tokens
-    )
+    blinded_tokens = list(token.blind() for token in random_tokens)
     signatures = list(
-        signing_key.sign(blinded_token)
-        for blinded_token
-        in blinded_tokens
+        signing_key.sign(blinded_token) for blinded_token in blinded_tokens
     )
     proof = BatchDLEQProof.create(
         signing_key,
@@ -63,26 +58,21 @@ def make_passes(signing_key, for_message, random_tokens):
         PublicKey.from_signing_key(signing_key),
     )
     preimages = list(
-        unblinded_signature.preimage()
-        for unblinded_signature
-        in unblinded_signatures
+        unblinded_signature.preimage() for unblinded_signature in unblinded_signatures
     )
     verification_keys = list(
         unblinded_signature.derive_verification_key_sha512()
-        for unblinded_signature
-        in unblinded_signatures
+        for unblinded_signature in unblinded_signatures
     )
     message_signatures = list(
         verification_key.sign_sha512(for_message.encode("utf-8"))
-        for verification_key
-        in verification_keys
+        for verification_key in verification_keys
     )
     passes = list(
         u"{} {}".format(
             preimage.encode_base64().decode("ascii"),
             signature.encode_base64().decode("ascii"),
         ).encode("ascii")
-        for (preimage, signature)
-        in zip(preimages, message_signatures)
+        for (preimage, signature) in zip(preimages, message_signatures)
     )
     return passes

--- a/src/_zkapauthorizer/tests/privacypass.py
+++ b/src/_zkapauthorizer/tests/privacypass.py
@@ -16,14 +16,9 @@
 Ristretto-flavored PrivacyPass helpers for the test suite.
 """
 
-from __future__ import (
-    absolute_import,
-)
+from __future__ import absolute_import
 
-from challenge_bypass_ristretto import (
-    BatchDLEQProof,
-    PublicKey,
-)
+from challenge_bypass_ristretto import BatchDLEQProof, PublicKey
 
 
 def make_passes(signing_key, for_message, random_tokens):

--- a/src/_zkapauthorizer/tests/storage_common.py
+++ b/src/_zkapauthorizer/tests/storage_common.py
@@ -16,53 +16,20 @@
 ``allmydata.storage``-related helpers shared across the test suite.
 """
 
-from functools import (
-    partial,
-)
-
-from os import (
-    SEEK_CUR,
-)
-from struct import (
-    pack,
-)
-
-from itertools import (
-    islice,
-)
+from functools import partial
+from itertools import islice
+from os import SEEK_CUR
+from struct import pack
 
 import attr
+from challenge_bypass_ristretto import RandomToken
+from twisted.python.filepath import FilePath
+from zope.interface import implementer
 
-from zope.interface import (
-    implementer,
-)
-
-from twisted.python.filepath import (
-    FilePath,
-)
-
-from challenge_bypass_ristretto import (
-    RandomToken,
-)
-
-from .strategies import (
-    # Not really a strategy...
-    bytes_for_share,
-)
-
-from .privacypass import (
-    make_passes,
-)
-
-from ..model import (
-    NotEnoughTokens,
-    Pass,
-)
-
-from ..spending import (
-    IPassFactory,
-    PassGroup,
-)
+from ..model import NotEnoughTokens, Pass
+from ..spending import IPassFactory, PassGroup
+from .privacypass import make_passes
+from .strategies import bytes_for_share  # Not really a strategy...
 
 # Hard-coded in Tahoe-LAFS
 LEASE_INTERVAL = 60 * 60 * 24 * 31

--- a/src/_zkapauthorizer/tests/storage_common.py
+++ b/src/_zkapauthorizer/tests/storage_common.py
@@ -55,11 +55,11 @@ def cleanup_storage_server(storage_server):
 def write_toy_shares(
     storage_server,
     storage_index,
-    renew_secret,
-    cancel_secret,
     sharenums,
     size,
     canary,
+    renew_secret,
+    cancel_secret,
 ):
     """
     Write some immutable shares to the given storage server.

--- a/src/_zkapauthorizer/tests/storage_common.py
+++ b/src/_zkapauthorizer/tests/storage_common.py
@@ -67,6 +67,7 @@ from ..spending import (
 # Hard-coded in Tahoe-LAFS
 LEASE_INTERVAL = 60 * 60 * 24 * 31
 
+
 def cleanup_storage_server(storage_server):
     """
     Delete all of the shares held by the given storage server.
@@ -85,13 +86,13 @@ def cleanup_storage_server(storage_server):
 
 
 def write_toy_shares(
-        storage_server,
-        storage_index,
-        renew_secret,
-        cancel_secret,
-        sharenums,
-        size,
-        canary,
+    storage_server,
+    storage_index,
+    renew_secret,
+    cancel_secret,
+    sharenums,
+    size,
+    canary,
 ):
     """
     Write some immutable shares to the given storage server.
@@ -161,8 +162,7 @@ def whitebox_write_sparse_share(sharepath, version, size, leases, now):
                     # expiration timestamp
                     int(now + LEASE_INTERVAL),
                 )
-                for renew
-                in leases
+                for renew in leases
             ),
         )
 
@@ -175,11 +175,13 @@ def integer_passes(limit):
         passes.  Successive calls to the function return unique pass values.
     """
     counter = iter(range(limit))
+
     def get_passes(message, num_passes):
         result = list(islice(counter, num_passes))
         if len(result) < num_passes:
             raise NotEnoughTokens()
         return result
+
     return get_passes
 
 
@@ -196,8 +198,7 @@ def get_passes(message, count, signing_key):
     """
     return list(
         Pass(*pass_.split(u" "))
-        for pass_
-        in make_passes(
+        for pass_ in make_passes(
             signing_key,
             message,
             list(RandomToken.create() for n in range(count)),
@@ -252,6 +253,7 @@ class _PassFactory(object):
     :ivar list[int] returned: A list of passes which were given out but then
         returned via ``IPassGroup.reset``.
     """
+
     _get_passes = attr.ib()
 
     returned = attr.ib(default=attr.Factory(list), init=False)
@@ -291,7 +293,9 @@ class _PassFactory(object):
     def _mark_invalid(self, reason, passes):
         for p in passes:
             if p not in self.in_use:
-                raise ValueError("Pass {} cannot be invalid, it is not in use.".format(p))
+                raise ValueError(
+                    "Pass {} cannot be invalid, it is not in use.".format(p)
+                )
         self.invalid.update(dict.fromkeys(passes, reason))
         self.in_use.difference_update(passes)
 

--- a/src/_zkapauthorizer/tests/strategies.py
+++ b/src/_zkapauthorizer/tests/strategies.py
@@ -101,6 +101,7 @@ _UNBLINDED_TOKEN_LENGTH = 96
 # The length of a `VerificationSignature`, in bytes.
 _VERIFICATION_SIGNATURE_LENGTH = 64
 
+
 def tahoe_config_texts(storage_client_plugins, shares):
     """
     Build the text of complete Tahoe-LAFS configurations for a node.
@@ -113,6 +114,7 @@ def tahoe_config_texts(storage_client_plugins, shares):
         may be an integer or None to leave it unconfigured (and rely on the
         default).
     """
+
     def merge_shares(shares, the_rest):
         for (k, v) in zip(("needed", "happy", "total"), shares):
             if v is not None:
@@ -138,8 +140,7 @@ def tahoe_config_texts(storage_client_plugins, shares):
         fixed_dictionaries(
             {
                 "storageclient.plugins.{}".format(name): configs
-                for (name, configs)
-                in storage_client_plugins.items()
+                for (name, configs) in storage_client_plugins.items()
             },
         ),
         fixed_dictionaries(
@@ -198,13 +199,17 @@ def dummy_ristretto_keys():
     They're not really because they're entirely random rather than points on
     the curve.
     """
-    return binary(
-        min_size=32,
-        max_size=32,
-    ).map(
-        b64encode,
-    ).map(
-        lambda bs: bs.decode("ascii"),
+    return (
+        binary(
+            min_size=32,
+            max_size=32,
+        )
+        .map(
+            b64encode,
+        )
+        .map(
+            lambda bs: bs.decode("ascii"),
+        )
     )
 
 
@@ -216,17 +221,22 @@ def server_configurations(signing_key_path):
         **ristretto-signing-key-path** item.
     """
     return one_of(
-        fixed_dictionaries({
-            u"pass-value":
-            # The configuration is ini so everything is always a byte string!
-            integers(min_value=1).map(bytes),
-        }),
+        fixed_dictionaries(
+            {
+                u"pass-value":
+                # The configuration is ini so everything is always a byte string!
+                integers(min_value=1).map(bytes),
+            }
+        ),
         just({}),
     ).map(
-        lambda config: config.update({
-            u"ristretto-issuer-root-url": u"https://issuer.example.invalid/",
-            u"ristretto-signing-key-path": signing_key_path.path,
-        }) or config,
+        lambda config: config.update(
+            {
+                u"ristretto-issuer-root-url": u"https://issuer.example.invalid/",
+                u"ristretto-signing-key-path": signing_key_path.path,
+            }
+        )
+        or config,
     )
 
 
@@ -274,26 +284,34 @@ def client_ristrettoredeemer_configurations():
     """
     Build Ristretto-using configuration values for the client-side plugin.
     """
-    return zkapauthz_configuration(just({
-        u"ristretto-issuer-root-url": u"https://issuer.example.invalid/",
-        u"redeemer": u"ristretto",
-    }))
+    return zkapauthz_configuration(
+        just(
+            {
+                u"ristretto-issuer-root-url": u"https://issuer.example.invalid/",
+                u"redeemer": u"ristretto",
+            }
+        )
+    )
 
 
 def client_dummyredeemer_configurations():
     """
     Build DummyRedeemer-using configuration values for the client-side plugin.
     """
+
     def share_a_key(allowed_keys):
         return zkapauthz_configuration(
-            just({
-                u"redeemer": u"dummy",
-                # Pick out one of the allowed public keys so that the dummy
-                # appears to produce usable tokens.
-                u"issuer-public-key": next(iter(allowed_keys)),
-            }),
+            just(
+                {
+                    u"redeemer": u"dummy",
+                    # Pick out one of the allowed public keys so that the dummy
+                    # appears to produce usable tokens.
+                    u"issuer-public-key": next(iter(allowed_keys)),
+                }
+            ),
             allowed_public_keys=just(allowed_keys),
         )
+
     return dummy_ristretto_keys_sets().flatmap(share_a_key)
 
 
@@ -309,42 +327,58 @@ def client_doublespendredeemer_configurations(default_token_counts=token_counts(
     """
     Build DoubleSpendRedeemer-using configuration values for the client-side plugin.
     """
-    return zkapauthz_configuration(just({
-        u"redeemer": u"double-spend",
-    }))
+    return zkapauthz_configuration(
+        just(
+            {
+                u"redeemer": u"double-spend",
+            }
+        )
+    )
 
 
 def client_unpaidredeemer_configurations():
     """
     Build UnpaidRedeemer-using configuration values for the client-side plugin.
     """
-    return zkapauthz_configuration(just({
-        u"redeemer": u"unpaid",
-    }))
+    return zkapauthz_configuration(
+        just(
+            {
+                u"redeemer": u"unpaid",
+            }
+        )
+    )
 
 
 def client_nonredeemer_configurations():
     """
     Build NonRedeemer-using configuration values for the client-side plugin.
     """
-    return zkapauthz_configuration(just({
-        u"redeemer": u"non",
-    }))
+    return zkapauthz_configuration(
+        just(
+            {
+                u"redeemer": u"non",
+            }
+        )
+    )
 
 
 def client_errorredeemer_configurations(details):
     """
     Build ErrorRedeemer-using configuration values for the client-side plugin.
     """
-    return zkapauthz_configuration(just({
-        u"redeemer": u"error",
-        u"details": details,
-    }))
+    return zkapauthz_configuration(
+        just(
+            {
+                u"redeemer": u"error",
+                u"details": details,
+            }
+        )
+    )
 
 
 def direct_tahoe_configs(
-        zkapauthz_v1_configuration=client_dummyredeemer_configurations(),
-        shares=just((None, None, None)),
+    zkapauthz_v1_configuration=client_dummyredeemer_configurations(),
+    shares=just((None, None, None)),
 ):
     """
     Build complete Tahoe-LAFS configurations including the zkapauthorizer
@@ -355,9 +389,12 @@ def direct_tahoe_configs(
     :return SearchStrategy[_Config]: A strategy that builds Tahoe config
         objects.
     """
-    config_texts = minimal_tahoe_configs({
-        u"privatestorageio-zkapauthz-v1": zkapauthz_v1_configuration,
-    }, shares)
+    config_texts = minimal_tahoe_configs(
+        {
+            u"privatestorageio-zkapauthz-v1": zkapauthz_v1_configuration,
+        },
+        shares,
+    )
     return config_texts.map(
         lambda config_text: config_from_string(
             u"/dev/null/illegal",
@@ -368,8 +405,8 @@ def direct_tahoe_configs(
 
 
 def tahoe_configs(
-        zkapauthz_v1_configuration=client_dummyredeemer_configurations(),
-        shares=just((None, None, None)),
+    zkapauthz_v1_configuration=client_dummyredeemer_configurations(),
+    shares=just((None, None, None)),
 ):
     """
     Build complete Tahoe-LAFS configurations including the zkapauthorizer
@@ -384,16 +421,16 @@ def tahoe_configs(
         are the ``basedir`` and ``portnumfile`` arguments to Tahoe's
         ``config_from_string.``
     """
+
     def path_setter(config):
         def set_paths(basedir, portnumfile):
             config._basedir = basedir.decode("ascii")
             config.portnum_fname = portnumfile
             return config
+
         return set_paths
-    return direct_tahoe_configs(
-        zkapauthz_v1_configuration,
-        shares,
-    ).map(
+
+    return direct_tahoe_configs(zkapauthz_v1_configuration, shares,).map(
         path_setter,
     )
 
@@ -403,11 +440,7 @@ def share_parameters():
     Build three-tuples of integers giving usable k, happy, N parameters to
     Tahoe-LAFS' erasure encoding process.
     """
-    return lists(
-        integers(min_value=1, max_value=255),
-        min_size=3,
-        max_size=3,
-    ).map(
+    return lists(integers(min_value=1, max_value=255), min_size=3, max_size=3,).map(
         sorted,
     )
 
@@ -416,13 +449,17 @@ def vouchers():
     """
     Build unicode strings in the format of vouchers.
     """
-    return binary(
-        min_size=32,
-        max_size=32,
-    ).map(
-        urlsafe_b64encode,
-    ).map(
-        lambda voucher: voucher.decode("ascii"),
+    return (
+        binary(
+            min_size=32,
+            max_size=32,
+        )
+        .map(
+            urlsafe_b64encode,
+        )
+        .map(
+            lambda voucher: voucher.decode("ascii"),
+        )
     )
 
 
@@ -516,13 +553,12 @@ def byte_strings(label, length, entropy):
     potentially the entire length is random.
     """
     if len(label) + entropy > length:
-        raise ValueError("Entropy and label don't fit into {} bytes".format(
-            length,
-        ))
-    return binary(
-        min_size=entropy,
-        max_size=entropy,
-    ).map(
+        raise ValueError(
+            "Entropy and label don't fit into {} bytes".format(
+                length,
+            )
+        )
+    return binary(min_size=entropy, max_size=entropy,).map(
         lambda bs: label + b"x" * (length - entropy - len(label)) + bs,
     )
 
@@ -531,14 +567,18 @@ def random_tokens():
     """
     Build ``RandomToken`` instances.
     """
-    return byte_strings(
-        label=b"random-tokens",
-        length=_TOKEN_LENGTH,
-        entropy=4,
-    ).map(
-        b64encode,
-    ).map(
-        lambda token: RandomToken(token.decode("ascii")),
+    return (
+        byte_strings(
+            label=b"random-tokens",
+            length=_TOKEN_LENGTH,
+            entropy=4,
+        )
+        .map(
+            b64encode,
+        )
+        .map(
+            lambda token: RandomToken(token.decode("ascii")),
+        )
     )
 
 
@@ -586,14 +626,18 @@ def unblinded_tokens():
     base64 encode data.  You cannot use these in the PrivacyPass cryptographic
     protocol but you can put them into the database and take them out again.
     """
-    return byte_strings(
-        label=b"unblinded-tokens",
-        length=_UNBLINDED_TOKEN_LENGTH,
-        entropy=4,
-    ).map(
-        b64encode,
-    ).map(
-        lambda zkap: UnblindedToken(zkap.decode("ascii")),
+    return (
+        byte_strings(
+            label=b"unblinded-tokens",
+            length=_UNBLINDED_TOKEN_LENGTH,
+            entropy=4,
+        )
+        .map(
+            b64encode,
+        )
+        .map(
+            lambda zkap: UnblindedToken(zkap.decode("ascii")),
+        )
     )
 
 
@@ -729,10 +773,7 @@ def shares():
     """
     Build Tahoe-LAFS share data.
     """
-    return tuples(
-        sharenums(),
-        sizes()
-    ).map(
+    return tuples(sharenums(), sizes()).map(
         lambda num_and_size: bytes_for_share(*num_and_size),
     )
 
@@ -775,6 +816,7 @@ class TestAndWriteVectors(object):
     ``tw_vectors`` parameter accepted by
     ``RIStorageServer.slot_testv_and_readv_and_writev``.
     """
+
     test_vector = attr.ib()
     write_vector = attr.ib()
     new_length = attr.ib()
@@ -822,12 +864,15 @@ def announcements():
     """
     Build announcements for the ZKAPAuthorizer plugin.
     """
-    return just({
-        u"ristretto-issuer-root-url": u"https://issuer.example.invalid/",
-    })
+    return just(
+        {
+            u"ristretto-issuer-root-url": u"https://issuer.example.invalid/",
+        }
+    )
 
 
 _POSIX_EPOCH = datetime.utcfromtimestamp(0)
+
 
 def posix_safe_datetimes():
     """
@@ -869,10 +914,12 @@ def clocks(now=posix_timestamps()):
     :param now: A strategy that builds POSIX timestamps (ie, ints or floats in
         the range of time_t).
     """
+
     def clock_at_time(when):
         c = Clock()
         c.advance(when)
         return c
+
     return now.map(clock_at_time)
 
 
@@ -936,6 +983,7 @@ def node_hierarchies():
     Build hierarchies of ``IDirectoryNode`` and other ``IFilesystemNode``
     (incomplete) providers.
     """
+
     def storage_indexes_are_distinct(nodes):
         seen = set()
         for n in nodes.flatten():
@@ -945,10 +993,7 @@ def node_hierarchies():
             seen.add(si)
         return True
 
-    return recursive(
-        leaf_nodes(),
-        directory_nodes,
-    ).filter(
+    return recursive(leaf_nodes(), directory_nodes,).filter(
         storage_indexes_are_distinct,
     )
 
@@ -975,22 +1020,26 @@ def ristretto_signing_keys():
     Build byte strings holding base64-encoded Ristretto signing keys, perhaps
     with leading or trailing whitespace.
     """
-    keys = sampled_from([
-        # A few legit keys
-        b"mkQf85V2vyLQRUYuqRb+Ke6K+M9pOtXm4MslsuCdBgg=",
-        b"6f93OIdZHHAmSIaRXDSIU1UcN+sbDAh41TRPb5DhrgI=",
-        b"k58h8yPT18epw+EKMJhwHFfoM6r3TIExKm4efQHNBgM=",
-        b"rbaAlWZ3NCnl5oZ9meviGfpLbyJpgpuiuFOX0rLnNwQ=",
-    ])
-    whitespace = sampled_from([
-        # maybe no whitespace at all
-        b""
-        # or maybe some
-        b" ",
-        b"\t",
-        b"\n",
-        b"\r\n",
-    ])
+    keys = sampled_from(
+        [
+            # A few legit keys
+            b"mkQf85V2vyLQRUYuqRb+Ke6K+M9pOtXm4MslsuCdBgg=",
+            b"6f93OIdZHHAmSIaRXDSIU1UcN+sbDAh41TRPb5DhrgI=",
+            b"k58h8yPT18epw+EKMJhwHFfoM6r3TIExKm4efQHNBgM=",
+            b"rbaAlWZ3NCnl5oZ9meviGfpLbyJpgpuiuFOX0rLnNwQ=",
+        ]
+    )
+    whitespace = sampled_from(
+        [
+            # maybe no whitespace at all
+            b""
+            # or maybe some
+            b" ",
+            b"\t",
+            b"\n",
+            b"\r\n",
+        ]
+    )
 
     return builds(
         lambda leading, key, trailing: leading + key + trailing,

--- a/src/_zkapauthorizer/tests/strategies.py
+++ b/src/_zkapauthorizer/tests/strategies.py
@@ -16,77 +16,48 @@
 Hypothesis strategies for property testing.
 """
 
-from base64 import (
-    b64encode,
-    urlsafe_b64encode,
-)
-from datetime import (
-    datetime,
-)
-from urllib import (
-    quote,
-)
+from base64 import b64encode, urlsafe_b64encode
+from datetime import datetime
+from urllib import quote
 
 import attr
-
-from zope.interface import (
-    implementer,
-)
-
+from allmydata.client import config_from_string
+from allmydata.interfaces import HASH_SIZE, IDirectoryNode, IFilesystemNode
 from hypothesis.strategies import (
-    one_of,
-    sampled_from,
-    just,
-    none,
     binary,
+    builds,
     characters,
-    text,
-    integers,
-    sets,
-    lists,
-    tuples,
+    datetimes,
     dictionaries,
     fixed_dictionaries,
-    builds,
-    datetimes,
+    integers,
+    just,
+    lists,
+    none,
+    one_of,
     recursive,
+    sampled_from,
+    sets,
+    text,
+    tuples,
 )
+from twisted.internet.defer import succeed
+from twisted.internet.task import Clock
+from twisted.web.test.requesthelper import DummyRequest
+from zope.interface import implementer
 
-from twisted.internet.defer import (
-    succeed,
-)
-from twisted.internet.task import (
-    Clock,
-)
-from twisted.web.test.requesthelper import (
-    DummyRequest,
-)
-
-from allmydata.interfaces import (
-    IFilesystemNode,
-    IDirectoryNode,
-    HASH_SIZE,
-)
-
-from allmydata.client import (
-    config_from_string,
-)
-
+from ..configutil import config_string_from_sections
 from ..model import (
-    Pass,
-    RandomToken,
-    UnblindedToken,
-    Voucher,
-    Pending,
     DoubleSpend,
-    Unpaid,
     Error,
-    Redeeming,
+    Pass,
+    Pending,
+    RandomToken,
     Redeemed,
-)
-
-from ..configutil import (
-    config_string_from_sections,
+    Redeeming,
+    UnblindedToken,
+    Unpaid,
+    Voucher,
 )
 
 # Sizes informed by

--- a/src/_zkapauthorizer/tests/test_base64.py
+++ b/src/_zkapauthorizer/tests/test_base64.py
@@ -47,6 +47,7 @@ class Base64Tests(TestCase):
     """
     Tests for ``urlsafe_b64decode``.
     """
+
     @given(binary())
     def test_roundtrip(self, bytestring):
         """

--- a/src/_zkapauthorizer/tests/test_base64.py
+++ b/src/_zkapauthorizer/tests/test_base64.py
@@ -16,31 +16,16 @@
 Tests for ``_zkapauthorizer._base64``.
 """
 
-from __future__ import (
-    absolute_import,
-)
+from __future__ import absolute_import
 
-from base64 import (
-    urlsafe_b64encode,
-)
+from base64 import urlsafe_b64encode
 
-from testtools import (
-    TestCase,
-)
-from testtools.matchers import (
-    Equals,
-)
+from hypothesis import given
+from hypothesis.strategies import binary
+from testtools import TestCase
+from testtools.matchers import Equals
 
-from hypothesis import (
-    given,
-)
-from hypothesis.strategies import (
-    binary,
-)
-
-from .._base64 import (
-    urlsafe_b64decode,
-)
+from .._base64 import urlsafe_b64decode
 
 
 class Base64Tests(TestCase):

--- a/src/_zkapauthorizer/tests/test_client_resource.py
+++ b/src/_zkapauthorizer/tests/test_client_resource.py
@@ -112,6 +112,7 @@ from .strategies import (
 
 TRANSIENT_ERROR = u"something went wrong, who knows what"
 
+
 # Helper to work-around https://github.com/twisted/treq/issues/161
 def uncooperator(started=True):
     return Cooperator(
@@ -130,7 +131,7 @@ def is_not_json(bytestring):
     """
     try:
         loads(bytestring)
-    except:
+    except Exception:
         return True
     return False
 
@@ -161,7 +162,7 @@ def is_urlsafe_base64(text):
     """
     try:
         urlsafe_b64decode(text)
-    except:
+    except Exception:
         return False
     return True
 

--- a/src/_zkapauthorizer/tests/test_controller.py
+++ b/src/_zkapauthorizer/tests/test_controller.py
@@ -16,138 +16,77 @@
 Tests for ``_zkapauthorizer.controller``.
 """
 
-from __future__ import (
-    absolute_import,
-    division,
-)
+from __future__ import absolute_import, division
 
-from json import (
-    loads,
-    dumps,
-)
-from functools import (
-    partial,
-)
-from datetime import (
-    datetime,
-    timedelta,
-)
-from zope.interface import (
-    implementer,
-)
-from testtools import (
-    TestCase,
-)
-from testtools.content import (
-    text_content,
-)
-from testtools.matchers import (
-    Always,
-    Equals,
-    MatchesAll,
-    AllMatch,
-    IsInstance,
-    HasLength,
-    AfterPreprocessing,
-    MatchesStructure,
-)
-from testtools.twistedsupport import (
-    succeeded,
-    has_no_result,
-    failed,
-)
-
-from hypothesis import (
-    given,
-    assume,
-)
-from hypothesis.strategies import (
-    integers,
-    datetimes,
-    lists,
-    sampled_from,
-    randoms,
-)
-from twisted.python.url import (
-    URL,
-)
-from twisted.internet.defer import (
-    fail,
-)
-from twisted.internet.task import (
-    Clock,
-)
-from twisted.web.iweb import (
-    IAgent,
-)
-from twisted.web.resource import (
-    ErrorPage,
-    Resource,
-)
-from twisted.web.http_headers import (
-    Headers,
-)
-from twisted.web.http import (
-    UNSUPPORTED_MEDIA_TYPE,
-    BAD_REQUEST,
-    INTERNAL_SERVER_ERROR,
-)
-from treq.testing import (
-    StubTreq,
-)
+from datetime import datetime, timedelta
+from functools import partial
+from json import dumps, loads
 
 from challenge_bypass_ristretto import (
-    SecurityException,
-    PublicKey,
-    BlindedToken,
     BatchDLEQProof,
+    BlindedToken,
+    PublicKey,
+    SecurityException,
     TokenPreimage,
     VerificationSignature,
     random_signing_key,
 )
+from hypothesis import assume, given
+from hypothesis.strategies import datetimes, integers, lists, randoms, sampled_from
+from testtools import TestCase
+from testtools.content import text_content
+from testtools.matchers import (
+    AfterPreprocessing,
+    AllMatch,
+    Always,
+    Equals,
+    HasLength,
+    IsInstance,
+    MatchesAll,
+    MatchesStructure,
+)
+from testtools.twistedsupport import failed, has_no_result, succeeded
+from treq.testing import StubTreq
+from twisted.internet.defer import fail
+from twisted.internet.task import Clock
+from twisted.python.url import URL
+from twisted.web.http import BAD_REQUEST, INTERNAL_SERVER_ERROR, UNSUPPORTED_MEDIA_TYPE
+from twisted.web.http_headers import Headers
+from twisted.web.iweb import IAgent
+from twisted.web.resource import ErrorPage, Resource
+from zope.interface import implementer
 
 from ..controller import (
+    AlreadySpent,
+    DoubleSpendRedeemer,
+    DummyRedeemer,
+    IndexedRedeemer,
     IRedeemer,
     NonRedeemer,
-    DummyRedeemer,
-    DoubleSpendRedeemer,
-    UnpaidRedeemer,
-    RistrettoRedeemer,
-    IndexedRedeemer,
-    RecordingRedeemer,
     PaymentController,
+    RecordingRedeemer,
+    RistrettoRedeemer,
     UnexpectedResponse,
-    AlreadySpent,
     Unpaid,
+    UnpaidRedeemer,
     token_count_for_group,
 )
-
-from ..model import (
-    UnblindedToken,
-    Pending as model_Pending,
-    Redeeming as model_Redeeming,
-    DoubleSpend as model_DoubleSpend,
-    Redeemed as model_Redeemed,
-    Unpaid as model_Unpaid,
-)
-
+from ..model import DoubleSpend as model_DoubleSpend
+from ..model import Pending as model_Pending
+from ..model import Redeemed as model_Redeemed
+from ..model import Redeeming as model_Redeeming
+from ..model import UnblindedToken
+from ..model import Unpaid as model_Unpaid
+from .fixtures import ConfiglessMemoryVoucherStore, TemporaryVoucherStore
+from .matchers import Provides, between, raises
 from .strategies import (
-    tahoe_configs,
-    vouchers,
-    voucher_objects,
-    voucher_counters,
-    redemption_group_counts,
-    dummy_ristretto_keys,
     clocks,
-)
-from .matchers import (
-    Provides,
-    raises,
-    between,
-)
-from .fixtures import (
-    TemporaryVoucherStore,
-    ConfiglessMemoryVoucherStore,
+    dummy_ristretto_keys,
+    redemption_group_counts,
+    tahoe_configs,
+    voucher_counters,
+    voucher_objects,
+    vouchers,
 )
 
 

--- a/src/_zkapauthorizer/tests/test_controller.py
+++ b/src/_zkapauthorizer/tests/test_controller.py
@@ -155,6 +155,7 @@ class TokenCountForGroupTests(TestCase):
     """
     Tests for ``token_count_for_group``.
     """
+
     @given(
         integers(),
         integers(),
@@ -167,9 +168,7 @@ class TokenCountForGroupTests(TestCase):
         range then ``ValueError`` is raised.
         """
         assume(
-            group_number < 0 or
-            group_number >= num_groups or
-            total_tokens < num_groups
+            group_number < 0 or group_number >= num_groups or total_tokens < num_groups
         )
         self.assertThat(
             lambda: token_count_for_group(num_groups, total_tokens, group_number),
@@ -189,8 +188,7 @@ class TokenCountForGroupTests(TestCase):
         self.assertThat(
             sum(
                 token_count_for_group(num_groups, total_tokens, group_number)
-                for group_number
-                in range(num_groups)
+                for group_number in range(num_groups)
             ),
             Equals(total_tokens),
         )
@@ -211,8 +209,7 @@ class TokenCountForGroupTests(TestCase):
         self.assertThat(
             list(
                 token_count_for_group(num_groups, total_tokens, group_number)
-                for group_number
-                in range(num_groups)
+                for group_number in range(num_groups)
             ),
             AllMatch(between(lower_bound, upper_bound)),
         )
@@ -222,6 +219,7 @@ class PaymentControllerTests(TestCase):
     """
     Tests for ``PaymentController``.
     """
+
     @given(tahoe_configs(), datetimes(), vouchers(), dummy_ristretto_keys())
     def test_should_not_redeem(self, get_config, now, voucher, public_key):
         """
@@ -284,7 +282,13 @@ class PaymentControllerTests(TestCase):
             Equals(model_Pending(counter=0)),
         )
 
-    @given(tahoe_configs(), datetimes(), vouchers(), voucher_counters(), dummy_ristretto_keys())
+    @given(
+        tahoe_configs(),
+        datetimes(),
+        vouchers(),
+        voucher_counters(),
+        dummy_ristretto_keys(),
+    )
     def test_redeeming(self, get_config, now, voucher, num_successes, public_key):
         """
         A ``Voucher`` is marked redeeming while ``IRedeemer.redeem`` is actively
@@ -296,8 +300,7 @@ class PaymentControllerTests(TestCase):
         # that.
         counter = num_successes + 1
         redeemer = IndexedRedeemer(
-            [DummyRedeemer(public_key)] * num_successes +
-            [NonRedeemer()],
+            [DummyRedeemer(public_key)] * num_successes + [NonRedeemer()],
         )
         store = self.useFixture(TemporaryVoucherStore(get_config, lambda: now)).store
         controller = PaymentController(
@@ -320,10 +323,12 @@ class PaymentControllerTests(TestCase):
         controller_voucher = controller.get_voucher(voucher)
         self.assertThat(
             controller_voucher.state,
-            Equals(model_Redeeming(
-                started=now,
-                counter=num_successes,
-            )),
+            Equals(
+                model_Redeeming(
+                    started=now,
+                    counter=num_successes,
+                )
+            ),
         )
 
     @given(
@@ -334,7 +339,9 @@ class PaymentControllerTests(TestCase):
         voucher_counters().map(lambda v: v + 1),
         dummy_ristretto_keys(),
     )
-    def test_restart_redeeming(self, get_config, now, voucher, before_restart, after_restart, public_key):
+    def test_restart_redeeming(
+        self, get_config, now, voucher, before_restart, after_restart, public_key
+    ):
         """
         If some redemption groups for a voucher have succeeded but the process is
         interrupted, redemption begins at the first incomplete redemption
@@ -360,8 +367,8 @@ class PaymentControllerTests(TestCase):
                 store,
                 # It will let `before_restart` attempts succeed before hanging.
                 IndexedRedeemer(
-                    [DummyRedeemer(public_key)] * before_restart +
-                    [NonRedeemer()] * after_restart,
+                    [DummyRedeemer(public_key)] * before_restart
+                    + [NonRedeemer()] * after_restart,
                 ),
                 default_token_count=num_tokens,
                 num_redemption_groups=num_redemption_groups,
@@ -381,8 +388,8 @@ class PaymentControllerTests(TestCase):
                 # It will succeed only for the higher counter values which did
                 # not succeed or did not get started on the first try.
                 IndexedRedeemer(
-                    [NonRedeemer()] * before_restart +
-                    [DummyRedeemer(public_key)] * after_restart,
+                    [NonRedeemer()] * before_restart
+                    + [DummyRedeemer(public_key)] * after_restart,
                 ),
                 # The default token count for this new controller doesn't
                 # matter.  The redemption attempt already started with some
@@ -410,8 +417,16 @@ class PaymentControllerTests(TestCase):
             ),
         )
 
-    @given(tahoe_configs(), datetimes(), vouchers(), voucher_counters(), integers(min_value=0, max_value=100))
-    def test_stop_redeeming_on_error(self, get_config, now, voucher, counter, extra_tokens):
+    @given(
+        tahoe_configs(),
+        datetimes(),
+        vouchers(),
+        voucher_counters(),
+        integers(min_value=0, max_value=100),
+    )
+    def test_stop_redeeming_on_error(
+        self, get_config, now, voucher, counter, extra_tokens
+    ):
         """
         If an error is encountered on one of the redemption attempts performed by
         ``IRedeemer.redeem``, the effort is suspended until the normal retry
@@ -463,10 +478,12 @@ class PaymentControllerTests(TestCase):
         persisted_voucher = store.get(voucher)
         self.assertThat(
             persisted_voucher.state,
-            Equals(model_Redeemed(
-                finished=now,
-                token_count=100,
-            )),
+            Equals(
+                model_Redeemed(
+                    finished=now,
+                    token_count=100,
+                )
+            ),
         )
 
     @given(tahoe_configs(), datetimes(), vouchers())
@@ -492,9 +509,11 @@ class PaymentControllerTests(TestCase):
         self.assertThat(
             persisted_voucher,
             MatchesStructure(
-                state=Equals(model_DoubleSpend(
-                    finished=now,
-                )),
+                state=Equals(
+                    model_DoubleSpend(
+                        finished=now,
+                    )
+                ),
             ),
         )
 
@@ -578,7 +597,7 @@ class PaymentControllerTests(TestCase):
                 MatchesStructure(
                     finished=Equals(datetime_now()),
                 ),
-            )
+            ),
         )
 
         # Some time passes.
@@ -618,7 +637,10 @@ class PaymentControllerTests(TestCase):
                     unique=True,
                 ).map(
                     # Split the keys into allowed and disallowed groups
-                    lambda public_keys: (public_keys[:num_allowed_key_groups], public_keys[num_allowed_key_groups:]),
+                    lambda public_keys: (
+                        public_keys[:num_allowed_key_groups],
+                        public_keys[num_allowed_key_groups:],
+                    ),
                 ),
             ),
         ),
@@ -626,7 +648,9 @@ class PaymentControllerTests(TestCase):
         # required by the number of redemption groups we have.
         integers(min_value=0, max_value=32),
     )
-    def test_sequester_tokens_for_untrusted_key(self, random, clock, voucher, public_keys, extra_token_count):
+    def test_sequester_tokens_for_untrusted_key(
+        self, random, clock, voucher, public_keys, extra_token_count
+    ):
         """
         All unblinded tokens which are returned from the redemption process
         associated with a public key that the controller has not been
@@ -655,11 +679,7 @@ class PaymentControllerTests(TestCase):
         datetime_now = lambda: datetime.utcfromtimestamp(clock.seconds())
         store = self.useFixture(ConfiglessMemoryVoucherStore(datetime_now)).store
 
-        redeemers = list(
-            DummyRedeemer(public_key)
-            for public_key
-            in all_public_keys
-        )
+        redeemers = list(DummyRedeemer(public_key) for public_key in all_public_keys)
 
         controller = PaymentController(
             store,
@@ -678,12 +698,14 @@ class PaymentControllerTests(TestCase):
         )
 
         def count_in_group(public_keys, key_group):
-            return sum((
-                token_count_for_group(num_redemption_groups, token_count, n)
-                for n, public_key
-                in enumerate(public_keys)
-                if public_key in key_group
-            ), 0)
+            return sum(
+                (
+                    token_count_for_group(num_redemption_groups, token_count, n)
+                    for n, public_key in enumerate(public_keys)
+                    if public_key in key_group
+                ),
+                0,
+            )
 
         allowed_token_count = count_in_group(all_public_keys, allowed_public_keys)
         disallowed_token_count = count_in_group(all_public_keys, disallowed_public_keys)
@@ -723,8 +745,7 @@ class PaymentControllerTests(TestCase):
             unblinded_token
             for counter, redeemer in enumerate(redeemers)
             if redeemer._public_key in allowed_public_keys
-            for unblinded_token
-            in redeemer.redeemWithCounter(
+            for unblinded_token in redeemer.redeemWithCounter(
                 voucher_obj,
                 counter,
                 redeemer.random_tokens_for_voucher(
@@ -746,10 +767,12 @@ class PaymentControllerTests(TestCase):
 
 NOWHERE = URL.from_text(u"https://127.0.0.1/")
 
+
 class RistrettoRedeemerTests(TestCase):
     """
     Tests for ``RistrettoRedeemer``.
     """
+
     def test_interface(self):
         """
         An ``RistrettoRedeemer`` instance provides ``IRedeemer``.
@@ -937,9 +960,11 @@ class RistrettoRedeemerTests(TestCase):
             counter,
             random_tokens,
         )
+
         def unblinded_tokens_to_passes(result):
             passes = redeemer.tokens_to_passes(message, result.unblinded_tokens)
             return passes
+
         d.addCallback(unblinded_tokens_to_passes)
 
         self.assertThat(
@@ -974,39 +999,32 @@ def ristretto_verify(signing_key, message, marshaled_passes):
         ``marshaled_passes`` pass the Ristretto-defined verification for an
         exchange using the given signing key and message.
     """
+
     def decode(marshaled_pass):
         t, s = marshaled_pass.split(u" ")
         return (
             TokenPreimage.decode_base64(t.encode("ascii")),
             VerificationSignature.decode_base64(s.encode("ascii")),
         )
+
     servers_passes = list(
-        decode(marshaled_pass.pass_text)
-        for marshaled_pass
-        in marshaled_passes
+        decode(marshaled_pass.pass_text) for marshaled_pass in marshaled_passes
     )
     servers_unblinded_tokens = list(
         signing_key.rederive_unblinded_token(token_preimage)
-        for (token_preimage, sig)
-        in servers_passes
+        for (token_preimage, sig) in servers_passes
     )
-    servers_verification_sigs = list(
-        sig
-        for (token_preimage, sig)
-        in servers_passes
-    )
+    servers_verification_sigs = list(sig for (token_preimage, sig) in servers_passes)
     servers_verification_keys = list(
         unblinded_token.derive_verification_key_sha512()
-        for unblinded_token
-        in servers_unblinded_tokens
+        for unblinded_token in servers_unblinded_tokens
     )
     invalid_passes = list(
         key.invalid_sha512(
             sig,
             message,
         )
-        for (key, sig)
-        in zip(servers_verification_keys, servers_verification_sigs)
+        for (key, sig) in zip(servers_verification_keys, servers_verification_sigs)
     )
 
     return not any(invalid_passes)
@@ -1038,6 +1056,7 @@ class UnexpectedResponseRedemption(Resource):
     An ``UnexpectedResponseRedemption`` simulates the Ristretto redemption
     server but always returns a non-JSON error response.
     """
+
     def render_POST(self, request):
         request.setResponseCode(INTERNAL_SERVER_ERROR)
         return b"Sorry, this server does not behave well."
@@ -1049,6 +1068,7 @@ class AlreadySpentRedemption(Resource):
     but always refuses to allow vouchers to be redeemed and reports an error
     that the voucher has already been redeemed.
     """
+
     def render_POST(self, request):
         request_error = check_redemption_request(request)
         if request_error is not None:
@@ -1063,6 +1083,7 @@ class UnpaidRedemption(Resource):
     always refuses to allow vouchers to be redeemed and reports an error that
     the voucher has not been paid for.
     """
+
     def render_POST(self, request):
         request_error = check_redemption_request(request)
         if request_error is not None:
@@ -1086,18 +1107,14 @@ class RistrettoRedemption(Resource):
         marshaled_blinded_tokens = request_body[u"redeemTokens"]
         servers_blinded_tokens = list(
             BlindedToken.decode_base64(marshaled_blinded_token.encode("ascii"))
-            for marshaled_blinded_token
-            in marshaled_blinded_tokens
+            for marshaled_blinded_token in marshaled_blinded_tokens
         )
         servers_signed_tokens = list(
             self.signing_key.sign(blinded_token)
-            for blinded_token
-            in servers_blinded_tokens
+            for blinded_token in servers_blinded_tokens
         )
         marshaled_signed_tokens = list(
-            signed_token.encode_base64()
-            for signed_token
-            in servers_signed_tokens
+            signed_token.encode_base64() for signed_token in servers_signed_tokens
         )
         servers_proof = BatchDLEQProof.create(
             self.signing_key,
@@ -1109,18 +1126,21 @@ class RistrettoRedemption(Resource):
         finally:
             servers_proof.destroy()
 
-        return dumps({
-            u"success": True,
-            u"public-key": self.public_key.encode_base64(),
-            u"signatures": marshaled_signed_tokens,
-            u"proof": marshaled_proof,
-        })
+        return dumps(
+            {
+                u"success": True,
+                u"public-key": self.public_key.encode_base64(),
+                u"signatures": marshaled_signed_tokens,
+                u"proof": marshaled_proof,
+            }
+        )
 
 
 class CheckRedemptionRequestTests(TestCase):
     """
     Tests for ``check_redemption_request``.
     """
+
     def test_content_type(self):
         """
         If the request content-type is not application/json, the response is
@@ -1197,6 +1217,7 @@ class CheckRedemptionRequestTests(TestCase):
             ),
         )
 
+
 def check_redemption_request(request):
     """
     Verify that the given request conforms to the redemption server's public
@@ -1218,7 +1239,8 @@ def check_redemption_request(request):
     actual_keys = set(request_body.keys())
     if expected_keys != actual_keys:
         return bad_request(
-            request, {
+            request,
+            {
                 u"success": False,
                 u"reason": u"{} != {}".format(
                     expected_keys,

--- a/src/_zkapauthorizer/tests/test_foolscap.py
+++ b/src/_zkapauthorizer/tests/test_foolscap.py
@@ -16,70 +16,29 @@
 Tests for Foolscap-related test helpers.
 """
 
-from __future__ import (
-    absolute_import,
-)
+from __future__ import absolute_import
 
-from fixtures import (
-    Fixture,
-)
-from testtools import (
-    TestCase,
-)
+from fixtures import Fixture
+from foolscap.api import Any, RemoteInterface, Violation
+from foolscap.furl import decode_furl
+from foolscap.pb import Tub
+from foolscap.referenceable import RemoteReferenceOnly, RemoteReferenceTracker
+from hypothesis import given
+from hypothesis.strategies import just, one_of
+from testtools import TestCase
 from testtools.matchers import (
-    Equals,
-    MatchesAll,
     AfterPreprocessing,
     Always,
+    Equals,
     IsInstance,
+    MatchesAll,
 )
-from testtools.twistedsupport import (
-    succeeded,
-    failed,
-)
+from testtools.twistedsupport import failed, succeeded
+from twisted.internet.defer import inlineCallbacks
+from twisted.trial.unittest import TestCase as TrialTestCase
 
-from twisted.trial.unittest import (
-    TestCase as TrialTestCase,
-)
-from twisted.internet.defer import (
-    inlineCallbacks,
-)
-
-from foolscap.api import (
-    Violation,
-    RemoteInterface,
-    Any,
-)
-from foolscap.furl import (
-    decode_furl,
-)
-from foolscap.pb import (
-    Tub,
-)
-from foolscap.referenceable import (
-    RemoteReferenceTracker,
-    RemoteReferenceOnly,
-)
-
-from hypothesis import (
-    given,
-)
-from hypothesis.strategies import (
-    one_of,
-    just,
-)
-
-from .foolscap import (
-    RIStub,
-    Echoer,
-    LocalRemote,
-    BrokenCopyable,
-    DummyReferenceable,
-)
-
-from ..foolscap import (
-    ShareStat,
-)
+from ..foolscap import ShareStat
+from .foolscap import BrokenCopyable, DummyReferenceable, Echoer, LocalRemote, RIStub
 
 
 class IHasSchema(RemoteInterface):

--- a/src/_zkapauthorizer/tests/test_foolscap.py
+++ b/src/_zkapauthorizer/tests/test_foolscap.py
@@ -81,6 +81,7 @@ from ..foolscap import (
     ShareStat,
 )
 
+
 class IHasSchema(RemoteInterface):
     def method(arg=int):
         return bytes
@@ -111,6 +112,7 @@ class LocalRemoteTests(TestCase):
     """
     Tests for the ``LocalRemote`` test double.
     """
+
     @given(
         ref=one_of(
             just(remote_reference()),
@@ -195,6 +197,7 @@ class LocalRemoteTests(TestCase):
         ``LocalRemote.callRemote`` returns a ``Deferred`` that fires with a
         failure if the method's result cannot be serialized.
         """
+
         class BrokenResultReferenceable(DummyReferenceable):
             def doRemoteCall(self, *a, **kw):
                 return BrokenCopyable()
@@ -224,6 +227,7 @@ class SerializationTests(TrialTestCase):
     """
     Tests for the serialization of types used in the Foolscap API.
     """
+
     def test_sharestat(self):
         """
         A ``ShareStat`` instance can be sent as an argument to and received in a

--- a/src/_zkapauthorizer/tests/test_lease_maintenance.py
+++ b/src/_zkapauthorizer/tests/test_lease_maintenance.py
@@ -146,16 +146,18 @@ class DummyStorageServer(object):
     :ivar dict[bytes, ShareStat] buckets: A mapping from storage index to
         metadata about shares at that storage index.
     """
+
     clock = attr.ib()
     buckets = attr.ib()
     lease_seed = attr.ib()
 
     def stat_shares(self, storage_indexes):
-        return succeed(list(
-            {0: self.buckets[idx]} if idx in self.buckets else {}
-            for idx
-            in storage_indexes
-        ))
+        return succeed(
+            list(
+                {0: self.buckets[idx]} if idx in self.buckets else {}
+                for idx in storage_indexes
+            )
+        )
 
     def get_lease_seed(self):
         return self.lease_seed
@@ -227,6 +229,7 @@ class DummyServer(object):
     """
     A partial implementation of a Tahoe-LAFS "native" storage server.
     """
+
     _storage_server = attr.ib()
 
     def get_storage_server(self):
@@ -239,6 +242,7 @@ class DummyStorageBroker(object):
     """
     A partial implementation of a Tahoe-LAFS storage broker.
     """
+
     clock = attr.ib()
     _storage_servers = attr.ib()
 
@@ -259,6 +263,7 @@ class LeaseMaintenanceServiceTests(TestCase):
     """
     Tests for the service returned by ``lease_maintenance_service``.
     """
+
     @given(randoms())
     def test_interface(self, random):
         """
@@ -268,7 +273,7 @@ class LeaseMaintenanceServiceTests(TestCase):
         service = lease_maintenance_service(
             dummy_maintain_leases,
             clock,
-            FilePath(self.useFixture(TempDir()).join(u"last-run")),
+            FilePath(self.useFixture(TempDir()).join("last-run")),
             random,
         )
         self.assertThat(
@@ -296,7 +301,7 @@ class LeaseMaintenanceServiceTests(TestCase):
         service = lease_maintenance_service(
             dummy_maintain_leases,
             clock,
-            FilePath(self.useFixture(TempDir()).join(u"last-run")),
+            FilePath(self.useFixture(TempDir()).join("last-run")),
             random,
             mean,
             range_,
@@ -333,7 +338,7 @@ class LeaseMaintenanceServiceTests(TestCase):
 
         # Figure out the absolute last run time.
         last_run = datetime_now - since_last_run
-        last_run_path = FilePath(self.useFixture(TempDir()).join(u"last-run"))
+        last_run_path = FilePath(self.useFixture(TempDir()).join("last-run"))
         last_run_path.setContent(last_run.isoformat())
 
         service = lease_maintenance_service(
@@ -359,9 +364,16 @@ class LeaseMaintenanceServiceTests(TestCase):
             datetime_now + mean + (range_ / 2) - since_last_run,
         )
 
-        note("mean: {}\nrange: {}\nnow: {}\nlow: {}\nhigh: {}\nsince last: {}".format(
-            mean, range_, datetime_now, low, high, since_last_run,
-        ))
+        note(
+            "mean: {}\nrange: {}\nnow: {}\nlow: {}\nhigh: {}\nsince last: {}".format(
+                mean,
+                range_,
+                datetime_now,
+                low,
+                high,
+                since_last_run,
+            )
+        )
 
         self.assertThat(
             datetime.utcfromtimestamp(maintenance_call.getTime()),
@@ -379,7 +391,7 @@ class LeaseMaintenanceServiceTests(TestCase):
         service = lease_maintenance_service(
             lambda: None,
             clock,
-            FilePath(self.useFixture(TempDir()).join(u"last-run")),
+            FilePath(self.useFixture(TempDir()).join("last-run")),
             random,
         )
         service.startService()
@@ -405,13 +417,14 @@ class LeaseMaintenanceServiceTests(TestCase):
         When the service runs, it calls the ``maintain_leases`` object.
         """
         leases_maintained_at = []
+
         def maintain_leases():
             leases_maintained_at.append(datetime.utcfromtimestamp(clock.seconds()))
 
         service = lease_maintenance_service(
             maintain_leases,
             clock,
-            FilePath(self.useFixture(TempDir()).join(u"last-run")),
+            FilePath(self.useFixture(TempDir()).join("last-run")),
             random,
         )
         service.startService()
@@ -428,6 +441,7 @@ class VisitStorageIndexesFromRootTests(TestCase):
     """
     Tests for ``visit_storage_indexes_from_root``.
     """
+
     @given(node_hierarchies(), clocks())
     def test_visits_all_nodes(self, root_node, clock):
         """
@@ -435,6 +449,7 @@ class VisitStorageIndexesFromRootTests(TestCase):
         its deepest children.
         """
         visited = []
+
         def perform_visit(visit_assets):
             return visit_assets(visited.append)
 
@@ -454,11 +469,7 @@ class VisitStorageIndexesFromRootTests(TestCase):
                 HasLength(len(expected)),
                 AfterPreprocessing(
                     set,
-                    Equals(set(
-                        node.get_storage_index()
-                        for node
-                        in expected
-                    )),
+                    Equals(set(node.get_storage_index() for node in expected)),
                 ),
             ),
         )
@@ -468,6 +479,7 @@ class RenewLeasesTests(TestCase):
     """
     Tests for ``renew_leases``.
     """
+
     @given(storage_brokers(clocks()), lists(leaf_nodes(), unique=True))
     def test_renewed(self, storage_broker, nodes):
         """
@@ -519,23 +531,20 @@ class RenewLeasesTests(TestCase):
             succeeded(Always()),
         )
 
-        relevant_storage_indexes = set(
-            node.get_storage_index()
-            for node
-            in nodes
-        )
+        relevant_storage_indexes = set(node.get_storage_index() for node in nodes)
 
         self.assertThat(
             list(
                 server.get_storage_server()
-                for server
-                in storage_broker.get_connected_servers()
+                for server in storage_broker.get_connected_servers()
             ),
-            AllMatch(leases_current(
-                relevant_storage_indexes,
-                get_now(),
-                min_lease_remaining,
-            )),
+            AllMatch(
+                leases_current(
+                    relevant_storage_indexes,
+                    get_now(),
+                    min_lease_remaining,
+                )
+            ),
         )
 
 
@@ -543,6 +552,7 @@ class MaintainLeasesFromRootTests(TestCase):
     """
     Tests for ``maintain_leases_from_root``.
     """
+
     @given(storage_brokers(clocks()), node_hierarchies())
     def test_renewed(self, storage_broker, root_node):
         """
@@ -575,22 +585,21 @@ class MaintainLeasesFromRootTests(TestCase):
         )
 
         relevant_storage_indexes = set(
-            node.get_storage_index()
-            for node
-            in root_node.flatten()
+            node.get_storage_index() for node in root_node.flatten()
         )
 
         self.assertThat(
             list(
                 server.get_storage_server()
-                for server
-                in storage_broker.get_connected_servers()
+                for server in storage_broker.get_connected_servers()
             ),
-            AllMatch(leases_current(
-                relevant_storage_indexes,
-                get_now(),
-                min_lease_remaining,
-            ))
+            AllMatch(
+                leases_current(
+                    relevant_storage_indexes,
+                    get_now(),
+                    min_lease_remaining,
+                )
+            ),
         )
 
     @given(storage_brokers(clocks()), node_hierarchies())

--- a/src/_zkapauthorizer/tests/test_lease_maintenance.py
+++ b/src/_zkapauthorizer/tests/test_lease_maintenance.py
@@ -16,105 +16,55 @@
 Tests for ``_zkapauthorizer.lease_maintenance``.
 """
 
-from __future__ import (
-    absolute_import,
-    unicode_literals,
-)
+from __future__ import absolute_import, unicode_literals
 
-from datetime import (
-    datetime,
-    timedelta,
-)
+from datetime import datetime, timedelta
 
 import attr
-
-from zope.interface import (
-    implementer,
-)
-
-from testtools import (
-    TestCase,
-)
-from testtools.matchers import (
-    Is,
-    Equals,
-    Always,
-    HasLength,
-    MatchesAll,
-    AllMatch,
-    AfterPreprocessing,
-)
-from testtools.twistedsupport import (
-    succeeded,
-)
-from fixtures import (
-    TempDir,
-)
-from hypothesis import (
-    given,
-    note,
-)
+from allmydata.client import SecretHolder
+from allmydata.interfaces import IServer, IStorageBroker
+from allmydata.util.hashutil import CRYPTO_VAL_SIZE
+from fixtures import TempDir
+from hypothesis import given, note
 from hypothesis.strategies import (
-    builds,
     binary,
-    integers,
-    lists,
-    floats,
-    dictionaries,
-    randoms,
+    builds,
     composite,
+    dictionaries,
+    floats,
+    integers,
     just,
+    lists,
+    randoms,
 )
+from testtools import TestCase
+from testtools.matchers import (
+    AfterPreprocessing,
+    AllMatch,
+    Always,
+    Equals,
+    HasLength,
+    Is,
+    MatchesAll,
+)
+from testtools.twistedsupport import succeeded
+from twisted.application.service import IService
+from twisted.internet.defer import maybeDeferred, succeed
+from twisted.internet.task import Clock
+from twisted.python.filepath import FilePath
+from zope.interface import implementer
 
-from twisted.python.filepath import (
-    FilePath,
-)
-from twisted.internet.task import (
-    Clock,
-)
-from twisted.internet.defer import (
-    succeed,
-    maybeDeferred,
-)
-from twisted.application.service import (
-    IService,
-)
-
-from allmydata.util.hashutil import (
-    CRYPTO_VAL_SIZE,
-)
-from allmydata.client import (
-    SecretHolder,
-)
-from allmydata.interfaces import (
-    IStorageBroker,
-    IServer,
-)
-
-from ..foolscap import (
-    ShareStat,
-)
-
-from .matchers import (
-    Provides,
-    between,
-    leases_current,
-)
-from .strategies import (
-    storage_indexes,
-    clocks,
-    leaf_nodes,
-    node_hierarchies,
-)
-
+from ..foolscap import ShareStat
 from ..lease_maintenance import (
-    NoopMaintenanceObserver,
     MemoryMaintenanceObserver,
+    NoopMaintenanceObserver,
     lease_maintenance_service,
     maintain_leases_from_root,
-    visit_storage_indexes_from_root,
     renew_leases,
+    visit_storage_indexes_from_root,
 )
+from .matchers import Provides, between, leases_current
+from .strategies import clocks, leaf_nodes, node_hierarchies, storage_indexes
 
 
 def interval_means():

--- a/src/_zkapauthorizer/tests/test_matchers.py
+++ b/src/_zkapauthorizer/tests/test_matchers.py
@@ -16,27 +16,13 @@
 Tests for ``_zkapauthorizer.tests.matchers``.
 """
 
-from __future__ import (
-    absolute_import,
-)
+from __future__ import absolute_import
 
-from zope.interface import (
-    Interface,
-    implementer,
-)
+from testtools import TestCase
+from testtools.matchers import Is, Not
+from zope.interface import Interface, implementer
 
-from testtools import (
-    TestCase,
-)
-from testtools.matchers import (
-    Not,
-    Is,
-)
-
-from .matchers import (
-    Provides,
-    returns,
-)
+from .matchers import Provides, returns
 
 
 class IX(Interface):

--- a/src/_zkapauthorizer/tests/test_matchers.py
+++ b/src/_zkapauthorizer/tests/test_matchers.py
@@ -61,6 +61,7 @@ class ProvidesTests(TestCase):
     """
     Tests for ``Provides``.
     """
+
     def test_match(self):
         """
         ``Provides.match`` returns ``None`` when the given object provides all of
@@ -86,6 +87,7 @@ class ReturnsTests(TestCase):
     """
     Tests for ``returns``.
     """
+
     def test_match(self):
         """
         ``returns(m)`` returns a matcher that matches when the given object

--- a/src/_zkapauthorizer/tests/test_model.py
+++ b/src/_zkapauthorizer/tests/test_model.py
@@ -17,101 +17,69 @@
 Tests for ``_zkapauthorizer.model``.
 """
 
-from __future__ import (
-    absolute_import,
-)
+from __future__ import absolute_import
 
-from os import (
-    mkdir,
-)
-from errno import (
-    EACCES,
-)
-from datetime import (
-    datetime,
-    timedelta,
-)
+from datetime import datetime, timedelta
+from errno import EACCES
+from os import mkdir
+from unittest import skipIf
 
-from unittest import (
-    skipIf,
-)
-
-from testtools import (
-    TestCase,
-)
-from testtools.matchers import (
-    Always,
-    HasLength,
-    AfterPreprocessing,
-    MatchesStructure,
-    MatchesAll,
-    Equals,
-    Raises,
-    IsInstance,
-)
-from testtools.twistedsupport import (
-    succeeded,
-)
-
-from fixtures import (
-    TempDir,
-)
-
-from hypothesis import (
-    note,
-    given,
-    assume,
-)
+from fixtures import TempDir
+from hypothesis import assume, given, note
 from hypothesis.stateful import (
     RuleBasedStateMachine,
-    rule,
-    precondition,
     invariant,
+    precondition,
+    rule,
     run_state_machine_as_test,
 )
 from hypothesis.strategies import (
-    data,
     booleans,
-    lists,
-    tuples,
+    data,
     datetimes,
-    timedeltas,
     integers,
+    lists,
     randoms,
+    timedeltas,
+    tuples,
 )
-
-from twisted.python.runtime import (
-    platform,
+from testtools import TestCase
+from testtools.matchers import (
+    AfterPreprocessing,
+    Always,
+    Equals,
+    HasLength,
+    IsInstance,
+    MatchesAll,
+    MatchesStructure,
+    Raises,
 )
+from testtools.twistedsupport import succeeded
+from twisted.python.runtime import platform
 
 from ..model import (
-    StoreOpenError,
-    NotEnoughTokens,
-    VoucherStore,
-    Voucher,
-    Pending,
     DoubleSpend,
-    Redeemed,
     LeaseMaintenanceActivity,
+    NotEnoughTokens,
+    Pending,
+    Redeemed,
+    StoreOpenError,
+    Voucher,
+    VoucherStore,
     memory_connect,
 )
+from .fixtures import ConfiglessMemoryVoucherStore, TemporaryVoucherStore
+from .matchers import raises
 from .strategies import (
-    tahoe_configs,
-    vouchers,
-    voucher_objects,
-    voucher_counters,
-    random_tokens,
-    unblinded_tokens,
-    posix_safe_datetimes,
     dummy_ristretto_keys,
     pass_counts,
-)
-from .fixtures import (
-    TemporaryVoucherStore,
-    ConfiglessMemoryVoucherStore,
-)
-from .matchers import (
-    raises,
+    posix_safe_datetimes,
+    random_tokens,
+    tahoe_configs,
+    unblinded_tokens,
+    voucher_counters,
+    voucher_objects,
+    vouchers,
 )
 
 

--- a/src/_zkapauthorizer/tests/test_model.py
+++ b/src/_zkapauthorizer/tests/test_model.py
@@ -349,7 +349,8 @@ class VoucherStoreTests(TestCase):
 
         :param get_config: See ``tahoe_configs``
         :param unicode voucher_value: A voucher value to associate with the tokens.
-        :param unicode public_key: A public key to associate with inserted unblinded tokens.
+        :param unicode public_key: A public key to associate with inserted
+            unblinded tokens.
         :param datetime now: A time to pretend is current.
         :param data: A Hypothesis data for drawing values from strategies.
 
@@ -711,7 +712,8 @@ class UnblindedTokenStoreTests(TestCase):
         self, get_config, now, voucher_value, public_key, unblinded_tokens, completed
     ):
         """
-        Unblinded tokens for a voucher which has not been added to the store cannot be inserted.
+        Unblinded tokens for a voucher which has not been added to the store
+        cannot be inserted.
         """
         store = self.useFixture(TemporaryVoucherStore(get_config, lambda: now)).store
         self.assertThat(

--- a/src/_zkapauthorizer/tests/test_plugin.py
+++ b/src/_zkapauthorizer/tests/test_plugin.py
@@ -174,7 +174,6 @@ from .eliot import (
 )
 
 
-
 SIGNING_KEY_PATH = FilePath(__file__).sibling(u"testing-signing.key")
 
 
@@ -184,11 +183,11 @@ def get_rref(interface=None):
     return LocalRemote(DummyReferenceable(interface))
 
 
-
 class GetRRefTests(TestCase):
     """
     Tests for ``get_rref``.
     """
+
     def test_localremote(self):
         """
         ``get_rref`` returns an instance of ``LocalRemote``.
@@ -210,7 +209,9 @@ class GetRRefTests(TestCase):
             AfterPreprocessing(
                 lambda ref: ref.tracker,
                 MatchesStructure(
-                    interfaceName=Equals(RIPrivacyPassAuthorizedStorageServer.__remote_name__),
+                    interfaceName=Equals(
+                        RIPrivacyPassAuthorizedStorageServer.__remote_name__
+                    ),
                 ),
             ),
         )
@@ -237,6 +238,7 @@ class PluginTests(TestCase):
     """
     Tests for ``twisted.plugins.zkapauthorizer.storage_server``.
     """
+
     def test_discoverable(self):
         """
         The plugin can be discovered.
@@ -245,7 +247,6 @@ class PluginTests(TestCase):
             getPlugins(IFoolscapStoragePlugin),
             Contains(storage_server),
         )
-
 
     def test_provides_interface(self):
         """
@@ -257,12 +258,12 @@ class PluginTests(TestCase):
         )
 
 
-
 class ServerPluginTests(TestCase):
     """
     Tests for the plugin's implementation of
     ``IFoolscapStoragePlugin.get_storage_server``.
     """
+
     @given(server_configurations(SIGNING_KEY_PATH))
     def test_returns_announceable(self, configuration):
         """
@@ -277,7 +278,6 @@ class ServerPluginTests(TestCase):
             storage_server_deferred,
             succeeded(Provides([IAnnounceableStorageServer])),
         )
-
 
     @given(server_configurations(SIGNING_KEY_PATH))
     def test_returns_referenceable(self, configuration):
@@ -323,7 +323,6 @@ class ServerPluginTests(TestCase):
             ),
         )
 
-
     @given(server_configurations(SIGNING_KEY_PATH))
     def test_returns_hashable(self, configuration):
         """
@@ -352,15 +351,21 @@ class ServerPluginTests(TestCase):
 
 tahoe_configs_with_dummy_redeemer = tahoe_configs(client_dummyredeemer_configurations())
 
-tahoe_configs_with_mismatched_issuer = minimal_tahoe_configs({
-    u"privatestorageio-zkapauthz-v1": just({u"ristretto-issuer-root-url": u"https://another-issuer.example.invalid/"}),
-})
+tahoe_configs_with_mismatched_issuer = minimal_tahoe_configs(
+    {
+        u"privatestorageio-zkapauthz-v1": just(
+            {u"ristretto-issuer-root-url": u"https://another-issuer.example.invalid/"}
+        ),
+    }
+)
+
 
 class ClientPluginTests(TestCase):
     """
     Tests for the plugin's implementation of
     ``IFoolscapStoragePlugin.get_storage_client``.
     """
+
     @given(tahoe_configs(), announcements())
     def test_interface(self, get_config, announcement):
         """
@@ -383,7 +388,6 @@ class ClientPluginTests(TestCase):
             storage_client,
             Provides([IStorageServer]),
         )
-
 
     @given(tahoe_configs_with_mismatched_issuer, announcements())
     def test_mismatched_ristretto_issuer(self, config_text, announcement):
@@ -420,7 +424,6 @@ class ClientPluginTests(TestCase):
             raises(IssuerConfigurationMismatch),
         )
 
-
     @given(
         tahoe_configs(),
         announcements(),
@@ -431,15 +434,14 @@ class ClientPluginTests(TestCase):
         sizes(),
     )
     def test_mismatch_storage_server_furl(
-            self,
-            get_config,
-            announcement,
-            storage_index,
-            renew_secret,
-            cancel_secret,
-            sharenums,
-            size,
-
+        self,
+        get_config,
+        announcement,
+        storage_index,
+        renew_secret,
+        cancel_secret,
+        sharenums,
+        size,
     ):
         """
         If the ``get_rref`` passed to ``get_storage_client`` returns a reference
@@ -484,14 +486,14 @@ class ClientPluginTests(TestCase):
     )
     @capture_logging(lambda self, logger: logger.validate())
     def test_unblinded_tokens_spent(
-            self,
-            logger,
-            get_config,
-            now,
-            announcement,
-            voucher,
-            num_passes,
-            public_key,
+        self,
+        logger,
+        get_config,
+        now,
+        announcement,
+        voucher,
+        num_passes,
+        public_key,
     ):
         """
         The ``ZKAPAuthorizerStorageServer`` returned by ``get_storage_client``
@@ -548,10 +550,12 @@ class ClientPluginTests(TestCase):
                 AllMatch(
                     AfterPreprocessing(
                         lambda logged_message: logged_message.message,
-                        ContainsDict({
-                            u"message": Equals(u"request binding message"),
-                            u"count": Equals(num_passes),
-                        }),
+                        ContainsDict(
+                            {
+                                u"message": Equals(u"request binding message"),
+                                u"count": Equals(num_passes),
+                            }
+                        ),
                     ),
                 ),
             ),
@@ -563,6 +567,7 @@ class ClientResourceTests(TestCase):
     Tests for the plugin's implementation of
     ``IFoolscapStoragePlugin.get_client_resource``.
     """
+
     @given(tahoe_configs())
     def test_interface(self, get_config):
         """
@@ -617,6 +622,7 @@ class LeaseMaintenanceServiceTests(TestCase):
     """
     Tests for the plugin's initialization of the lease maintenance service.
     """
+
     def _created_test(self, get_config, servers_yaml, rootcap):
         original_tempdir = tempfile.tempdir
 
@@ -654,7 +660,7 @@ class LeaseMaintenanceServiceTests(TestCase):
             # suite if we don't clean it up.  We can't do this with a tearDown
             # or a fixture or an addCleanup because hypothesis doesn't run any
             # of those at the right time. :/
-           tempfile.tempdir = original_tempdir
+            tempfile.tempdir = original_tempdir
 
     @settings(
         deadline=None,
@@ -670,7 +676,6 @@ class LeaseMaintenanceServiceTests(TestCase):
         connect to.
         """
         return self._created_test(get_config, servers_yaml, rootcap=True)
-
 
     @settings(
         deadline=None,
@@ -691,6 +696,7 @@ class LoadSigningKeyTests(TestCase):
     """
     Tests for ``load_signing_key``.
     """
+
     @given(ristretto_signing_keys())
     def test_valid(self, key_bytes):
         """

--- a/src/_zkapauthorizer/tests/test_pricecalculator.py
+++ b/src/_zkapauthorizer/tests/test_pricecalculator.py
@@ -17,41 +17,16 @@
 Tests for ``_zkapauthorizer.pricecalculator``.
 """
 
-from functools import (
-    partial,
-)
+from functools import partial
 
-from testtools import (
-    TestCase,
-)
-from testtools.matchers import (
-    Equals,
-    GreaterThan,
-    IsInstance,
-    MatchesAll,
-)
+from hypothesis import given
+from hypothesis.strategies import integers, lists, tuples
+from testtools import TestCase
+from testtools.matchers import Equals, GreaterThan, IsInstance, MatchesAll
 
-from hypothesis import (
-    given,
-)
-
-from hypothesis.strategies import (
-    integers,
-    lists,
-    tuples,
-)
-
-from ..pricecalculator import (
-    PriceCalculator,
-)
-
-from .strategies import (
-    sizes,
-    share_parameters,
-)
-from .matchers import (
-    greater_or_equal,
-)
+from ..pricecalculator import PriceCalculator
+from .matchers import greater_or_equal
+from .strategies import share_parameters, sizes
 
 file_sizes = lists(sizes(), min_size=1)
 

--- a/src/_zkapauthorizer/tests/test_pricecalculator.py
+++ b/src/_zkapauthorizer/tests/test_pricecalculator.py
@@ -55,10 +55,12 @@ from .matchers import (
 
 file_sizes = lists(sizes(), min_size=1)
 
+
 class PriceCalculatorTests(TestCase):
     """
     Tests for ``PriceCalculator``.
     """
+
     @given(
         integers(min_value=1),
         integers(min_value=1),
@@ -102,7 +104,6 @@ class PriceCalculatorTests(TestCase):
             fewer_needed_price,
             greater_or_equal(more_needed_price),
         )
-
 
     @given(
         integers(min_value=1, max_value=127),

--- a/src/_zkapauthorizer/tests/test_private.py
+++ b/src/_zkapauthorizer/tests/test_private.py
@@ -53,21 +53,25 @@ from allmydata.test.web.matchers import (
     has_response_code,
 )
 
+
 class PrivacyTests(TestCase):
     """
     Tests for the privacy features of the resources created by ``create_private_tree``.
     """
+
     def setUp(self):
         self.token = b"abcdef"
         self.resource = create_private_tree(lambda: self.token, Resource())
         self.agent = RequestTraversalAgent(self.resource)
-        self.client =  HTTPClient(self.agent)
+        self.client = HTTPClient(self.agent)
         return super(PrivacyTests, self).setUp()
 
     def _authorization(self, scheme, value):
-        return Headers({
-            u"authorization": [u"{} {}".format(scheme, value)],
-        })
+        return Headers(
+            {
+                "authorization": ["{} {}".format(scheme, value)],
+            }
+        )
 
     def test_unauthorized(self):
         """
@@ -86,7 +90,7 @@ class PrivacyTests(TestCase):
         self.assertThat(
             self.client.head(
                 b"http:///foo/bar",
-                headers=self._authorization(u"basic", self.token),
+                headers=self._authorization("basic", self.token),
             ),
             succeeded(has_response_code(Equals(UNAUTHORIZED))),
         )
@@ -99,7 +103,7 @@ class PrivacyTests(TestCase):
         self.assertThat(
             self.client.head(
                 b"http:///foo/bar",
-                headers=self._authorization(SCHEME, u"foo bar"),
+                headers=self._authorization(SCHEME, "foo bar"),
             ),
             succeeded(has_response_code(Equals(UNAUTHORIZED))),
         )

--- a/src/_zkapauthorizer/tests/test_private.py
+++ b/src/_zkapauthorizer/tests/test_private.py
@@ -9,49 +9,19 @@
 Tests for ``_zkapauthorizer.private``.
 """
 
-from __future__ import (
-    print_function,
-    unicode_literals,
-    absolute_import,
-    division,
-)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
-from testtools import (
-    TestCase,
-)
-from testtools.matchers import (
-    Equals,
-)
-from testtools.twistedsupport import (
-    succeeded,
-)
+from allmydata.test.web.matchers import has_response_code
+from testtools import TestCase
+from testtools.matchers import Equals
+from testtools.twistedsupport import succeeded
+from treq.client import HTTPClient
+from treq.testing import RequestTraversalAgent
+from twisted.web.http import NOT_FOUND, UNAUTHORIZED
+from twisted.web.http_headers import Headers
+from twisted.web.resource import Resource
 
-from twisted.web.http import (
-    UNAUTHORIZED,
-    NOT_FOUND,
-)
-from twisted.web.http_headers import (
-    Headers,
-)
-from twisted.web.resource import (
-    Resource,
-)
-
-from treq.client import (
-    HTTPClient,
-)
-from treq.testing import (
-    RequestTraversalAgent,
-)
-
-from ..private import (
-    SCHEME,
-    create_private_tree,
-)
-
-from allmydata.test.web.matchers import (
-    has_response_code,
-)
+from ..private import SCHEME, create_private_tree
 
 
 class PrivacyTests(TestCase):

--- a/src/_zkapauthorizer/tests/test_schema.py
+++ b/src/_zkapauthorizer/tests/test_schema.py
@@ -32,6 +32,7 @@ from ..schema import (
     _UPGRADES,
 )
 
+
 class UpgradeTests(TestCase):
     def test_consistency(self):
         """

--- a/src/_zkapauthorizer/tests/test_schema.py
+++ b/src/_zkapauthorizer/tests/test_schema.py
@@ -17,20 +17,12 @@
 Tests for ``_zkapauthorizer.schema``.
 """
 
-from __future__ import (
-    absolute_import,
-)
+from __future__ import absolute_import
 
-from testtools import (
-    TestCase,
-)
-from testtools.matchers import (
-    Equals,
-)
+from testtools import TestCase
+from testtools.matchers import Equals
 
-from ..schema import (
-    _UPGRADES,
-)
+from ..schema import _UPGRADES
 
 
 class UpgradeTests(TestCase):

--- a/src/_zkapauthorizer/tests/test_spending.py
+++ b/src/_zkapauthorizer/tests/test_spending.py
@@ -16,45 +16,23 @@
 Tests for ``_zkapauthorizer.spending``.
 """
 
-from testtools import (
-    TestCase,
-)
+from hypothesis import given
+from hypothesis.strategies import data, integers, randoms
+from testtools import TestCase
 from testtools.matchers import (
+    AfterPreprocessing,
     Always,
     Equals,
+    HasLength,
     MatchesAll,
     MatchesStructure,
-    HasLength,
-    AfterPreprocessing,
 )
-from testtools.twistedsupport import (
-    succeeded,
-)
+from testtools.twistedsupport import succeeded
 
-from hypothesis import (
-    given,
-)
-from hypothesis.strategies import (
-    integers,
-    randoms,
-    data,
-)
-
-from .strategies import (
-    vouchers,
-    pass_counts,
-    posix_safe_datetimes,
-)
-from .matchers import (
-    Provides,
-)
-from .fixtures import (
-    ConfiglessMemoryVoucherStore,
-)
-from ..spending import (
-    IPassGroup,
-    SpendingController,
-)
+from ..spending import IPassGroup, SpendingController
+from .fixtures import ConfiglessMemoryVoucherStore
+from .matchers import Provides
+from .strategies import pass_counts, posix_safe_datetimes, vouchers
 
 
 class PassGroupTests(TestCase):

--- a/src/_zkapauthorizer/tests/test_spending.py
+++ b/src/_zkapauthorizer/tests/test_spending.py
@@ -56,10 +56,12 @@ from ..spending import (
     SpendingController,
 )
 
+
 class PassGroupTests(TestCase):
     """
     Tests for ``IPassGroup`` and the factories that create them.
     """
+
     @given(vouchers(), pass_counts(), posix_safe_datetimes())
     def test_get(self, voucher, num_passes, now):
         """
@@ -94,14 +96,14 @@ class PassGroupTests(TestCase):
         )
 
     def _test_token_group_operation(
-            self,
-            operation,
-            matches_tokens,
-            voucher,
-            num_passes,
-            now,
-            random,
-            data,
+        self,
+        operation,
+        matches_tokens,
+        voucher,
+        num_passes,
+        now,
+        random,
+        data,
     ):
         configless = self.useFixture(
             ConfiglessMemoryVoucherStore(
@@ -143,6 +145,7 @@ class PassGroupTests(TestCase):
         Passes in a group can be marked as successfully spent to prevent them from
         being re-used by a future ``get`` call.
         """
+
         def matches_tokens(num_passes, group):
             return AfterPreprocessing(
                 # The use of `backup` here to check is questionable.  TODO:
@@ -150,6 +153,7 @@ class PassGroupTests(TestCase):
                 lambda store: store.backup()[u"unblinded-tokens"],
                 HasLength(num_passes - len(group.passes)),
             )
+
         return self._test_token_group_operation(
             lambda group: group.mark_spent(),
             matches_tokens,
@@ -166,6 +170,7 @@ class PassGroupTests(TestCase):
         Passes in a group can be marked as invalid to prevent them from being
         re-used by a future ``get`` call.
         """
+
         def matches_tokens(num_passes, group):
             return AfterPreprocessing(
                 # The use of `backup` here to check is questionable.  TODO:
@@ -173,6 +178,7 @@ class PassGroupTests(TestCase):
                 lambda store: store.backup()[u"unblinded-tokens"],
                 HasLength(num_passes - len(group.passes)),
             )
+
         return self._test_token_group_operation(
             lambda group: group.mark_invalid(u"reason"),
             matches_tokens,
@@ -189,12 +195,14 @@ class PassGroupTests(TestCase):
         Passes in a group can be reset to allow them to be re-used by a future
         ``get`` call.
         """
+
         def matches_tokens(num_passes, group):
             return AfterPreprocessing(
                 # They've been reset so we should be able to re-get them.
                 lambda store: store.get_unblinded_tokens(len(group.passes)),
                 Equals(group.unblinded_tokens),
             )
+
         return self._test_token_group_operation(
             lambda group: group.reset(),
             matches_tokens,

--- a/src/_zkapauthorizer/tests/test_storage_client.py
+++ b/src/_zkapauthorizer/tests/test_storage_client.py
@@ -96,11 +96,11 @@ from .storage_common import (
 )
 
 
-
 class GetConfiguredValueTests(TestCase):
     """
     Tests for helpers for reading certain configuration values.
     """
+
     @given(integers(min_value=1, max_value=255))
     def test_get_configured_shares_needed(self, expected):
         """
@@ -115,7 +115,9 @@ class GetConfiguredValueTests(TestCase):
 shares.needed = {}
 shares.happy = 5
 shares.total = 10
-""".format(expected),
+""".format(
+                expected
+            ),
         )
 
         self.assertThat(
@@ -137,7 +139,9 @@ shares.total = 10
 shares.needed = 5
 shares.happy = 5
 shares.total = {}
-""".format(expected),
+""".format(
+                expected
+            ),
         )
 
         self.assertThat(
@@ -163,7 +167,9 @@ shares.total = 10
 
 [storageclient.plugins.privatestorageio-zkapauthz-v1]
 pass-value={}
-""".format(expected),
+""".format(
+                expected
+            ),
         )
 
         self.assertThat(
@@ -189,7 +195,9 @@ shares.total = 10
 
 [storageclient.plugins.privatestorageio-zkapauthz-v1]
 allowed-public-keys = {}
-""".format(",".join(expected)),
+""".format(
+                ",".join(expected)
+            ),
         )
 
         self.assertThat(
@@ -202,6 +210,7 @@ class CallWithPassesTests(TestCase):
     """
     Tests for ``call_with_passes``.
     """
+
     @given(pass_counts())
     def test_success_result(self, num_passes):
         """
@@ -321,7 +330,9 @@ class CallWithPassesTests(TestCase):
         def reject_even_pass_values(group):
             passes = group.passes
             good_passes = list(idx for (idx, p) in enumerate(passes) if p % 2)
-            bad_passes = list(idx for (idx, p) in enumerate(passes) if idx not in good_passes)
+            bad_passes = list(
+                idx for (idx, p) in enumerate(passes) if idx not in good_passes
+            )
             if len(good_passes) < num_passes:
                 _ValidationResult(
                     valid=good_passes,
@@ -463,11 +474,14 @@ class CallWithPassesTests(TestCase):
             ),
         )
 
+
 def reset(group):
     group.reset()
 
+
 def spend(group):
     group.mark_spent()
+
 
 def invalidate(group):
     group.mark_invalid(u"reason")
@@ -480,6 +494,7 @@ class PassFactoryTests(TestCase):
     It is unfortunate that this isn't the same test suite as
     ``test_spending.PassGroupTests``.
     """
+
     @given(pass_counts(), pass_counts())
     def test_returned_passes_reused(self, num_passes_a, num_passes_b):
         """

--- a/src/_zkapauthorizer/tests/test_storage_client.py
+++ b/src/_zkapauthorizer/tests/test_storage_client.py
@@ -16,84 +16,41 @@
 Tests for ``_zkapauthorizer._storage_client``.
 """
 
-from __future__ import (
-    division,
-)
+from __future__ import division
 
-from functools import (
-    partial,
-)
+from functools import partial
 
-from testtools import (
-    TestCase,
-)
+from allmydata.client import config_from_string
+from hypothesis import given
+from hypothesis.strategies import integers, sampled_from, sets
+from testtools import TestCase
 from testtools.matchers import (
-    Always,
-    Is,
-    Equals,
     AfterPreprocessing,
-    MatchesStructure,
-    HasLength,
-    MatchesAll,
     AllMatch,
+    Always,
+    Equals,
+    HasLength,
+    Is,
     IsInstance,
+    MatchesAll,
+    MatchesStructure,
 )
-from testtools.twistedsupport import (
-    succeeded,
-    failed,
-)
+from testtools.twistedsupport import failed, succeeded
+from twisted.internet.defer import fail, succeed
 
-from hypothesis import (
-    given,
-)
-from hypothesis.strategies import (
-    sampled_from,
-    integers,
-    sets,
-)
-
-from twisted.internet.defer import (
-    succeed,
-    fail,
-)
-
-from allmydata.client import (
-    config_from_string,
-)
-
-
-from ..api import (
-    MorePassesRequired,
-)
-from ..model import (
-    NotEnoughTokens,
-)
+from .._storage_client import call_with_passes
+from .._storage_server import _ValidationResult
+from ..api import MorePassesRequired
+from ..model import NotEnoughTokens
 from ..storage_common import (
+    get_configured_allowed_public_keys,
+    get_configured_pass_value,
     get_configured_shares_needed,
     get_configured_shares_total,
-    get_configured_pass_value,
-    get_configured_allowed_public_keys,
 )
-from .._storage_client import (
-    call_with_passes,
-)
-
-from .._storage_server import (
-    _ValidationResult,
-)
-from .matchers import (
-    even,
-    odd,
-    raises,
-)
-from .strategies import (
-    pass_counts,
-    dummy_ristretto_keys,
-)
-from .storage_common import (
-    pass_factory,
-    integer_passes,
-)
+from .matchers import even, odd, raises
+from .storage_common import integer_passes, pass_factory
+from .strategies import dummy_ristretto_keys, pass_counts
 
 
 class GetConfiguredValueTests(TestCase):

--- a/src/_zkapauthorizer/tests/test_storage_protocol.py
+++ b/src/_zkapauthorizer/tests/test_storage_protocol.py
@@ -18,6 +18,8 @@ Tests for communication between the client and server components.
 
 from __future__ import absolute_import
 
+from functools import partial
+
 from allmydata.storage.common import storage_index_to_dir
 from challenge_bypass_ristretto import random_signing_key
 from fixtures import MonkeyPatch
@@ -36,9 +38,10 @@ from testtools.matchers import (
     raises,
 )
 from testtools.twistedsupport import failed, succeeded
-from testtools.twistedsupport._deferred import (  # I'd rather use https://twistedmatrix.com/trac/ticket/8900 but efforts; there appear to have stalled.
-    extract_result,
-)
+
+# I'd rather use https://twistedmatrix.com/trac/ticket/8900 but efforts there
+# appear to have stalled.
+from testtools.twistedsupport._deferred import extract_result
 from twisted.internet.task import Clock
 from twisted.python.filepath import FilePath
 from twisted.python.runtime import platform
@@ -399,11 +402,11 @@ class ShareTests(TestCase):
         write_toy_shares(
             self.anonymous_storage_server,
             storage_index,
-            renew_secret,
-            cancel_secret,
             existing_sharenums,
             size,
             canary=self.canary,
+            renew_secret=renew_secret,
+            cancel_secret=cancel_secret,
         )
 
         # Do a partial repeat of the operation.  Shuffle around
@@ -472,11 +475,11 @@ class ShareTests(TestCase):
         write_toy_shares(
             self.anonymous_storage_server,
             storage_index,
-            add_lease_secret,
-            cancel_secret,
             sharenums,
             size,
             canary=self.canary,
+            renew_secret=add_lease_secret,
+            cancel_secret=cancel_secret,
         )
 
         self.assertThat(
@@ -565,14 +568,10 @@ class ShareTests(TestCase):
             size,
             when,
             leases,
-            lambda storage_server, storage_index, sharenums, size, canary: write_toy_shares(
-                storage_server,
-                storage_index,
-                renew_secret,
-                cancel_secret,
-                sharenums,
-                size,
-                canary,
+            partial(
+                write_toy_shares,
+                renew_secret=renew_secret,
+                cancel_secret=cancel_secret,
             ),
         )
 
@@ -787,7 +786,8 @@ class ShareTests(TestCase):
 
     @skipIf(
         platform.isWindows(),
-        "StorageServer fails to create necessary directory for corruption advisories in Windows.",
+        "StorageServer fails to create necessary directory "
+        "for corruption advisories in Windows.",
     )
     @given(
         storage_index=storage_indexes(),
@@ -810,11 +810,11 @@ class ShareTests(TestCase):
         write_toy_shares(
             self.anonymous_storage_server,
             storage_index,
-            renew_secret,
-            cancel_secret,
             {sharenum},
             size,
             canary=self.canary,
+            renew_secret=renew_secret,
+            cancel_secret=cancel_secret,
         )
 
         self.assertThat(

--- a/src/_zkapauthorizer/tests/test_storage_protocol.py
+++ b/src/_zkapauthorizer/tests/test_storage_protocol.py
@@ -138,6 +138,7 @@ class RequiredPassesTests(TestCase):
     """
     Tests for ``required_passes``.
     """
+
     @given(integers(min_value=1), sets(integers(min_value=0)))
     def test_incorrect_types(self, bytes_per_pass, share_sizes):
         """
@@ -160,11 +161,7 @@ class RequiredPassesTests(TestCase):
         """
         actual = required_passes(
             bytes_per_pass,
-            list(
-                passes * bytes_per_pass
-                for passes
-                in expected_per_share
-            ),
+            list(passes * bytes_per_pass for passes in expected_per_share),
         )
         self.assertThat(
             actual,
@@ -191,13 +188,16 @@ class ShareTests(TestCase):
     :ivar pass_factory: An object which is responsible for creating passes
         which are used by these tests.
     """
+
     pass_value = 128 * 1024
 
     def setUp(self):
         super(ShareTests, self).setUp()
         self.canary = LocalReferenceable(None)
         self.signing_key = random_signing_key()
-        self.pass_factory = pass_factory(get_passes=privacypass_passes(self.signing_key))
+        self.pass_factory = pass_factory(
+            get_passes=privacypass_passes(self.signing_key)
+        )
 
         self.clock = Clock()
         self.anonymous_storage_server = self.useFixture(
@@ -246,7 +246,9 @@ class ShareTests(TestCase):
         size=sizes(),
         data=data_strategy(),
     )
-    def test_rejected_passes_reported(self, storage_index, renew_secret, cancel_secret, sharenums, size, data):
+    def test_rejected_passes_reported(
+        self, storage_index, renew_secret, cancel_secret, sharenums, size, data
+    ):
         """
         Any passes rejected by the storage server are reported with a
         ``MorePassesRequired`` exception sent to the client.
@@ -301,11 +303,7 @@ class ShareTests(TestCase):
             # it.
             self.local_remote_server.callRemote(
                 "allocate_buckets",
-                list(
-                    pass_.pass_text.encode("ascii")
-                    for pass_
-                    in all_passes
-                ),
+                list(pass_.pass_text.encode("ascii") for pass_ in all_passes),
                 storage_index,
                 renew_secret,
                 cancel_secret,
@@ -334,7 +332,9 @@ class ShareTests(TestCase):
         sharenums=sharenum_sets(),
         size=sizes(),
     )
-    def test_create_immutable(self, storage_index, renew_secret, cancel_secret, sharenums, size):
+    def test_create_immutable(
+        self, storage_index, renew_secret, cancel_secret, sharenums, size
+    ):
         """
         Immutable share data created using *allocate_buckets* and methods of the
         resulting buckets can be read back using *get_buckets* and methods of
@@ -399,13 +399,11 @@ class ShareTests(TestCase):
             MatchesStructure(
                 issued=HasLength(anticipated_passes),
                 spent=HasLength(anticipated_passes),
-
                 returned=HasLength(0),
                 in_use=HasLength(0),
                 invalid=HasLength(0),
             ),
         )
-
 
     @given(
         storage_index=storage_indexes(),
@@ -416,13 +414,13 @@ class ShareTests(TestCase):
         size=sizes(),
     )
     def test_shares_already_exist(
-            self,
-            storage_index,
-            renew_secret,
-            cancel_secret,
-            existing_sharenums,
-            additional_sharenums,
-            size,
+        self,
+        storage_index,
+        renew_secret,
+        cancel_secret,
+        existing_sharenums,
+        additional_sharenums,
+        size,
     ):
         """
         When the remote *allocate_buckets* implementation reports that shares
@@ -493,7 +491,6 @@ class ShareTests(TestCase):
                 issued=HasLength(anticipated_passes),
                 spent=HasLength(expected_spent_passes),
                 returned=HasLength(expected_returned_passes),
-
                 in_use=HasLength(0),
                 invalid=HasLength(0),
             ),
@@ -506,7 +503,9 @@ class ShareTests(TestCase):
         sharenums=sharenum_sets(),
         size=sizes(),
     )
-    def test_add_lease(self, storage_index, renew_secrets, cancel_secret, sharenums, size):
+    def test_add_lease(
+        self, storage_index, renew_secrets, cancel_secret, sharenums, size
+    ):
         """
         A lease can be added to an existing immutable share.
         """
@@ -541,7 +540,9 @@ class ShareTests(TestCase):
         leases = list(self.anonymous_storage_server.get_leases(storage_index))
         self.assertThat(leases, HasLength(2))
 
-    def _stat_shares_immutable_test(self, storage_index, sharenum, size, when, leases, write_shares):
+    def _stat_shares_immutable_test(
+        self, storage_index, sharenum, size, when, leases, write_shares
+    ):
         # Hypothesis causes our storage server to be used many times.  Clean
         # up between iterations.
         cleanup_storage_server(self.anonymous_storage_server)
@@ -579,12 +580,14 @@ class ShareTests(TestCase):
         finally:
             patch.cleanUp()
 
-        expected = [{
-            sharenum: ShareStat(
-                size=size,
-                lease_expiration=int(self.clock.seconds() + LEASE_INTERVAL),
-            ),
-        }]
+        expected = [
+            {
+                sharenum: ShareStat(
+                    size=size,
+                    lease_expiration=int(self.clock.seconds() + LEASE_INTERVAL),
+                ),
+            }
+        ]
         self.assertThat(
             self.client.stat_shares([storage_index]),
             succeeded(Equals(expected)),
@@ -599,7 +602,9 @@ class ShareTests(TestCase):
         when=posix_timestamps(),
         leases=lists(lease_renew_secrets(), unique=True),
     )
-    def test_stat_shares_immutable(self, storage_index, renew_secret, cancel_secret, sharenum, size, when, leases):
+    def test_stat_shares_immutable(
+        self, storage_index, renew_secret, cancel_secret, sharenum, size, when, leases
+    ):
         """
         Size and lease information about immutable shares can be retrieved from a
         storage server.
@@ -629,7 +634,9 @@ class ShareTests(TestCase):
         leases=lists(lease_renew_secrets(), unique=True, min_size=1),
         version=share_versions(),
     )
-    def test_stat_shares_immutable_wrong_version(self, storage_index, sharenum, size, when, leases, version):
+    def test_stat_shares_immutable_wrong_version(
+        self, storage_index, sharenum, size, when, leases, version
+    ):
         """
         If a share file with an unexpected version is found, ``stat_shares``
         declines to offer a result (by raising ``ValueError``).
@@ -674,7 +681,9 @@ class ShareTests(TestCase):
         # Encode our knowledge of the share header format and size right here...
         position=integers(min_value=0, max_value=11),
     )
-    def test_stat_shares_truncated_file(self, storage_index, sharenum, size, when, version, position):
+    def test_stat_shares_truncated_file(
+        self, storage_index, sharenum, size, when, version, position
+    ):
         """
         If a share file is truncated in the middle of the header,
         ``stat_shares`` declines to offer a result (by raising
@@ -713,8 +722,10 @@ class ShareTests(TestCase):
             ),
         )
 
-
-    @skipIf(platform.isWindows(), "Creating large files on Windows (no sparse files) is too slow")
+    @skipIf(
+        platform.isWindows(),
+        "Creating large files on Windows (no sparse files) is too slow",
+    )
     @given(
         storage_index=storage_indexes(),
         sharenum=sharenums(),
@@ -722,7 +733,9 @@ class ShareTests(TestCase):
         when=posix_timestamps(),
         leases=lists(lease_renew_secrets(), unique=True, min_size=1),
     )
-    def test_stat_shares_immutable_large(self, storage_index, sharenum, size, when, leases):
+    def test_stat_shares_immutable_large(
+        self, storage_index, sharenum, size, when, leases
+    ):
         """
         Size and lease information about very large immutable shares can be
         retrieved from a storage server.
@@ -731,6 +744,7 @@ class ShareTests(TestCase):
         share placement and layout.  This is necessary to avoid having to
         write real multi-gigabyte files to exercise the behavior.
         """
+
         def write_shares(storage_server, storage_index, sharenums, size, canary):
             sharedir = FilePath(storage_server.sharedir).preauthChild(
                 # storage_index_to_dir likes to return multiple segments
@@ -768,7 +782,9 @@ class ShareTests(TestCase):
         test_and_write_vectors_for_shares=slot_test_and_write_vectors_for_shares(),
         when=posix_timestamps(),
     )
-    def test_stat_shares_mutable(self, storage_index, secrets, test_and_write_vectors_for_shares, when):
+    def test_stat_shares_mutable(
+        self, storage_index, secrets, test_and_write_vectors_for_shares, when
+    ):
         """
         Size and lease information about mutable shares can be retrieved from a
         storage server.
@@ -789,8 +805,7 @@ class ShareTests(TestCase):
                     secrets=secrets,
                     tw_vectors={
                         k: v.for_call()
-                        for (k, v)
-                        in test_and_write_vectors_for_shares.items()
+                        for (k, v) in test_and_write_vectors_for_shares.items()
                     },
                     r_vector=[],
                 ),
@@ -803,22 +818,22 @@ class ShareTests(TestCase):
             u"Server rejected a write to a new mutable slot",
         )
 
-        expected = [{
-            sharenum: ShareStat(
-                size=get_implied_data_length(
-                    vectors.write_vector,
-                    vectors.new_length,
-                ),
-                lease_expiration=int(self.clock.seconds() + LEASE_INTERVAL),
-            )
-            for (sharenum, vectors)
-            in test_and_write_vectors_for_shares.items()
-        }]
+        expected = [
+            {
+                sharenum: ShareStat(
+                    size=get_implied_data_length(
+                        vectors.write_vector,
+                        vectors.new_length,
+                    ),
+                    lease_expiration=int(self.clock.seconds() + LEASE_INTERVAL),
+                )
+                for (sharenum, vectors) in test_and_write_vectors_for_shares.items()
+            }
+        ]
         self.assertThat(
             self.client.stat_shares([storage_index]),
             succeeded(Equals(expected)),
         )
-
 
     @skipIf(
         platform.isWindows(),
@@ -831,7 +846,9 @@ class ShareTests(TestCase):
         sharenum=sharenums(),
         size=sizes(),
     )
-    def test_advise_corrupt_share(self, storage_index, renew_secret, cancel_secret, sharenum, size):
+    def test_advise_corrupt_share(
+        self, storage_index, renew_secret, cancel_secret, sharenum, size
+    ):
         """
         An advisory of corruption in a share can be sent to the server.
         """
@@ -873,7 +890,9 @@ class ShareTests(TestCase):
         ),
         test_and_write_vectors_for_shares=slot_test_and_write_vectors_for_shares(),
     )
-    def test_create_mutable(self, storage_index, secrets, test_and_write_vectors_for_shares):
+    def test_create_mutable(
+        self, storage_index, secrets, test_and_write_vectors_for_shares
+    ):
         """
         Mutable share data written using *slot_testv_and_readv_and_writev* can be
         read back as-written and without spending any more passes.
@@ -888,8 +907,7 @@ class ShareTests(TestCase):
                 secrets=secrets,
                 tw_vectors={
                     k: v.for_call()
-                    for (k, v)
-                    in test_and_write_vectors_for_shares.items()
+                    for (k, v) in test_and_write_vectors_for_shares.items()
                 },
                 r_vector=[],
             ),
@@ -906,7 +924,9 @@ class ShareTests(TestCase):
         )
         # Now we can read it back without spending any more passes.
         before_passes = len(self.pass_factory.issued)
-        assert_read_back_data(self, storage_index, secrets, test_and_write_vectors_for_shares)
+        assert_read_back_data(
+            self, storage_index, secrets, test_and_write_vectors_for_shares
+        )
         after_passes = len(self.pass_factory.issued)
         self.assertThat(
             before_passes,
@@ -922,7 +942,9 @@ class ShareTests(TestCase):
         ),
         test_and_write_vectors_for_shares=slot_test_and_write_vectors_for_shares(),
     )
-    def test_mutable_rewrite_preserves_lease(self, storage_index, secrets, test_and_write_vectors_for_shares):
+    def test_mutable_rewrite_preserves_lease(
+        self, storage_index, secrets, test_and_write_vectors_for_shares
+    ):
         """
         When mutable share data is rewritten using
         *slot_testv_and_readv_and_writev* any leases on the corresponding slot
@@ -935,8 +957,9 @@ class ShareTests(TestCase):
         def leases():
             return list(
                 lease.to_mutable_data()
-                for lease
-                in self.anonymous_storage_server.get_slot_leases(storage_index)
+                for lease in self.anonymous_storage_server.get_slot_leases(
+                    storage_index
+                )
             )
 
         def write():
@@ -945,8 +968,7 @@ class ShareTests(TestCase):
                 secrets=secrets,
                 tw_vectors={
                     k: v.for_call()
-                    for (k, v)
-                    in test_and_write_vectors_for_shares.items()
+                    for (k, v) in test_and_write_vectors_for_shares.items()
                 },
                 r_vector=[],
             )
@@ -985,15 +1007,15 @@ class ShareTests(TestCase):
         test_and_write_vectors_for_shares=slot_test_and_write_vectors_for_shares(),
     )
     def test_mutable_rewrite_renews_expired_lease(
-            self,
-            storage_index,
-            when,
-            sharenum,
-            size,
-            write_enabler,
-            renew_secret,
-            cancel_secret,
-            test_and_write_vectors_for_shares,
+        self,
+        storage_index,
+        when,
+        sharenum,
+        size,
+        write_enabler,
+        renew_secret,
+        cancel_secret,
+        test_and_write_vectors_for_shares,
     ):
         """
         When mutable share data with an expired lease is rewritten using
@@ -1013,8 +1035,7 @@ class ShareTests(TestCase):
                 secrets=secrets,
                 tw_vectors={
                     k: v.for_call()
-                    for (k, v)
-                    in test_and_write_vectors_for_shares.items()
+                    for (k, v) in test_and_write_vectors_for_shares.items()
                 },
                 r_vector=[],
             )
@@ -1038,17 +1059,23 @@ class ShareTests(TestCase):
         # marked as expiring one additional lease period into the future.
         self.assertThat(
             self.server.remote_stat_shares([storage_index]),
-            Equals([{
-                num: ShareStat(
-                    size=get_implied_data_length(
-                        test_and_write_vectors_for_shares[num].write_vector,
-                        test_and_write_vectors_for_shares[num].new_length,
-                    ),
-                    lease_expiration=int(self.clock.seconds() + self.server.LEASE_PERIOD.total_seconds()),
-                )
-                for num
-                in test_and_write_vectors_for_shares
-            }]),
+            Equals(
+                [
+                    {
+                        num: ShareStat(
+                            size=get_implied_data_length(
+                                test_and_write_vectors_for_shares[num].write_vector,
+                                test_and_write_vectors_for_shares[num].new_length,
+                            ),
+                            lease_expiration=int(
+                                self.clock.seconds()
+                                + self.server.LEASE_PERIOD.total_seconds()
+                            ),
+                        )
+                        for num in test_and_write_vectors_for_shares
+                    }
+                ]
+            ),
         )
 
     @given(
@@ -1060,7 +1087,9 @@ class ShareTests(TestCase):
         ),
         test_and_write_vectors_for_shares=slot_test_and_write_vectors_for_shares(),
     )
-    def test_client_cannot_control_lease_behavior(self, storage_index, secrets, test_and_write_vectors_for_shares):
+    def test_client_cannot_control_lease_behavior(
+        self, storage_index, secrets, test_and_write_vectors_for_shares
+    ):
         """
         If the client passes ``renew_leases`` to *slot_testv_and_readv_and_writev*
         it fails with ``TypeError``, no lease is updated, and no share data is
@@ -1087,11 +1116,7 @@ class ShareTests(TestCase):
             # secrets
             secrets,
             # tw_vectors
-            {
-                k: v.for_call()
-                for (k, v)
-                in test_and_write_vectors_for_shares.items()
-            },
+            {k: v.for_call() for (k, v) in test_and_write_vectors_for_shares.items()},
             # r_vector
             [],
             # add_leases
@@ -1116,8 +1141,7 @@ class ShareTests(TestCase):
             shares=None,
             r_vector=list(
                 list(map(write_vector_to_read_vector, vector.write_vector))
-                for vector
-                in test_and_write_vectors_for_shares.values()
+                for vector in test_and_write_vectors_for_shares.values()
             ),
         )
         self.expectThat(
@@ -1134,7 +1158,9 @@ class ShareTests(TestCase):
         )
 
 
-def assert_read_back_data(self, storage_index, secrets, test_and_write_vectors_for_shares):
+def assert_read_back_data(
+    self, storage_index, secrets, test_and_write_vectors_for_shares
+):
     """
     Assert that the data written by ``test_and_write_vectors_for_shares`` can
     be read back from ``storage_index``.
@@ -1150,22 +1176,17 @@ def assert_read_back_data(self, storage_index, secrets, test_and_write_vectors_f
     # Create a buffer and pile up all the write operations in it.
     # This lets us make correct assertions about overlapping writes.
     for sharenum, vectors in test_and_write_vectors_for_shares.items():
-        length = max(
-            offset + len(data)
-            for (offset, data)
-            in vectors.write_vector
-        )
+        length = max(offset + len(data) for (offset, data) in vectors.write_vector)
         expected = b"\x00" * length
         for (offset, data) in vectors.write_vector:
-            expected = expected[:offset] + data + expected[offset + len(data):]
+            expected = expected[:offset] + data + expected[offset + len(data) :]
         if vectors.new_length is not None and vectors.new_length < length:
-            expected = expected[:vectors.new_length]
+            expected = expected[: vectors.new_length]
 
         expected_result = list(
             # Get the expected value out of our scratch buffer.
-            expected[offset:offset + len(data)]
-            for (offset, data)
-            in vectors.write_vector
+            expected[offset : offset + len(data)]
+            for (offset, data) in vectors.write_vector
         )
 
         _, single_read = extract_result(

--- a/src/_zkapauthorizer/tests/test_storage_protocol.py
+++ b/src/_zkapauthorizer/tests/test_storage_protocol.py
@@ -16,121 +16,71 @@
 Tests for communication between the client and server components.
 """
 
-from __future__ import (
-    absolute_import,
-)
+from __future__ import absolute_import
 
-from fixtures import (
-    MonkeyPatch,
-)
-from testtools import (
-    TestCase,
-)
+from allmydata.storage.common import storage_index_to_dir
+from challenge_bypass_ristretto import random_signing_key
+from fixtures import MonkeyPatch
+from foolscap.referenceable import LocalReferenceable
+from hypothesis import assume, given
+from hypothesis.strategies import data as data_strategy
+from hypothesis.strategies import integers, lists, sets, tuples
+from testtools import TestCase
 from testtools.matchers import (
+    AfterPreprocessing,
     Always,
     Equals,
     HasLength,
     IsInstance,
-    AfterPreprocessing,
     MatchesStructure,
     raises,
 )
-from testtools.twistedsupport import (
-    succeeded,
-    failed,
-)
-from testtools.twistedsupport._deferred import (
-    # I'd rather use https://twistedmatrix.com/trac/ticket/8900 but efforts
-    # there appear to have stalled.
+from testtools.twistedsupport import failed, succeeded
+from testtools.twistedsupport._deferred import (  # I'd rather use https://twistedmatrix.com/trac/ticket/8900 but efforts; there appear to have stalled.
     extract_result,
 )
+from twisted.internet.task import Clock
+from twisted.python.filepath import FilePath
+from twisted.python.runtime import platform
 
-from hypothesis import (
-    given,
-    assume,
-)
-from hypothesis.strategies import (
-    sets,
-    lists,
-    tuples,
-    integers,
-    data as data_strategy,
-)
-
-from twisted.python.runtime import (
-    platform,
-)
-from twisted.python.filepath import (
-    FilePath,
-)
-from twisted.internet.task import (
-    Clock,
-)
-
-from foolscap.referenceable import (
-    LocalReferenceable,
-)
-
-from challenge_bypass_ristretto import (
-    random_signing_key,
-)
-
-from allmydata.storage.common import (
-    storage_index_to_dir,
-)
-
-from .common import (
-    skipIf,
-)
-
-from .strategies import (
-    storage_indexes,
-    lease_renew_secrets,
-    lease_cancel_secrets,
-    write_enabler_secrets,
-    share_versions,
-    sharenums,
-    sharenum_sets,
-    sizes,
-    slot_test_and_write_vectors_for_shares,
-    posix_timestamps,
-    # Not really a strategy...
-    bytes_for_share,
-)
-from .matchers import (
-    matches_version_dictionary,
-)
-from .fixtures import (
-    AnonymousStorageServer,
-)
-from .storage_common import (
-    LEASE_INTERVAL,
-    cleanup_storage_server,
-    write_toy_shares,
-    whitebox_write_sparse_share,
-    get_passes,
-    privacypass_passes,
-    pass_factory,
-)
-from .foolscap import (
-    LocalRemote,
-)
+from .._storage_client import _encode_passes
 from ..api import (
     MorePassesRequired,
-    ZKAPAuthorizerStorageServer,
     ZKAPAuthorizerStorageClient,
+    ZKAPAuthorizerStorageServer,
 )
+from ..foolscap import ShareStat
 from ..storage_common import (
-    slot_testv_and_readv_and_writev_message,
     allocate_buckets_message,
     get_implied_data_length,
     required_passes,
+    slot_testv_and_readv_and_writev_message,
 )
-from .._storage_client import (
-    _encode_passes,
+from .common import skipIf
+from .fixtures import AnonymousStorageServer
+from .foolscap import LocalRemote
+from .matchers import matches_version_dictionary
+from .storage_common import (
+    LEASE_INTERVAL,
+    cleanup_storage_server,
+    get_passes,
+    pass_factory,
+    privacypass_passes,
+    whitebox_write_sparse_share,
+    write_toy_shares,
 )
-from ..foolscap import (
-    ShareStat,
+from .strategies import (  # Not really a strategy...
+    bytes_for_share,
+    lease_cancel_secrets,
+    lease_renew_secrets,
+    posix_timestamps,
+    share_versions,
+    sharenum_sets,
+    sharenums,
+    sizes,
+    slot_test_and_write_vectors_for_shares,
+    storage_indexes,
+    write_enabler_secrets,
 )
 
 

--- a/src/_zkapauthorizer/tests/test_storage_server.py
+++ b/src/_zkapauthorizer/tests/test_storage_server.py
@@ -111,6 +111,7 @@ class ValidationResultTests(TestCase):
     """
     Tests for ``_ValidationResult``.
     """
+
     def setUp(self):
         super(ValidationResultTests, self).setUp()
         self.signing_key = random_signing_key()
@@ -128,9 +129,7 @@ class ValidationResultTests(TestCase):
             list(RandomToken.create() for i in range(valid_count)),
         )
         all_passes = valid_passes + list(
-            pass_.pass_text.encode("ascii")
-            for pass_
-            in invalid_passes
+            pass_.pass_text.encode("ascii") for pass_ in invalid_passes
         )
         shuffle(all_passes)
 
@@ -144,14 +143,12 @@ class ValidationResultTests(TestCase):
                 _ValidationResult(
                     valid=list(
                         idx
-                        for (idx, pass_)
-                        in enumerate(all_passes)
+                        for (idx, pass_) in enumerate(all_passes)
                         if pass_ in valid_passes
                     ),
                     signature_check_failed=list(
                         idx
-                        for (idx, pass_)
-                        in enumerate(all_passes)
+                        for (idx, pass_) in enumerate(all_passes)
                         if pass_ not in valid_passes
                     ),
                 ),
@@ -183,7 +180,9 @@ class ValidationResultTests(TestCase):
                     ),
                     AfterPreprocessing(
                         str,
-                        Equals("MorePassesRequired(valid_count=4, required_count=10, signature_check_failed=frozenset([4]))"),
+                        Equals(
+                            "MorePassesRequired(valid_count=4, required_count=10, signature_check_failed=frozenset([4]))"
+                        ),
                     ),
                 ),
             )
@@ -193,6 +192,7 @@ class PassValidationTests(TestCase):
     """
     Tests for pass validation performed by ``ZKAPAuthorizerStorageServer``.
     """
+
     pass_value = 128 * 1024
 
     @skipIf(platform.isWindows(), "Storage server is not supported on Windows")
@@ -238,13 +238,14 @@ class PassValidationTests(TestCase):
 
         allocate_buckets = lambda: self.storage_server.doRemoteCall(
             "allocate_buckets",
-            (valid_passes,
-             storage_index,
-             renew_secret,
-             cancel_secret,
-             share_nums,
-             allocated_size,
-             LocalReferenceable(None),
+            (
+                valid_passes,
+                storage_index,
+                renew_secret,
+                cancel_secret,
+                share_nums,
+                allocated_size,
+                LocalReferenceable(None),
             ),
             {},
         )
@@ -252,7 +253,6 @@ class PassValidationTests(TestCase):
             allocate_buckets,
             raises(MorePassesRequired),
         )
-
 
     @given(
         storage_index=storage_indexes(),
@@ -305,13 +305,12 @@ class PassValidationTests(TestCase):
         else:
             self.fail("expected MorePassesRequired, got {}".format(result))
 
-
     def _test_extend_mutable_fails_without_passes(
-            self,
-            storage_index,
-            secrets,
-            test_and_write_vectors_for_shares,
-            make_data_vector,
+        self,
+        storage_index,
+        secrets,
+        test_and_write_vectors_for_shares,
+        make_data_vector,
     ):
         """
         Verify that increasing the storage requirements of a slot without
@@ -327,9 +326,7 @@ class PassValidationTests(TestCase):
         cleanup_storage_server(self.anonymous_storage_server)
 
         tw_vectors = {
-            k: v.for_call()
-            for (k, v)
-            in test_and_write_vectors_for_shares.items()
+            k: v.for_call() for (k, v) in test_and_write_vectors_for_shares.items()
         }
 
         note("tw_vectors summarized: {}".format(summarize(tw_vectors)))
@@ -344,11 +341,7 @@ class PassValidationTests(TestCase):
         valid_passes = make_passes(
             self.signing_key,
             slot_testv_and_readv_and_writev_message(storage_index),
-            list(
-                RandomToken.create()
-                for i
-                in range(required_pass_count)
-            ),
+            list(RandomToken.create() for i in range(required_pass_count)),
         )
 
         # Create an initial share to toy with.
@@ -417,7 +410,9 @@ class PassValidationTests(TestCase):
         ),
         test_and_write_vectors_for_shares=slot_test_and_write_vectors_for_shares(),
     )
-    def test_extend_mutable_with_write_fails_without_passes(self, storage_index, secrets, test_and_write_vectors_for_shares):
+    def test_extend_mutable_with_write_fails_without_passes(
+        self, storage_index, secrets, test_and_write_vectors_for_shares
+    ):
         """
         If ``remote_slot_testv_and_readv_and_writev`` is invoked to increase
         storage usage by performing a write past the end of a share without
@@ -435,13 +430,13 @@ class PassValidationTests(TestCase):
         )
 
     def _test_lease_operation_fails_without_passes(
-            self,
-            storage_index,
-            secrets,
-            sharenums,
-            allocated_size,
-            lease_operation,
-            lease_operation_message,
+        self,
+        storage_index,
+        secrets,
+        sharenums,
+        allocated_size,
+        lease_operation,
+        lease_operation_message,
     ):
         """
         Assert that a lease-taking operation fails if it is not supplied with
@@ -461,7 +456,9 @@ class PassValidationTests(TestCase):
 
         renew_secret, cancel_secret = secrets
 
-        required_count = required_passes(self.pass_value, [allocated_size] * len(sharenums))
+        required_count = required_passes(
+            self.pass_value, [allocated_size] * len(sharenums)
+        )
         # Create some shares at a slot which will require lease renewal.
         write_toy_shares(
             self.anonymous_storage_server,
@@ -514,16 +511,20 @@ class PassValidationTests(TestCase):
         sharenums=sharenum_sets(),
         allocated_size=sizes(),
     )
-    def test_add_lease_fails_without_passes(self, storage_index, secrets, sharenums, allocated_size):
+    def test_add_lease_fails_without_passes(
+        self, storage_index, secrets, sharenums, allocated_size
+    ):
         """
         If ``remote_add_lease`` is invoked without supplying enough passes to
         cover the storage for all shares on the given storage index, the
         operation fails with ``MorePassesRequired``.
         """
         renew_secret, cancel_secret = secrets
+
         def add_lease(storage_server, passes):
             return storage_server.doRemoteCall(
-                "add_lease", (
+                "add_lease",
+                (
                     passes,
                     storage_index,
                     renew_secret,
@@ -531,6 +532,7 @@ class PassValidationTests(TestCase):
                 ),
                 {},
             )
+
         return self._test_lease_operation_fails_without_passes(
             storage_index,
             secrets,
@@ -550,7 +552,9 @@ class PassValidationTests(TestCase):
         sharenums=one_of(just(None), sharenum_sets()),
         test_and_write_vectors_for_shares=slot_test_and_write_vectors_for_shares(),
     )
-    def test_mutable_share_sizes(self, slot, secrets, sharenums, test_and_write_vectors_for_shares):
+    def test_mutable_share_sizes(
+        self, slot, secrets, sharenums, test_and_write_vectors_for_shares
+    ):
         """
         ``share_sizes`` returns the size of the requested mutable shares in the
         requested slot.
@@ -560,9 +564,7 @@ class PassValidationTests(TestCase):
         cleanup_storage_server(self.anonymous_storage_server)
 
         tw_vectors = {
-            k: v.for_call()
-            for (k, v)
-            in test_and_write_vectors_for_shares.items()
+            k: v.for_call() for (k, v) in test_and_write_vectors_for_shares.items()
         }
 
         # Create an initial share to toy with.
@@ -574,11 +576,7 @@ class PassValidationTests(TestCase):
         valid_passes = make_passes(
             self.signing_key,
             slot_testv_and_readv_and_writev_message(slot),
-            list(
-                RandomToken.create()
-                for i
-                in range(required_pass_count)
-            ),
+            list(RandomToken.create() for i in range(required_pass_count)),
         )
         test, read = self.storage_server.doRemoteCall(
             "slot_testv_and_readv_and_writev",
@@ -599,13 +597,13 @@ class PassValidationTests(TestCase):
 
         expected_sizes = {
             sharenum: get_implied_data_length(data_vector, new_length)
-            for (sharenum, (testv, data_vector, new_length))
-            in tw_vectors.items()
+            for (sharenum, (testv, data_vector, new_length)) in tw_vectors.items()
             if sharenums is None or sharenum in sharenums
         }
 
         actual_sizes = self.storage_server.doRemoteCall(
-            "share_sizes", (
+            "share_sizes",
+            (
                 slot,
                 sharenums,
             ),

--- a/src/_zkapauthorizer/tests/test_storage_server.py
+++ b/src/_zkapauthorizer/tests/test_storage_server.py
@@ -132,7 +132,7 @@ class ValidationResultTests(TestCase):
                     AfterPreprocessing(
                         str,
                         Equals(
-                            "MorePassesRequired(valid_count=4, required_count=10, signature_check_failed=frozenset([4]))"
+                            "MorePassesRequired(valid_count=4, required_count=10, signature_check_failed=frozenset([4]))"  # noqa: 501
                         ),
                     ),
                 ),
@@ -414,11 +414,11 @@ class PassValidationTests(TestCase):
         write_toy_shares(
             self.anonymous_storage_server,
             storage_index,
-            renew_secret,
-            cancel_secret,
             sharenums,
             allocated_size,
             LocalReferenceable(None),
+            renew_secret,
+            cancel_secret,
         )
 
         # Advance time to a point where the lease is expired.  This simplifies

--- a/src/_zkapauthorizer/tests/test_storage_server.py
+++ b/src/_zkapauthorizer/tests/test_storage_server.py
@@ -16,94 +16,45 @@
 Tests for ``_zkapauthorizer._storage_server``.
 """
 
-from __future__ import (
-    absolute_import,
-    division,
-)
+from __future__ import absolute_import, division
 
-from time import (
-    time,
-)
-from random import (
-    shuffle,
-)
+from random import shuffle
+from time import time
 
-from testtools import (
-    TestCase,
-)
-from testtools.matchers import (
-    Equals,
-    AfterPreprocessing,
-    MatchesAll,
-)
-from hypothesis import (
-    given,
-    note,
-)
-from hypothesis.strategies import (
-    integers,
-    lists,
-    tuples,
-    one_of,
-    just,
-)
-from challenge_bypass_ristretto import (
-    RandomToken,
-    random_signing_key,
-)
+from challenge_bypass_ristretto import RandomToken, random_signing_key
+from foolscap.referenceable import LocalReferenceable
+from hypothesis import given, note
+from hypothesis.strategies import integers, just, lists, one_of, tuples
+from testtools import TestCase
+from testtools.matchers import AfterPreprocessing, Equals, MatchesAll
+from twisted.internet.task import Clock
+from twisted.python.runtime import platform
 
-from twisted.python.runtime import (
-    platform,
-)
-from twisted.internet.task import (
-    Clock,
-)
-
-from foolscap.referenceable import (
-    LocalReferenceable,
-)
-
-from .common import (
-    skipIf,
-)
-from .privacypass import (
-    make_passes,
-)
-from .matchers import (
-    raises,
-)
-from .strategies import (
-    zkaps,
-    sizes,
-    sharenum_sets,
-    storage_indexes,
-    write_enabler_secrets,
-    lease_renew_secrets,
-    lease_cancel_secrets,
-    slot_test_and_write_vectors_for_shares,
-)
-from .fixtures import (
-    AnonymousStorageServer,
-)
-from .storage_common import (
-    cleanup_storage_server,
-    write_toy_shares,
-)
-from ..api import (
-    ZKAPAuthorizerStorageServer,
-    MorePassesRequired,
-)
+from .._storage_server import _ValidationResult
+from ..api import MorePassesRequired, ZKAPAuthorizerStorageServer
 from ..storage_common import (
-    required_passes,
-    allocate_buckets_message,
     add_lease_message,
-    slot_testv_and_readv_and_writev_message,
+    allocate_buckets_message,
     get_implied_data_length,
     get_required_new_passes_for_mutable_write,
+    required_passes,
+    slot_testv_and_readv_and_writev_message,
     summarize,
 )
-from .._storage_server import (
-    _ValidationResult,
+from .common import skipIf
+from .fixtures import AnonymousStorageServer
+from .matchers import raises
+from .privacypass import make_passes
+from .storage_common import cleanup_storage_server, write_toy_shares
+from .strategies import (
+    lease_cancel_secrets,
+    lease_renew_secrets,
+    sharenum_sets,
+    sizes,
+    slot_test_and_write_vectors_for_shares,
+    storage_indexes,
+    write_enabler_secrets,
+    zkaps,
 )
 
 

--- a/src/_zkapauthorizer/tests/test_strategies.py
+++ b/src/_zkapauthorizer/tests/test_strategies.py
@@ -47,10 +47,12 @@ from .strategies import (
     share_parameters,
 )
 
+
 class TahoeConfigsTests(TestCase):
     """
     Tests for ``tahoe_configs``.
     """
+
     @given(data())
     def test_parses(self, data):
         """

--- a/src/_zkapauthorizer/tests/test_strategies.py
+++ b/src/_zkapauthorizer/tests/test_strategies.py
@@ -16,36 +16,15 @@
 Tests for our custom Hypothesis strategies.
 """
 
-from __future__ import (
-    absolute_import,
-)
+from __future__ import absolute_import
 
-from testtools import (
-    TestCase,
-)
+from allmydata.client import config_from_string
+from fixtures import TempDir
+from hypothesis import given, note
+from hypothesis.strategies import data, just, one_of
+from testtools import TestCase
 
-from fixtures import (
-    TempDir,
-)
-
-from hypothesis import (
-    given,
-    note,
-)
-from hypothesis.strategies import (
-    data,
-    one_of,
-    just,
-)
-
-from allmydata.client import (
-    config_from_string,
-)
-
-from .strategies import (
-    tahoe_config_texts,
-    share_parameters,
-)
+from .strategies import share_parameters, tahoe_config_texts
 
 
 class TahoeConfigsTests(TestCase):

--- a/src/_zkapauthorizer/validators.py
+++ b/src/_zkapauthorizer/validators.py
@@ -16,9 +16,7 @@
 This module implements validators for ``attrs``-defined attributes.
 """
 
-from base64 import (
-    b64decode,
-)
+from base64 import b64decode
 
 
 def is_base64_encoded(b64decode=b64decode):

--- a/src/_zkapauthorizer/validators.py
+++ b/src/_zkapauthorizer/validators.py
@@ -20,6 +20,7 @@ from base64 import (
     b64decode,
 )
 
+
 def is_base64_encoded(b64decode=b64decode):
     def validate_is_base64_encoded(inst, attr, value):
         try:
@@ -31,7 +32,9 @@ def is_base64_encoded(b64decode=b64decode):
                     value=value,
                 ),
             )
+
     return validate_is_base64_encoded
+
 
 def has_length(expected):
     def validate_has_length(inst, attr, value):
@@ -43,7 +46,9 @@ def has_length(expected):
                     actual=len(value),
                 ),
             )
+
     return validate_has_length
+
 
 def greater_than(expected):
     def validate_relation(inst, attr, value):
@@ -57,4 +62,5 @@ def greater_than(expected):
                 actual=value,
             ),
         )
+
     return validate_relation

--- a/src/_zkapauthorizer/validators.py
+++ b/src/_zkapauthorizer/validators.py
@@ -38,7 +38,8 @@ def has_length(expected):
     def validate_has_length(inst, attr, value):
         if len(value) != expected:
             raise ValueError(
-                "{name!r} must have length {expected}, instead has length {actual}".format(
+                "{name!r} must have length {expected}, "
+                "instead has length {actual}".format(
                     name=attr.name,
                     expected=expected,
                     actual=len(value),

--- a/src/twisted/plugins/zkapauthorizer.py
+++ b/src/twisted/plugins/zkapauthorizer.py
@@ -16,8 +16,6 @@
 A drop-in to supply plugins to the Twisted plugin system.
 """
 
-from _zkapauthorizer.api import (
-    ZKAPAuthorizer,
-)
+from _zkapauthorizer.api import ZKAPAuthorizer
 
 storage_server = ZKAPAuthorizer()

--- a/tests.nix
+++ b/tests.nix
@@ -32,6 +32,14 @@ in
       packagesExtra = [ zkapauthorizer ];
       _.hypothesis.postUnpack = "";
     };
+
+    lint-python = mach-nix.mkPython {
+      python = "python39";
+      requirements = ''
+        isort
+        black
+      '';
+    };
   in
     pkgs.runCommand "zkapauthorizer-tests" {
       passthru = {
@@ -42,6 +50,8 @@ in
 
       pushd ${zkapauthorizer.src}
       ${python}/bin/pyflakes
+      ${lint-python}/bin/black --check src
+      ${lint-python}/bin/isort --check src
       popd
 
       ZKAPAUTHORIZER_HYPOTHESIS_PROFILE=${hypothesisProfile'} ${python}/bin/python -m ${if collectCoverage

--- a/tests.nix
+++ b/tests.nix
@@ -49,7 +49,7 @@ in
       mkdir -p $out
 
       pushd ${zkapauthorizer.src}
-      ${python}/bin/pyflakes
+      ${python}/bin/flake8 src
       ${lint-python}/bin/black --check src
       ${lint-python}/bin/isort --check src
       popd


### PR DESCRIPTION
Here are the issues that were reported by flake8, along with some comments on how I addressed them where appropriate.
- E402 module level import not at top of file
  This was cause by some code calling `registerAdapter` on `ZKAPAuthorizerStorageServer`. It looks like that was needed because the interfaces for it were defined by `implementer_only` which explicitly ignored interfaces defined by parent classes. Looking at the history, I assume the use of `implementer_only` was to avoid implementing `RIStorageServer` via `proxyForInterface`. Given that the later is no longer used, `implementer_only` is no longer necessary.

  Reading some documentation, I think an alternative to needing to having the `registerAdapter` would have been to use
  ```patch
  -@implementer_only(RIPrivacyPassAuthorizedStorageServer, IReferenceable, IRemotelyCallable)
  +@implementer_only(RIPrivacyPassAuthorizedStorageServer, implementedBy(Referenceable))
  ```

- E722 do not use bare 'except'
  These were replaced by `except Exception:`
- E302 expected 2 blank lines, found 1
- E501 line too long 
  These are the changes I'm least sure of. I did a variety of things for this
  - Most places, there were reasonable ways to wrap the code, which I did.
  - There was one place where black didn't like wrapping a line with a `lambda` with a bunch of parameters. Here I changed the order of agruments, and converted the lambda to use `partial` instead. 
  - There were three places where there wasn't a good place to wrap, which I annotated with `# noqa: E501`
- E731 do not assign a lambda expression, use a def
  - I disabled this error in `*/tests/*.py`.