### PR TITLE
Make generating cross-plaform pins easier.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,13 @@ install_requires =
     treq
     pyutil
     prometheus-client
+    # Include colorama as a dependency to help pip-compile deal with multiple
+    # platforms.  In particular, tqdm depends on colorama only on Windows. By
+    # including it here, pip-compile will generate hashes (and install it) on
+    # all platforms. colorama and pywin32 are our only depdencies that are only
+    # required on some platforms; we can't include pywin32 here as it does not
+    # install cross-platform.
+    colorama
 
 [options.extras_require]
 test = coverage; fixtures; testtools; hypothesis


### PR DESCRIPTION
This add colorama as a direct dependency. Currently, it a transitive dependency only on windows. When using `pip-compile` (from pip-tools), to pin dependencies, it only supports generating dependencies for the current platform. However, there are only two dependencies that vary between platforms, colorama and pywin32. pywin32 can't be installed on non-windows platform and has dropped python 2 support, so is relatively easy to pin. colorama is cross-platform, so including it here is a tiny bit wasteful, but makes pinning it trivial.

This is part of implementing https://whetstone.privatestorage.io/privatestorage/privatestoragedesktop/-/issues/603 for gridsync (see https://github.com/gridsync/gridsync/pull/400).