### PR TITLE
Add a Tahoe-LAFS replica snapshot downloader

### DIFF
--- a/src/_zkapauthorizer/recover.py
+++ b/src/_zkapauthorizer/recover.py
@@ -208,7 +208,10 @@ async def tahoe_lafs_downloader(
     node's private directory.
     """
     api_root = DecodedURL.from_text(
-        FilePath(node_config.get_config_path("node.url")).getContent().decode("ascii")
+        FilePath(node_config.get_config_path("node.url"))
+        .getContent()
+        .decode("ascii")
+        .strip()
     )
     snapshot_path = FilePath(node_config.get_private_path("snapshot.sql"))
 

--- a/src/_zkapauthorizer/tahoe.py
+++ b/src/_zkapauthorizer/tahoe.py
@@ -141,6 +141,7 @@ async def download(
         raise TahoeAPIError("get", uri, resp.code, content)
 
 
+@async_retry([_not_enough_servers])
 async def make_directory(
     client: HTTPClient,
     api_root: DecodedURL,
@@ -156,6 +157,7 @@ async def make_directory(
     raise TahoeAPIError("post", uri, resp.code, content)
 
 
+@async_retry([_not_enough_servers])
 async def link(
     client: HTTPClient,
     api_root: DecodedURL,

--- a/src/_zkapauthorizer/tahoe.py
+++ b/src/_zkapauthorizer/tahoe.py
@@ -88,8 +88,9 @@ async def upload(
     :raise: If there is a problem uploading the data -- except for
         unavailability of storage servers -- then some exception is raised.
     """
+    uri = api_root.child("uri")
     with inpath.open() as f:
-        resp = await client.put(api_root.child("uri"), f)
+        resp = await client.put(uri, f)
     content = (await treq.content(resp)).decode("utf-8")
     if resp.code in (200, 201):
         return content

--- a/src/_zkapauthorizer/tahoe.py
+++ b/src/_zkapauthorizer/tahoe.py
@@ -59,7 +59,7 @@ def _scrub_cap(cap: str) -> str:
     can usually be distinguished from the scrubbed version of a different
     input string.
     """
-    scrubbed = b32encode(sha256(cap.encode("ascii")).digest())[:6]
+    scrubbed = b32encode(sha256(cap.encode("ascii")).digest())[:6].lower()
     return f"URI:SCRUBBED:{scrubbed}"
 
 

--- a/src/_zkapauthorizer/tahoe.py
+++ b/src/_zkapauthorizer/tahoe.py
@@ -45,9 +45,10 @@ def _not_enough_servers(exc: Exception) -> bool:
     Match the exception that is raised when the Tahoe-LAFS client node is not
     connected to enough servers to satisfy the encoding configuration.
     """
-    return isinstance(
-        exc, TahoeAPIError
-    ) and "allmydata.interfaces.NoServersError" in str(exc)
+    return isinstance(exc, TahoeAPIError) and (
+        "allmydata.interfaces.NoServersError" in str(exc)
+        or "allmydata.mutable.common.NotEnoughServersError" in str(exc)
+    )
 
 
 @define

--- a/src/_zkapauthorizer/tests/test_recover.py
+++ b/src/_zkapauthorizer/tests/test_recover.py
@@ -145,7 +145,7 @@ class StatefulRecoverTests(TestCase):
         #
         # Also try to play along with any profile that has been loaded.
         max_examples = settings.default.max_examples * 10
-        stateful_step_count = int(max(1, settings.default.stateful_step_count / 10))
+        stateful_step_count = int(max(3, settings.default.stateful_step_count / 10))
 
         run_state_machine_as_test(
             lambda: SnapshotMachine(self),

--- a/src/_zkapauthorizer/tests/test_tahoe.py
+++ b/src/_zkapauthorizer/tests/test_tahoe.py
@@ -137,8 +137,9 @@ class TahoeStorage:
         """
         Start the node child process.
         """
+        eliot = ["--eliot-destination", "file:" + self.node_dir.child("log.eliot").path]
         self.process = Popen(
-            TAHOE + ["run", self.node_dir.path],
+            TAHOE + eliot + ["run", self.node_dir.path],
             stdout=self.node_dir.child("stdout").open("wb"),
             stderr=self.node_dir.child("stderr").open("wb"),
         )
@@ -257,8 +258,9 @@ class TahoeClient:
         """
         Start the node child process.
         """
+        eliot = ["--eliot-destination", "file:" + self.node_dir.child("log.eliot").path]
         self.process = Popen(
-            TAHOE + ["run", self.node_dir.path],
+            TAHOE + eliot + ["run", self.node_dir.path],
             stdout=self.node_dir.child("stdout").open("wb"),
             stderr=self.node_dir.child("stderr").open("wb"),
         )

--- a/src/_zkapauthorizer/tests/test_tahoe.py
+++ b/src/_zkapauthorizer/tests/test_tahoe.py
@@ -188,6 +188,7 @@ class TahoeStorageManager(TestResourceManager):
         Kill the storage node child process.
         """
         storage.process.kill()
+        storage.process.wait()
 
     def make(self, dependency_resources):
         """
@@ -289,6 +290,7 @@ class TahoeClientManager(TestResourceManager):
         Kill the client node child process.
         """
         client.process.kill()
+        client.process.wait()
 
     def make(self, dependency_resources):
         """

--- a/src/_zkapauthorizer/tests/test_tahoe.py
+++ b/src/_zkapauthorizer/tests/test_tahoe.py
@@ -63,7 +63,7 @@ class TemporaryDirectoryResource(TestResourceManager):
     def make(self, dependency_resources):
         return FilePath(mkdtemp())
 
-    def isDirty(self, resource):
+    def isDirty(self):
         # Can't detect when the directory is written to, so assume it
         # can never be reused.  We could list the directory, but that might
         # not catch it being open as a cwd etc.


### PR DESCRIPTION
This relates to #235.  It integrates the downloader and recoverer together in StatefulRecoverer and implements a Tahoe-LAFS downloader that knows the recovery cap is a directory with a "snapshot.sql" child.

It also adds a bit more to our Tahoe-LAFS HTTP API helper library for creating directories, linking children into them, and retrieving those children again later.

In principle I expect this could actually recover from a snapshot now, except it is not yet plumbed into our HTTP API by `_plugin.py` (and of course nothing uploads a snapshot yet, and there is no "event stream" handling).
