### PR TITLE
Refactor the Nix packaging for reduced duplication and to provide a more useful shell environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
       # This pre-release image in particular fixes a problem in the 2.5.1
       # image where no CA certificates are available.
       # https://github.com/NixOS/nix/issues/5797
-      - image: "nixos/nix:2.6.0pre20211228_f7d22f4-"
+      - image: "nixos/nix:2.5.1"
 
     # Tahoe-LAFS requires more memory than we get from the default resource
     # class and sometimes we have to build it.
@@ -165,6 +165,7 @@ jobs:
       # Let us use features marked "experimental".  For example, most/all of
       # the `nix <subcommand>` forms.
       NIX_CONFIG: "experimental-features = nix-command"
+      NIX_SSL_CERT_FILE: "/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt"
 
       # Pin a NixOS 21.11 revision.  Most of the software involved in the
       # build process is pinned by nix/sources.json with niv but a few things

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
       # one day someone pushed a bad revision to it and our CI broke.  So now
       # we just pin some recent version.  Who would have thought a floating
       # dependency would cause build instability?
-      - image: "nixos/nix:2.3.16"
+      - image: "nixos/nix:2.5.1"
 
     # Tahoe-LAFS requires more memory than we get from the default resource
     # class and sometimes we have to build it.
@@ -167,6 +167,18 @@ jobs:
       NIXPKGS: "https://github.com/NixOS/nixpkgs/archive/28abc4e43a24d28729509e2d83f5c4f3b3418189.tar.gz"
 
     steps:
+      - run:
+          # Work around a bug in the 2.5.1 Docker image that prevents it from
+          # having any CA certificates to use to validate any certificates it
+          # encounters (and thus makes it incapable of talking to our binary
+          # caches).
+          #
+          # The work-around is from a comment on the issue
+          # https://github.com/NixOS/nix/issues/5797
+          name: "Fix CA Certificates"
+          command: |
+            ln -s $NIX_SSL_CERT_FILE /etc/ssl/certs/
+
       - run:
           name: "Set up Cachix"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,6 @@ jobs:
       - run:
           name: "Set up Cachix"
           command: |
-            find / -name ca-bundle.crt
             nix-env -f $NIXPKGS -iA cachix bash
             cachix use "${CACHIX_NAME}"
             nix path-info --all > /tmp/store-path-pre-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,7 @@ jobs:
       # Let us use features marked "experimental".  For example, most/all of
       # the `nix <subcommand>` forms.
       NIX_CONFIG: "experimental-features = nix-command"
-      NIX_SSL_CERT_FILE: "/nix/store/dvcalma5h3wd8bbwhj7g9m3yswxm707c-nss-cacert-3.66/etc/ssl/certs/ca-bundle.crt"
+      # NIX_SSL_CERT_FILE: "/nix/store/dvcalma5h3wd8bbwhj7g9m3yswxm707c-nss-cacert-3.66/etc/ssl/certs/ca-bundle.crt"
 
       # Pin a NixOS 21.11 revision.  Most of the software involved in the
       # build process is pinned by nix/sources.json with niv but a few things
@@ -179,6 +179,7 @@ jobs:
       - run:
           name: "Set up Cachix"
           command: |
+            env
             mkdir -p /etc/ssl/certs/
             ln -s $NIX_SSL_CERT_FILE /etc/ssl/certs/
             nix-env -f $NIXPKGS -iA cachix bash

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,6 +179,8 @@ jobs:
       - run:
           name: "Set up Cachix"
           command: |
+            mkdir -p /etc/ssl/certs/
+            ln -s $NIX_SSL_CERT_FILE /etc/ssl/certs/
             nix-env -f $NIXPKGS -iA cachix bash
             cachix use "${CACHIX_NAME}"
             nix path-info --all > /tmp/store-path-pre-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,6 +179,7 @@ jobs:
       - run:
           name: "Set up Cachix"
           command: |
