### PR TITLE
Change implementer_only to implementer.

### DIFF
--- a/src/_zkapauthorizer/_storage_server.py
+++ b/src/_zkapauthorizer/_storage_server.py
@@ -38,11 +38,10 @@ from attr.validators import instance_of, provides
 from challenge_bypass_ristretto import SigningKey, TokenPreimage, VerificationSignature
 from eliot import start_action
 from foolscap.api import Referenceable
-from foolscap.ipb import IReferenceable, IRemotelyCallable
 from twisted.internet.defer import Deferred
 from twisted.internet.interfaces import IReactorTime
 from twisted.python.reflect import namedAny
-from zope.interface import implementer_only
+from zope.interface import implementer
 
 from .foolscap import RIPrivacyPassAuthorizedStorageServer, ShareStat
 from .storage_common import (
@@ -147,9 +146,7 @@ class LeaseRenewalRequired(Exception):
     """
 
 
-@implementer_only(
-    RIPrivacyPassAuthorizedStorageServer, IReferenceable, IRemotelyCallable
-)
+@implementer(RIPrivacyPassAuthorizedStorageServer)
 # It would be great to use `frozen=True` (value-based hashing) instead of
 # `cmp=False` (identity based hashing) but Referenceable wants to set some
 # attributes on self and it's hard to avoid that.
@@ -698,14 +695,3 @@ def get_stat(sharepath):
             return stat_slot
         else:
             return stat_bucket
-
-
-from foolscap.ipb import ISlicer
-from foolscap.referenceable import ReferenceableSlicer
-
-# I don't understand why this is required.
-# ZKAPAuthorizerStorageServer is-a Referenceable.  It seems like
-# the built in adapter should take care of this case.
-from twisted.python.components import registerAdapter
-
-registerAdapter(ReferenceableSlicer, ZKAPAuthorizerStorageServer, ISlicer)


### PR DESCRIPTION
This removes the need to call `registerAdapter` on
`ZKAPAuthorizerStorageServer`. It looks like that was needed because the
interfaces for it were defined by `implementer_only` which explicitly ignored
interfaces defined by parent classes. Looking at the history, I assume the use
of `implementer_only` was to avoid implementing `RIStorageServer` via
`proxyForInterface`. Given that the later is no longer used, `implementer_only`
is no longer necessary.

This is extracted from #243.

Fixes #9 