### PR TITLE
Update to a version of tahoe that includes openmetrics support.

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -42,15 +42,15 @@
         "url_template": "https://releases.nixos.org/nixos/21.05/nixos-21.05.3740.ce7a1190a0f/nixexprs.tar.xz"
     },
     "tahoe-lafs": {
-        "branch": "tahoe-lafs-1.16.0",
+        "branch": "master",
         "description": "The Tahoe-LAFS decentralized secure filesystem.",
         "homepage": "https://tahoe-lafs.org/",
         "owner": "tahoe-lafs",
         "repo": "tahoe-lafs",
-        "rev": "4bfb9d21700b8084d5fb2c697ceeb7088dd97c37",
-        "sha256": "1hcp9gq5hcw43xmg7n24xx580jrg0fd382pklv79r5lr4cicyx7g",
+        "rev": "0a072a98c80f0a9ae1913674b54696ebc992406a",
+        "sha256": "13mbvg371xd2zncy8l9zxl9xv5fjxfddgp8vlv854z260ss4535r",
         "type": "tarball",
-        "url": "https://github.com/tahoe-lafs/tahoe-lafs/archive/4bfb9d21700b8084d5fb2c697ceeb7088dd97c37.tar.gz",
+        "url": "https://github.com/tahoe-lafs/tahoe-lafs/archive/0a072a98c80f0a9ae1913674b54696ebc992406a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/src/_zkapauthorizer/_storage_client.py
+++ b/src/_zkapauthorizer/_storage_client.py
@@ -424,6 +424,23 @@ class ZKAPAuthorizerStorageClient(object):
         # Read operations are free.
         num_passes = 0
 
+        # Convert tw_vectors from the new internal format to the wire format.
+        # See https://github.com/tahoe-lafs/tahoe-lafs/pull/1127/files#r716939082
+        tw_vectors = {
+            sharenum: (
+                [
+                    (offset, length, "eq", specimen)
+                    for (offset, length, specimen) in test_vector
+                ],
+                data_vectors,
+                new_length,
+            )
+            for (
+                sharenum,
+                (test_vector, data_vectors, new_length),
+            ) in tw_vectors.items()
+        }
+
         if has_writes(tw_vectors):
             # When performing writes, if we're increasing the storage
             # requirement, we need to spend more passes.  Unfortunately we


### PR DESCRIPTION
Fixes https://whetstone.privatestorage.io/privatestorage/PrivateStorageio/-/issues/90.

It turns out that the upstream change was only on the client side, so this changes the value as soon as we receive it on the client side.