+            find / -name ca-bundle.crt
             nix-env -f $NIXPKGS -iA cachix bash
             cachix use "${CACHIX_NAME}"
             nix path-info --all > /tmp/store-path-pre-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,11 @@ jobs:
       # one day someone pushed a bad revision to it and our CI broke.  So now
       # we just pin some recent version.  Who would have thought a floating
       # dependency would cause build instability?
-      - image: "nixos/nix:2.5.1"
+      #
+      # This pre-release image in particular fixes a problem in the 2.5.1
+      # image where no CA certificates are available.
+      # https://github.com/NixOS/nix/issues/5797
+      - image: "nixos/nix:2.6.0pre20211228_f7d22f4-"
 
     # Tahoe-LAFS requires more memory than we get from the default resource
     # class and sometimes we have to build it.
@@ -167,18 +171,6 @@ jobs:
       NIXPKGS: "https://github.com/NixOS/nixpkgs/archive/28abc4e43a24d28729509e2d83f5c4f3b3418189.tar.gz"
 
     steps:
-      - run:
-          # Work around a bug in the 2.5.1 Docker image that prevents it from
-          # having any CA certificates to use to validate any certificates it
-          # encounters (and thus makes it incapable of talking to our binary
-          # caches).
-          #
-          # The work-around is from a comment on the issue
-          # https://github.com/NixOS/nix/issues/5797
-          name: "Fix CA Certificates"
-          command: |
-            ln -s $NIX_SSL_CERT_FILE /etc/ssl/certs/
-
       - run:
           name: "Set up Cachix"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,10 @@ jobs:
       # CACHIX_AUTH_TOKEN is manually set in the CircleCI web UI and allows us to push to CACHIX_NAME.
       CACHIX_NAME: "privatestorage-opensource"
 
+      # Let us use features marked "experimental".  For example, most/all of
+      # the `nix <subcommand>` forms.
+      NIX_CONFIG: "experimental-features = nix-command"
+
       # Pin a NixOS 21.11 revision.  Most of the software involved in the
       # build process is pinned by nix/sources.json with niv but a few things
       # need to work before we get that far.  This pin is for those things.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,7 @@ jobs:
       # Let us use features marked "experimental".  For example, most/all of
       # the `nix <subcommand>` forms.
       NIX_CONFIG: "experimental-features = nix-command"
-      NIX_SSL_CERT_FILE: "/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt"
+      NIX_SSL_CERT_FILE: "/nix/store/dvcalma5h3wd8bbwhj7g9m3yswxm707c-nss-cacert-3.66/etc/ssl/certs/ca-bundle.crt"
 
       # Pin a NixOS 21.11 revision.  Most of the software involved in the
       # build process is pinned by nix/sources.json with niv but a few things

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,10 +148,6 @@ jobs:
       # one day someone pushed a bad revision to it and our CI broke.  So now
       # we just pin some recent version.  Who would have thought a floating
       # dependency would cause build instability?
-      #
-      # This pre-release image in particular fixes a problem in the 2.5.1
-      # image where no CA certificates are available.
-      # https://github.com/NixOS/nix/issues/5797
       - image: "nixos/nix:2.5.1"
 
     # Tahoe-LAFS requires more memory than we get from the default resource
@@ -165,7 +161,6 @@ jobs:
       # Let us use features marked "experimental".  For example, most/all of
       # the `nix <subcommand>` forms.
       NIX_CONFIG: "experimental-features = nix-command"
-      # NIX_SSL_CERT_FILE: "/nix/store/dvcalma5h3wd8bbwhj7g9m3yswxm707c-nss-cacert-3.66/etc/ssl/certs/ca-bundle.crt"
 
       # Pin a NixOS 21.11 revision.  Most of the software involved in the
       # build process is pinned by nix/sources.json with niv but a few things
@@ -177,11 +172,21 @@ jobs:
 
     steps:
       - run:
