### PR TITLE
Add Tahoe-LAFS `upload` and `download` helpers

### DIFF
--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,6 +1,7 @@
 coverage
 fixtures
 testtools
+testresources
 hypothesis
 pyflakes
 openapi_spec_validator

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ install_requires =
     colorama
 
 [options.extras_require]
-test = coverage; fixtures; testtools; hypothesis; openapi_spec_validator
+test = coverage; fixtures; testtools; testresources; hypothesis; openapi_spec_validator
 
 [flake8]
 # Enforce all pyflakes constraints, and also prohibit tabs for indentation.

--- a/src/_zkapauthorizer/tahoe.py
+++ b/src/_zkapauthorizer/tahoe.py
@@ -12,7 +12,7 @@ from twisted.python.filepath import FilePath
 
 async def upload(
     client: HTTPClient, inpath: FilePath, api_root: DecodedURL
-) -> Awaitable[str]:
+) -> Awaitable:  # Awaitable[str] but this requires Python 3.9
     """
     Upload data from the given path and return the resulting capability.
     """
@@ -26,7 +26,7 @@ async def upload(
 
 async def download(
     client: HTTPClient, outpath: FilePath, api_root: DecodedURL, cap: str
-) -> Awaitable[None]:
+) -> Awaitable:  # Awaitable[None] but this requires Python 3.9
     """
     Download the object identified by the given capability to the given path.
     """

--- a/src/_zkapauthorizer/tahoe.py
+++ b/src/_zkapauthorizer/tahoe.py
@@ -1,0 +1,40 @@
+"""
+A library for interacting with a Tahoe-LAFS node.
+"""
+
+from collections.abc import Awaitable
+
+import treq
+from hyperlink import DecodedURL
+from treq.client import HTTPClient
+from twisted.python.filepath import FilePath
+
+
+async def upload(client: HTTPClient, inpath: FilePath, api_root: DecodedURL) -> str:
+    """
+    Upload data from the given path and return the resulting capability.
+    """
+    with inpath.open() as f:
+        resp = await client.put(api_root.child("uri"), f)
+    content = (await treq.content(resp)).decode("utf-8")
+    if resp.code in (200, 201):
+        return content
+    raise Exception(content)
+
+
+async def download(
+    client: HTTPClient, outpath: FilePath, api_root: DecodedURL, cap: str
+) -> Awaitable[None]:
+    """
+    Download the object identified by the given capability to the given path.
+    """
+    outtemp = outpath.temporarySibling()
+
+    resp = await client.get(api_root.child("uri", cap).to_text())
+    if resp.code == 200:
+        with outtemp.open("w") as f:
+            await treq.collect(resp, f.write)
+        outtemp.moveTo(outpath)
+    else:
+        content = await treq.content(resp)
+        raise Exception(content.decode("utf-8"))

--- a/src/_zkapauthorizer/tahoe.py
+++ b/src/_zkapauthorizer/tahoe.py
@@ -10,7 +10,9 @@ from treq.client import HTTPClient
 from twisted.python.filepath import FilePath
 
 
-async def upload(client: HTTPClient, inpath: FilePath, api_root: DecodedURL) -> str:
+async def upload(
+    client: HTTPClient, inpath: FilePath, api_root: DecodedURL
+) -> Awaitable[str]:
     """
     Upload data from the given path and return the resulting capability.
     """

--- a/src/_zkapauthorizer/tahoe.py
+++ b/src/_zkapauthorizer/tahoe.py
@@ -15,6 +15,21 @@ async def upload(
 ) -> Awaitable:  # Awaitable[str] but this requires Python 3.9
     """
     Upload data from the given path and return the resulting capability.
+
+    :param client: An HTTP client to use to make requests to the Tahoe-LAFS
+        HTTP API to perform the upload.
+
+    :param inpath: The path to the regular file to upload.
+
+    :param api_root: The location of the root of the Tahoe-LAFS HTTP API to
+        use to perform the upload.  This should typically be the ``node.url``
+        value from a Tahoe-LAFS client node.
+
+    :return: If the upload is successful then the capability of the uploaded
+        data is returned.
+
+    :raise: If there is a problem uploading the data, some exception is
+        raised.
     """
     with inpath.open() as f:
         resp = await client.put(api_root.child("uri"), f)
