### PR TITLE
Replace the direct usages of `make_passes` with `get_passes`.

### DIFF
--- a/src/_zkapauthorizer/tests/privacypass.py
+++ b/src/_zkapauthorizer/tests/privacypass.py
@@ -20,6 +20,8 @@ from __future__ import absolute_import
 
 from challenge_bypass_ristretto import BatchDLEQProof, PublicKey
 
+from ..model import Pass
+
 
 def make_passes(signing_key, for_message, random_tokens):
     """
@@ -64,11 +66,9 @@ def make_passes(signing_key, for_message, random_tokens):
         for verification_key in verification_keys
     )
     passes = list(
-        b" ".join(
-            (
-                preimage.encode_base64(),
-                signature.encode_base64(),
-            )
+        Pass(
+            preimage.encode_base64(),
+            signature.encode_base64(),
         )
         for (preimage, signature) in zip(preimages, message_signatures)
     )

--- a/src/_zkapauthorizer/tests/storage_common.py
+++ b/src/_zkapauthorizer/tests/storage_common.py
@@ -26,7 +26,7 @@ from challenge_bypass_ristretto import RandomToken
 from twisted.python.filepath import FilePath
 from zope.interface import implementer
 
-from ..model import NotEnoughTokens, Pass
+from ..model import NotEnoughTokens
 from ..spending import IPassFactory, PassGroup
 from .privacypass import make_passes
 from .strategies import bytes_for_share  # Not really a strategy...
@@ -163,13 +163,10 @@ def get_passes(message, count, signing_key):
     :return list[Pass]: ``count`` new random passes signed with the given key
         and bound to the given message.
     """
-    return list(
-        Pass.from_bytes(pass_)
-        for pass_ in make_passes(
-            signing_key,
-            message,
-            list(RandomToken.create() for n in range(count)),
-        )
+    return make_passes(
+        signing_key,
+        message,
+        [RandomToken.create() for n in range(count)],
     )
 
 


### PR DESCRIPTION
The later function takes a count of passes to generated, and passes
them to `make_passes`. This also changes `make_passes` to return `Pass`es,
which is what `get_passes` wants to receive.

As part of working on https://whetstone.privatestorage.io/privatestorage/PrivateStorageio/-/issues/84 I want access to the tokens that are generated by `make_passes`/`get_passes`; by using a function that returns `Pass`, I can avoid needing to parse the result to make assertions.