-          name: "Set up Cachix"
+          # Work around a bug in the 2.5.1 Docker image that prevents it from
+          # having any CA certificates to use to validate any certificates it
+          # encounters (and thus makes it incapable of talking to our binary
+          # caches).
+          #
+          # The work-around is from a comment on the issue
+          # https://github.com/NixOS/nix/issues/5797
+          name: "Fix CA Certificates"
           command: |
-            env
             mkdir -p /etc/ssl/certs/
             ln -s $NIX_SSL_CERT_FILE /etc/ssl/certs/
+
+      - run:
+          name: "Set up Cachix"
+          command: |
             nix-env -f $NIXPKGS -iA cachix bash
             cachix use "${CACHIX_NAME}"
             nix path-info --all > /tmp/store-path-pre-build

--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,7 @@ in
 , mach-nix ? import sources.mach-nix { inherit pkgs pypiData; }
 , tahoe-lafs-source ? "tahoe-lafs"
 , tahoe-lafs-repo ? sources.${tahoe-lafs-source}
+, ...
 }:
   let
     lib = pkgs.lib;

--- a/default.nix
+++ b/default.nix
@@ -37,6 +37,8 @@ in
     };
   in
     rec {
+      inherit pkgs mach-nix;
+
       tahoe-lafs = mach-nix.buildPythonPackage rec {
         inherit python providers;
         name = "tahoe-lafs";

--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,6 @@ in
 , mach-nix ? import sources.mach-nix { inherit pkgs pypiData; }
 , tahoe-lafs-source ? "tahoe-lafs"
 , tahoe-lafs-repo ? sources.${tahoe-lafs-source}
-, ...
 }:
   let
     lib = pkgs.lib;

--- a/shell.nix
+++ b/shell.nix
@@ -1,17 +1,14 @@
+# Note: Passing arguments through here to customize the environment does not
+# work on Nix 2.3.  It works with Nix 2.5.  I'm not sure about 2.4.
+{ ... }@args:
 let
-  sources = import nix/sources.nix;
+  tests = import ./tests.nix args;
+  inherit (tests) pkgs;
 in
-{ pkgs ? import sources.release2105 {}
-, tahoe-lafs-source ? "tahoe-lafs"
-}:
-  let
-    tests = pkgs.callPackage ./tests.nix {
-      inherit tahoe-lafs-source;
-    };
-  in
-    pkgs.mkShell {
-      packages = [
-        tests.python
-        pkgs.niv
-      ];
-    }
+pkgs.mkShell {
+  buildInputs = [
+    tests.python
+    tests.lint-python
+    pkgs.niv
+  ];
+}

--- a/tests.nix
+++ b/tests.nix
@@ -1,8 +1,20 @@
-{ privatestorage ? import ./. args
+let
+  fixArgs = a: builtins.removeAttrs a [
+    # Make sure all the args tests.nix accepts but default.nix does not are
+    # listed here so we don't try to forward them to default.nix
+    "privatestorage"
+    "hypothesisProfile"
+    "collectCoverage"
+    "testSuite"
+    "trialArgs"
+  ];
+in
+{ privatestorage ? import ./. (fixArgs args)
 , hypothesisProfile ? null
 , collectCoverage ? false
 , testSuite ? null
 , trialArgs ? null
+# accept any other arguments to be passed on to default.nix
 , ...
 }@args:
 let


### PR DESCRIPTION
This changes `default.nix`, `tests.nix`, and `shell.nix` so that we don't need to duplicate `default.nix`'s parameters anywhere yet we can still pass them through from everywhere.

It also adds the lint tools to the environment defined by `shell.nix` for easier interactive linting during development.

It increases the version of Nix required to 2.5 (maybe 2.4 works but I don't see an easy way to get 2.4 to test it out so let's just say 2.5) for `shell.nix` and `tests.nix` but not for `default.nix`.
