### PR TITLE
Implement a minimal interface for reporting spent ZKAPs to a spending service.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ package_dir =
 # the plugins package we want to ship.
 packages =
     _zkapauthorizer
+    _zkapauthorizer.server
     _zkapauthorizer.tests
     twisted.plugins
 

--- a/src/_zkapauthorizer/server/__init__.py
+++ b/src/_zkapauthorizer/server/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2019 PrivateStorage.io, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/_zkapauthorizer/server/spending.py
+++ b/src/_zkapauthorizer/server/spending.py
@@ -1,0 +1,69 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+try:
+    from typing import Any
+except ImportError:
+    pass
+
+import attr
+from challenge_bypass_ristretto import PublicKey
+from prometheus_client import CollectorRegistry
+from twisted.internet.interfaces import IReactorTime
+from zope.interface import Interface, implementer
+
+
+class ISpender(Interface):
+    """
+    An ``ISpender`` can records spent ZKAPs and reports double spends.
+    """
+
+    def mark_as_spent(public_key, passes):
+        # type: (PublicKey, list[bytes]) -> None
+        """
+        Record the given ZKAPs (associated to the given public key as having
+        been spent.
+
+        This does *not* report errors and should only be used in cases when
+        recording spending that has already happened. This can be because
+        we could not contact the spending service when they were spent, or
+        because we can't yet check before making changes to the node.
+        """
+
+
+@attr.s
+class _SpendingData(object):
+    spent_tokens = attr.ib(init=False, factory=dict)
+
+    def reset(self):
+        self.spent_tokens.clear()
+
+
+@implementer(ISpender)
+@attr.s
+class RecordingSpender(object):
+    """
+    An in-memory :py:`ISpender` implementation that exposes the spent tokens
+    for testing purposes.
+    """
+
+    _recorder = attr.ib(validator=attr.validators.instance_of(_SpendingData))
+
+    @classmethod
+    def make(cls):
+        # type: () -> (_SpendingData, ISpender)
+        recorder = _SpendingData()
+        return recorder, cls(recorder)
+
+    def mark_as_spent(self, public_key, passes):
+        self._recorder.spent_tokens.setdefault(public_key.encode_base64(), []).extend(
+            passes
+        )
+
+
+def get_spender(config, reactor, registry):
+    # type: (dict[str, Any], IReactorTime, CollectorRegistry) -> ISpender
+    """
+    Return an :py:`ISpender` to be used with the given storage server configuration.
+    """
+    recorder, spender = RecordingSpender.make()
+    return spender


### PR DESCRIPTION
This includes a minimal in-memory implemenation which can be used by tests, and
adds the appropriate calls to the new interface to the storage server
implemenation.

This is based on #269. I have a work in progress real implementation in #270 which talks to https://whetstone.privatestorage.io/privatestorage/zkap-spending-service/-/merge_requests/4.