@@ -29,6 +44,21 @@ async def download(
 ) -> Awaitable:  # Awaitable[None] but this requires Python 3.9
     """
     Download the object identified by the given capability to the given path.
+
+    :param client: An HTTP client to use to make requests to the Tahoe-LAFS
+        HTTP API to perform the upload.
+
+    :param outpath: The path to the regular file to which the downloaded
+        content will be written.  The content will be written to a temporary
+        file next to this one during download and then moved to this location
+        at the end.
+
+    :param api_root: The location of the root of the Tahoe-LAFS HTTP API to
+        use to perform the upload.  This should typically be the ``node.url``
+        value from a Tahoe-LAFS client node.
+
+    :raise: If there is a problem downloading the data, some exception is
+        raised.
     """
     outtemp = outpath.temporarySibling()
 
@@ -38,5 +68,5 @@ async def download(
             await treq.collect(resp, f.write)
         outtemp.moveTo(outpath)
     else:
-        content = await treq.content(resp)
-        raise Exception(content.decode("utf-8"))
+        content = (await treq.content(resp)).decode("utf-8")
+        raise Exception(content)

--- a/src/_zkapauthorizer/tests/test_tahoe.py
+++ b/src/_zkapauthorizer/tests/test_tahoe.py
@@ -162,10 +162,20 @@ class TahoeStorageManager(TestResourceManager):
 
     resources = [("node_dir", TemporaryDirectoryResource())]
 
+    # This doesn't clean up the given resource - it cleans up the global
+    # runtime environment in which that resource was created - by destroying
+    # anything associated with it which Python will not automatically clean up
+    # when the Python objects are garbage collected.
     def clean(self, storage):
+        """
+        Kill the storage node child process.
+        """
         storage.process.kill()
 
     def make(self, dependency_resources):
+        """
+        Create and run a brand new Tahoe-LAFS storage node.
+        """
         storage = TahoeStorage(**dependency_resources)
         storage.run()
         return storage
@@ -254,10 +264,17 @@ class TahoeClientManager(TestResourceManager):
         ("node_dir", TemporaryDirectoryResource()),
     ]
 
+    # See note on TahoeStorageManager.clean
     def clean(self, client):
+        """
+        Kill the client node child process.
+        """
         client.process.kill()
 
     def make(self, dependency_resources):
+        """
+        Create and run a brand new Tahoe-LAFS client node.
+        """
         client = TahoeClient(**dependency_resources)
         client.run()
         return client

--- a/src/_zkapauthorizer/tests/test_tahoe.py
+++ b/src/_zkapauthorizer/tests/test_tahoe.py
@@ -25,6 +25,11 @@ from .fixtures import Treq
 # A plausible value for the ``retry`` parameter of ``wait_for_path``.
 RETRY_DELAY = [0.3] * 100
 
