### PR TITLE
Include linting tools in test requirements.

### DIFF
--- a/requirements/test.in
+++ b/requirements/test.in
@@ -3,5 +3,13 @@ fixtures
 testtools
 testresources
 hypothesis
-pyflakes
 openapi_spec_validator
+
+# Lint requirements
+# Pin these narrowly so that lint rules only change when we specifically
+# want them to.
+isort == 5.10.1
+black == 21.12b0
+flake8 == 4.0.1
+flake8-isort
+flake8-black

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,4 +65,6 @@ test = coverage; fixtures; testtools; testresources; hypothesis; openapi_spec_va
 # Reference:
 #   https://flake8.pycqa.org/en/latest/user/error-codes.html
 #   https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
-select = F, W191
+#   https://pypi.org/project/flake8-isort/#error-codes
+#   https://pypi.org/project/flake8-black/#flake8-validation-codes
+select = F, W191, I, BLK

--- a/shell.nix
+++ b/shell.nix
@@ -28,8 +28,6 @@ pkgs.mkShell {
   PYTHONDONTWRITEBYTECODE = "1";
 
   buildInputs = [
-    # Provide the linting tools for interactive usage.
-    lint-python
     # Supply all of the runtime and testing dependencies.
     python-env
   ];

--- a/tests.nix
+++ b/tests.nix
@@ -34,19 +34,6 @@ let
       _.hypothesis.postUnpack = "";
     };
 
-    lint-python = mach-nix.mkPython {
-      python = "python39";
-      # Pin these narrowly so that lint rules only change when we specifically
-      # want them to.
-      requirements = ''
-        isort == 5.10.1
-        black == 21.12b0
-        flake8 == 4.0.1
-        flake8-isort
-        flake8-black
-      '';
-    };
-
     tests = pkgs.runCommand "zkapauthorizer-tests" {
       passthru = {
         inherit python;
@@ -55,7 +42,7 @@ let
       mkdir -p $out
 
       pushd ${zkapauthorizer.src}
-      ${lint-python}/bin/flake8 src
+      ${python}/bin/flake8 src
       popd
 
       ZKAPAUTHORIZER_HYPOTHESIS_PROFILE=${hypothesisProfile'} ${python}/bin/python -m ${if collectCoverage
@@ -72,5 +59,5 @@ let
     '';
 in
 {
-  inherit privatestorage lint-python tests;
+  inherit privatestorage tests;
 }

--- a/tests.nix
+++ b/tests.nix
@@ -42,6 +42,8 @@ let
         isort == 5.10.1
         black == 21.12b0
         flake8 == 4.0.1
+        flake8-isort
+        flake8-black
       '';
     };
 
@@ -53,8 +55,6 @@ let
       mkdir -p $out
 
       pushd ${zkapauthorizer.src}
-      ${lint-python}/bin/black --check src
-      ${lint-python}/bin/isort --check src
       ${lint-python}/bin/flake8 src
       popd
 


### PR DESCRIPTION
Also, use flake8 plugins for reporting black and isort errors.

This does have the downside that the linting tools' dependencies can impact what versions of tools gets picked for the test environment, but that issue already exists for all our other test dependencies.

I did run into this in practice (though not in a way that impacted tests) with zkap-spending-service, where black's dependency on `tomli` was more restricted than was otherwise pulled in (as a dependency of setuptools-scm). I don't recall the exact details, but I think it only caused a conflict in the python environment, that was solved by defaulting to using wheels instead of sdists.