### PR TITLE
Create a minimal derivation for linting tools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,4 +65,6 @@ test = coverage; fixtures; testtools; testresources; hypothesis; openapi_spec_va
 # Reference:
 #   https://flake8.pycqa.org/en/latest/user/error-codes.html
 #   https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
-select = F, W191
+#   https://pypi.org/project/flake8-isort/#error-codes
+#   https://pypi.org/project/flake8-black/#flake8-validation-codes
+select = F, W191, I, BLK

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,7 @@
 { ... }@args:
 let
   tests = import ./tests.nix args;
-  inherit (tests) privatestorage lint-python;
+  inherit (tests) privatestorage lint-env;
   inherit (privatestorage) pkgs mach-nix tahoe-lafs zkapauthorizer;
 
   python-env = mach-nix.mkPython {
@@ -29,7 +29,7 @@ pkgs.mkShell {
 
   buildInputs = [
     # Provide the linting tools for interactive usage.
-    lint-python
+    lint-env
     # Supply all of the runtime and testing dependencies.
     python-env
   ];

--- a/tests.nix
+++ b/tests.nix
@@ -42,6 +42,8 @@ let
         isort == 5.10.1
         black == 21.12b0
         flake8 == 4.0.1
+        flake8-isort
+        flake8-black
       '';
     };
 
@@ -53,8 +55,6 @@ let
       mkdir -p $out
 
       pushd ${zkapauthorizer.src}
-      ${lint-python}/bin/black --check src
-      ${lint-python}/bin/isort --check src
       ${lint-python}/bin/flake8 src
       popd
 


### PR DESCRIPTION
Also, use flake8 plugins for reporting black and isort errors.

This creates a derivation with *just* the binaries needed for linting, which can then be included in an environment, and not have clashes with other derivations that have python libraries.

This is an alternative way of solving the shell.nix issue that #301 is solving, without the dependency interference.