### PR TITLE
Fix pyflakes invocation in nix.

### DIFF
--- a/src/_zkapauthorizer/_storage_server.py
+++ b/src/_zkapauthorizer/_storage_server.py
@@ -31,11 +31,10 @@ from os.path import join
 from struct import calcsize, unpack
 
 import attr
-from allmydata.interfaces import RIStorageServer
+from allmydata.interfaces import RIStorageServer, TestAndWriteVectorsForShares
 from allmydata.storage.common import storage_index_to_dir
-from allmydata.storage.immutable import ShareFile
 from allmydata.storage.lease import LeaseInfo
-from allmydata.storage.mutable import MutableShareFile
+from allmydata.storage.server import StorageServer
 from allmydata.storage.shares import get_share_file
 from allmydata.util.base32 import b2a
 from attr.validators import instance_of, provides
@@ -59,6 +58,11 @@ from .storage_common import (
     required_passes,
     slot_testv_and_readv_and_writev_message,
 )
+
+try:
+    from typing import Dict, List, Optional
+except ImportError:
+    pass
 
 # See allmydata/storage/mutable.py
 SLOT_HEADER_SIZE = 468
@@ -755,7 +759,7 @@ def share_has_active_leases(storage_server, storage_index, sharenum, now):
 
 
 def get_writev_price(storage_server, pass_value, storage_index, tw_vectors, now):
-    # type: (StorageServer, int, bytes, TestWriteVectors, float) -> int
+    # type: (StorageServer, int, bytes, TestAndWriteVectorsForShares, float) -> int
     """
     Determine the price to execute the given test/write vectors.
     """

--- a/src/_zkapauthorizer/lease_maintenance.py
+++ b/src/_zkapauthorizer/lease_maintenance.py
@@ -36,7 +36,13 @@ from twisted.python.log import err
 from zope.interface import implementer
 
 from .controller import bracket
+from .foolscap import ShareStat
 from .model import ILeaseMaintenanceObserver
+
+try:
+    from typing import Iterable
+except ImportError:
+    pass
 
 SERVICE_NAME = u"lease maintenance service"
 

--- a/src/_zkapauthorizer/tests/test_lease_maintenance.py
+++ b/src/_zkapauthorizer/tests/test_lease_maintenance.py
@@ -37,7 +37,6 @@ from hypothesis.strategies import (
     lists,
     randoms,
     sets,
-    tuples,
 )
 from testtools import TestCase
 from testtools.matchers import (
@@ -51,7 +50,7 @@ from testtools.matchers import (
 )
 from testtools.twistedsupport import succeeded
 from twisted.application.service import IService
-from twisted.internet.defer import maybeDeferred, succeed
+from twisted.internet.defer import Deferred, maybeDeferred, succeed
 from twisted.internet.task import Clock
 from twisted.python.filepath import FilePath
 from zope.interface import implementer
@@ -73,6 +72,11 @@ from .strategies import (
     sharenums,
     storage_indexes,
 )
+
+try:
+    from typing import Dict, List
+except ImportError:
+    pass
 
 
 def interval_means():
@@ -460,7 +464,6 @@ def lists_of_buckets():
             min_size=count,
             max_size=count,
         )
-        expiration_strategy = lists
         return builds(
             zip,
             si_strategy,

--- a/src/_zkapauthorizer/tests/test_storage_protocol.py
+++ b/src/_zkapauthorizer/tests/test_storage_protocol.py
@@ -46,7 +46,6 @@ from twisted.internet.task import Clock
 from twisted.python.filepath import FilePath
 from twisted.python.runtime import platform
 
-from .._storage_client import _encode_passes
 from ..api import (
     MorePassesRequired,
     ZKAPAuthorizerStorageClient,
@@ -57,7 +56,6 @@ from ..storage_common import (
     allocate_buckets_message,
     get_implied_data_length,
     required_passes,
-    slot_testv_and_readv_and_writev_message,
 )
 from .common import skipIf
 from .fixtures import AnonymousStorageServer

--- a/tests.nix
+++ b/tests.nix
@@ -49,7 +49,7 @@ in
       mkdir -p $out
 
       pushd ${zkapauthorizer.src}
-      ${python}/bin/pyflakes
+      ${python}/bin/pyflakes src
       ${lint-python}/bin/black --check src
       ${lint-python}/bin/isort --check src
       popd


### PR DESCRIPTION
It turns our that `pyflakes` with no arguments expects input
on stdin. In CI, this is likely connected to `/dev/null` so it
passes.

Also fix the errors that pyflakes is reporting.