+# An argv prefix to use in place of `tahoe` to run the Tahoe-LAFS CLI.  This
+# runs the CLI via the `__main__` so that we don't rely on `tahoe` being in
+# `PATH`.
+TAHOE = [executable, "-m", "allmydata"]
+
 
 def wait_for_path(path: FilePath, retry: Iterator[float] = RETRY_DELAY) -> None:
     """
@@ -101,10 +106,8 @@ class TahoeStorage:
         Create the node directory.
         """
         self.create_output = check_output(
-            [
-                executable,
-                "-m",
-                "allmydata",
+            TAHOE
+            + [
                 "create-node",
                 "--webport=tcp:port=0",
                 "--hostname=127.0.0.1",
@@ -119,7 +122,7 @@ class TahoeStorage:
         Start the node child process.
         """
         self.process = Popen(
-            [executable, "-m", "allmydata", "run", self.node_dir.path],
+            TAHOE + ["run", self.node_dir.path],
             stdout=self.node_dir.child("stdout").open("wb"),
             stderr=self.node_dir.child("stderr").open("wb"),
         )
@@ -203,8 +206,8 @@ class TahoeClient:
         Create the node directory and write the necessary configuration to it.
         """
         self.create_output = check_output(
-            [
-                "tahoe",
+            TAHOE
+            + [
                 "create-node",
                 "--webport=tcp:port=0",
                 "--hostname=127.0.0.1",
@@ -228,7 +231,7 @@ class TahoeClient:
         Start the node child process.
         """
         self.process = Popen(
-            ["tahoe", "run", self.node_dir.path],
+            TAHOE + ["run", self.node_dir.path],
             stdout=self.node_dir.child("stdout").open("wb"),
             stderr=self.node_dir.child("stderr").open("wb"),
         )

--- a/src/_zkapauthorizer/tests/test_tahoe.py
+++ b/src/_zkapauthorizer/tests/test_tahoe.py
@@ -1,0 +1,187 @@
+"""
+Tests for ``_zkapauthorizer.tahoe``.
+"""
+
+from subprocess import Popen, check_call
+from tempfile import mkdtemp
+from time import sleep
+from typing import Optional
+
+from attrs import define
+from fixtures import TempDir
+from hyperlink import DecodedURL
+from testresources import TestResourceManager, setUpResources, tearDownResources
+from testtools import TestCase
+from testtools.matchers import Equals
+from testtools.twistedsupport import AsynchronousDeferredRunTest
+from treq.client import HTTPClient
+from twisted.internet.defer import Deferred, ensureDeferred, inlineCallbacks
+from twisted.python.filepath import FilePath
+from twisted.web.client import Agent, HTTPConnectionPool
+from yaml import safe_dump
+
+from ..tahoe import download, upload
+
+
+def wait_for(path):
+    while not path.exists():
+        print(f"{path.path} does not exist")
+        sleep(0.3)
+
+
+@define
+class TahoeStorage:
+    node_dir: FilePath
+    process: Optional[Popen] = None
+    node_url: Optional[FilePath] = None
+    storage_furl: Optional[FilePath] = None
+    node_pubkey: Optional[str] = None
+
+    def run(self):
+        check_call(
+            [
+                "tahoe",
+                "create-node",
+                "--webport=tcp:port=0",
+                "--hostname=127.0.0.1",
+                self.node_dir.path,
+            ]
+        )
+        self.process = Popen(["tahoe", "run", self.node_dir.path])
+        node_url_path = self.node_dir.child("node.url")
+        wait_for(node_url_path)
+        self.node_url = node_url_path.getContent().decode("ascii").strip()
+        storage_furl_path = self.node_dir.descendant(["private", "storage.furl"])
+        wait_for(storage_furl_path)
+        self.storage_furl = storage_furl_path.getContent().decode("ascii").strip()
+        node_pubkey_path = self.node_dir.child("node.pubkey")
+        wait_for(node_pubkey_path)
+        self.node_pubkey = node_pubkey_path.getContent().decode("ascii").strip()
+
+    def servers_yaml_entry(self):
+        return {
+            self.node_pubkey[len("pub-") :]: {
+                "ann": {
+                    "anonymous-storage-FURL": self.storage_furl,
+                    "nickname": "storage",
+                },
+            },
+        }
+
+
+class TemporaryDirectoryResource(TestResourceManager):
+    def clean(self, resource):
+        resource.remove()
+
+    def make(self, dependency_resources):
+        return FilePath(mkdtemp())
+
+    def isDirty(self, resource):
+        # Can't detect when the directory is written to, so assume it
+        # can never be reused.  We could list the directory, but that might
+        # not catch it being open as a cwd etc.
+        return True
+
+
+class TahoeStorageManager(TestResourceManager):
+    resources = [("node_dir", TemporaryDirectoryResource())]
+
+    def clean(self, storage):
+        storage.process.kill()
+
+    def make(self, dependency_resources):
+        storage = TahoeStorage(**dependency_resources)
+        storage.run()
+        return storage
+
+
+@define
+class TahoeClient:
+    node_dir: FilePath
+    storage: Optional[TahoeStorage] = None
+    process: Optional[Popen] = None
+    node_url: Optional[FilePath] = None
+
+    def run(self):
+        check_call(
+            [
+                "tahoe",
+                "create-node",
+                "--webport=tcp:port=0",
+                "--hostname=127.0.0.1",
+                "--shares-needed=1",
+                "--shares-total=1",
+                "--shares-happy=1",
+                self.node_dir.path,
+            ]
+        )
+        with open(
+            self.node_dir.descendant(["private", "servers.yaml"]).path, "wt"
+        ) as f:
+            f.write(
+                safe_dump({"storage": self.storage.servers_yaml_entry()}),
+            )
+        self.process = Popen(["tahoe", "run", self.node_dir.path])
+        node_url_path = self.node_dir.child("node.url")
+        wait_for(node_url_path)
+        self.node_url = DecodedURL.from_text(
+            node_url_path.getContent().decode("ascii").strip()
+        )
+
+
+class TahoeClientManager(TestResourceManager):
+    resources = [
+        ("storage", TahoeStorageManager()),
+        ("node_dir", TemporaryDirectoryResource()),
+    ]
+
+    def clean(self, client):
+        client.process.kill()
+
+    def make(self, dependency_resources):
+        client = TahoeClient(**dependency_resources)
+        client.run()
+        return client
+
+
+class DownloadTestCase(TestCase):
+    """
+    Tests for ``download``.
+    """
+
+    run_tests_with = AsynchronousDeferredRunTest.make_factory(timeout=60.0)
+
+    resources = [("client", TahoeClientManager())]
+
+    def setUp(self):
+        super().setUp()
+        setUpResources(self, self.resources, None)
+        self.addCleanup(lambda: tearDownResources(self, self.resources, None))
+
+    @inlineCallbacks
+    def test_found(self):
+        """
+        If the identified object can be downloaded then it is written to the given
+        path.
+        """
+        sleep(1)
+        from twisted.internet import reactor
+
+        pool = HTTPConnectionPool(reactor, persistent=False)
+        self.addCleanup(pool.closeCachedConnections)
+
+        treq = HTTPClient(Agent(reactor, pool))
+
+        workdir = FilePath(self.useFixture(TempDir()).join("test_found"))
+        workdir.makedirs()
+
+        inpath = workdir.child("uploaded")
+        inpath.setContent(b"abc" * 1024)
+
+        outpath = workdir.child("downloaded")
+        cap = yield ensureDeferred(upload(treq, inpath, self.client.node_url))
+        yield ensureDeferred(download(treq, outpath, self.client.node_url, cap))
+        self.assertThat(
+            inpath.getContent(),
+            Equals(outpath.getContent()),
+        )

--- a/src/_zkapauthorizer/tests/test_tahoe.py
+++ b/src/_zkapauthorizer/tests/test_tahoe.py
@@ -53,9 +53,6 @@ def read_text(path: FilePath) -> str:
 
 
 class TemporaryDirectoryResource(TestResourceManager):
-    def clean(self, resource):
-        resource.remove()
-
     def make(self, dependency_resources):
         return FilePath(mkdtemp())
 

--- a/src/_zkapauthorizer/tests/test_tahoe.py
+++ b/src/_zkapauthorizer/tests/test_tahoe.py
@@ -3,6 +3,7 @@ Tests for ``_zkapauthorizer.tahoe``.
 """
 
 from subprocess import Popen, check_output
+from sys import executable
 from tempfile import mkdtemp
 from time import sleep
 from typing import Iterator, Optional
@@ -101,7 +102,9 @@ class TahoeStorage:
         """
         self.create_output = check_output(
             [
-                "tahoe",
+                executable,
+                "-m",
+                "allmydata",
                 "create-node",
                 "--webport=tcp:port=0",
                 "--hostname=127.0.0.1",
@@ -116,7 +119,7 @@ class TahoeStorage:
         Start the node child process.
         """
         self.process = Popen(
-            ["tahoe", "run", self.node_dir.path],
+            [executable, "-m", "allmydata", "run", self.node_dir.path],
             stdout=self.node_dir.child("stdout").open("wb"),
             stderr=self.node_dir.child("stderr").open("wb"),
         )


### PR DESCRIPTION
Related to #235.  The replication and recovery system will need to upload data to Tahoe storage servers for replication and download it again for recovery.

This adds very basic `upload` and `download` functions which are at least a pretty good step in that direction.

These are both inspired by the implementations in GridSync, though ultimately they're pretty simple functions.
