### PR TITLE
Add some recovery-related endpoints

### DIFF
--- a/src/_zkapauthorizer/_plugin.py
+++ b/src/_zkapauthorizer/_plugin.py
@@ -49,6 +49,7 @@ from .lease_maintenance import (
     maintain_leases_from_root,
 )
 from .model import VoucherStore
+from .recover import make_fail_downloader
 from .resource import from_configuration as resource_from_configuration
 from .server.spending import get_spender
 from .spending import SpendingController
@@ -184,9 +185,18 @@ class ZKAPAuthorizer(object):
         """
         if reactor is None:
             from twisted.internet import reactor
+
+        def get_downloader(cap):
+            return make_fail_downloader(
+                Exception(
+                    "The recovery system implementation is a work in progress.",
+                )
+            )
+
         return resource_from_configuration(
             node_config,
             store=self._get_store(node_config),
+            get_downloader=get_downloader,
             redeemer=self._get_redeemer(node_config, None, reactor),
             clock=reactor,
         )

--- a/src/_zkapauthorizer/recover.py
+++ b/src/_zkapauthorizer/recover.py
@@ -1,0 +1,140 @@
+"""
+A system for recovering local ZKAPAuthorizer state from a remote replica.
+"""
+
+__all__ = [
+    "AlreadyRecovering",
+    "RecoveryStages",
+    "RecoveryState",
+    "SetState",
+    "Downloader",
+    "StatefulRecoverer",
+    "make_fail_downloader",
+    "noop_downloader",
+]
+
+from collections.abc import Awaitable
+from enum import Enum, auto
+from sqlite3 import Cursor
+from typing import Callable, Dict, Optional
+
+from attrs import define
+
+
+class AlreadyRecovering(Exception):
+    """
+    A recovery attempt is already in-progress so another one cannot be made.
+    """
+
+
+class RecoveryStages(Enum):
+    """
+    Constants representing the different stages a recovery process may have
+    reached.
+
+    :ivar inactive: The recovery system has not been activated.  No recovery
+        has yet been attempted.
+
+    :ivar succeeded: The recovery system has successfully recovered state from
+        a replica.  Recovery is finished.  Since state now exists in the local
+        database, the recovery system cannot be re-activated.
+
+    :ivar failed: The recovery system has definitively failed in its attempt
+        to recover from a replica.  Recovery will progress no further.  It is
+        undefined what state now exists in the local database.
+    """
+
+    inactive = auto()
+    started = auto()
+    downloading = auto()
+    importing = auto()
+    succeeded = auto()
+    failed = auto()
+
+
+@define(frozen=True)
+class RecoveryState:
+    """
+    Describe the state of an attempt at recovery.
+
+    :ivar state: The recovery process progresses through different stages.
+        This indicates the point which that progress has reached.
+
+    :ivar failure_reason: If the recovery failed then a human-meaningful
+        (maybe) string giving details about why.
+    """
+
+    stage: RecoveryStages = RecoveryStages.inactive
+    failure_reason: Optional[str] = None
+
+    def marshal(self) -> Dict[str, Optional[str]]:
+        return {"stage": self.stage.name, "failure-reason": self.failure_reason}
+
+
+# A function for reporting a change in the state of a recovery attempt.
+SetState = Callable[[RecoveryState], None]
+
+# An object which can retrieve remote ZKAPAuthorizer state.
+Downloader = Callable[[SetState], Awaitable]
+
+
+@define
+class StatefulRecoverer:
+    """
+    An ``IRecoverer`` that exposes changing state as it progresses through the
+    recovery process.
+    """
+
+    _state: RecoveryState = RecoveryState(stage=RecoveryStages.inactive)
+
+    async def recover(
+        self,
+        download: Downloader,
+        cursor: Cursor,
+    ) -> Awaitable:
+        """
+        Begin the recovery process.
+
+        :param downloader: A callable which can be used to retrieve a replica.
+
+        :param cursor: A database cursor which can be used to populate the
+            database with recovered state.
+
+        :raise AlreadyRecovering: If recovery has already been attempted
+            (successfully or otherwise).
+        """
+        if self._state.stage != RecoveryStages.inactive:
+            raise AlreadyRecovering()
+
+        self._set_state(RecoveryState(stage=RecoveryStages.started))
+        try:
+            await download(self._set_state)
+        except Exception as e:
+            self._set_state(
+                RecoveryState(stage=RecoveryStages.failed, failure_reason=str(e))
+            )
+        else:
+            self._set_state(RecoveryState(stage=RecoveryStages.succeeded))
+
+    def _set_state(self, state):
+        self._state = state
+
+    def state(self):
+        return self._state
+
+
+def make_fail_downloader(reason: Exception) -> Downloader:
+    """
+    Make a downloader that always fails with the given exception.
+    """
+
+    async def fail_downloader(set_state: SetState) -> Awaitable:
+        raise reason
+
+    return fail_downloader
+
+
+async def noop_downloader(set_state: SetState) -> Awaitable:
+    """
+    A downloader that does nothing and then succeeds.
+    """

--- a/src/_zkapauthorizer/tests/sql.py
+++ b/src/_zkapauthorizer/tests/sql.py
@@ -1,0 +1,146 @@
+"""
+Model SQL-related datatypes.
+
+This is focused on SQLite3 and no doubt nevertheless incomplete.  The goal is
+to support testing the replication/recovery system.
+"""
+
+from enum import Enum, auto
+from typing import Any, List, Tuple
+
+from attrs import define
+
+
+class StorageAffinity(Enum):
+    """
+    Represent the different "storage affinities" possible for a SQLite3
+    column.
+    """
+
+    INT = auto()
+    TEXT = auto()
+    BLOB = auto()
+    REAL = auto()
+    NUMERIC = auto()
+
+
+@define(frozen=True)
+class Column:
+    """
+    Represent a column in a SQLite3 table.
+
+    :ivar affinity: The expected type affinity for values in this column.  See
+        https://www.sqlite.org/datatype3.html
+    """
+
+    affinity: StorageAffinity
+
+
+@define(frozen=True)
+class Table:
+    """
+    Represent a table in a SQLite3 database.
+
+    :ivar columns: The columns that make up this table.
+    """
+
+    columns: List[Tuple[str, Column]]
+
+
+@define(frozen=True)
+class Insert:
+    """
+    Represent an insertion of one row into a table.
+
+    :ivar table_name: The name of the table where the row can be inserted.
+
+    :ivar table: A representation of the table itself.
+
+    :ivar fields: The values which can be inserted.
+    """
+
+    table_name: str
+    table: Table
+    fields: Tuple[Any]
+
+    def statement(self):
+        names = ", ".join((escape(name) for (name, _) in self.table.columns))
+        placeholders = ", ".join("?" * len(self.table.columns))
+        return (
+            f"INSERT INTO {escape(self.table_name)} "
+            f"({names}) "
+            f"VALUES ({placeholders})"
+        )
+
+    def arguments(self):
+        return self.fields
+
+
+@define(frozen=True)
+class Update:
+    """
+    Represent an update to some rows in a table.
+
+    Currently this updates all rows.
+
+    :ivar table_name: The name of the table to which the update applies.
+
+    :ivar table: A representation of the table itself.
+
+    :ivar fields: The new values for each column in the table.
+    """
+
+    table_name: str
+    table: Table
+    fields: Tuple[Any]
+
+    def statement(self):
+        field_names = list(name for (name, _) in self.table.columns)
+        assignments = ", ".join(f"{escape(name)} = ?" for name in field_names)
+        return f"UPDATE {escape(self.table_name)} SET {assignments}"
+
+    def arguments(self):
+        return self.fields
+
+
+@define(frozen=True)
+class Delete:
+    """
+    Represent the deletion of some rows from a table.
+
+    Currently this deletes all rows.
+
+    :ivar table_name: The name of the table from which to rows can be deleted.
+    """
+
+    table_name: str
+
+    def statement(self):
+        return f"DELETE FROM {escape(self.table_name)}"
+
+    def arguments(self):
+        return ()
+
+
+def escape(string: str) -> str:
+    """
+    Escape an arbitrary string for use as a SQLite3 identifier.
+    """
+    return f"[{string}]"
+
+
+def column_ddl(name: str, column: Column) -> str:
+    """
+    Get a column DDL fragment for a column of the given name and type.
+
+    :return: *bar* in **create table foo ( bar )**
+    """
+    return f"{escape(name)} {column.affinity.name}"
+
+
+def create_table(name: str, table: Table) -> str:
+    """
+    Get a table creation DDL statement for a table of the given name and type.
+    """
+    columns = ", ".join(column_ddl(name, column) for (name, column) in table.columns)
+    return f"CREATE TABLE {escape(name)} ({columns})"


### PR DESCRIPTION
This is related to #235.  It implements GET and POST for the recover endpoint - though only wrapped around the thinnest feasible underlying implementation (in particular, not one which can recover anything - but hopefully which has the same shape as one which can).
