### PR TITLE
Compare structured SQL dumps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,12 +257,6 @@ workflows:
         # release.
         tahoe-lafs-source: "tahoe-lafs-master"
 
-    # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
-    - "macos-tests":
-        name: "macOS tests python 3.8 xcode 11.7.0"
-        py-version: "3.8"
-        xcode-version: "11.7.0"
-
     - "macos-tests":
         name: "macOS tests python 3.9 xcode 12.3.0"
         py-version: "3.9"

--- a/src/_zkapauthorizer/tests/matchers.py
+++ b/src/_zkapauthorizer/tests/matchers.py
@@ -27,8 +27,10 @@ __all__ = [
 
 from datetime import datetime
 from json import loads
+from math import isnan, nextafter
 
 import attr
+from attrs import define
 from testtools.matchers import (
     AfterPreprocessing,
     AllMatch,
@@ -267,3 +269,86 @@ def matches_capability(type_matcher):
         get_cap_type,
         type_matcher,
     )
+
+
+def unit_of_least_precision_distance(
+    start: float, goal: float, max_distance: int
+) -> int:
+    """
+    Compute the distance from ``start`` to ``goal`` in terms of floating point
+    "unit of least precision" ("ULP").
+
+    This is roughly how many floating point values there are between ``start``
+    and ``goal``.
+
+    :return: The distance.
+
+    :raise ValueError: If the distance is greater than ``max_distance``.  The
+        cost of the distance calculation is linear on the size of the distance
+        and the distance between two floating point values could be almost 2
+        ** 64.  You probably want to limit the amount of work done to a much
+        smaller distance.
+    """
+    if isnan(start) or isnan(goal):
+        raise ValueError("Cannot find distance to or from NaN")
+
+    if start == goal:
+        return 0
+
+    distance = 0
+    while distance < max_distance:
+        distance += 1
+        start = nextafter(start, goal)
+        if start == goal:
+            return distance
+
+    raise ValueError(f"{start} is more than {distance} from {goal}")
+
+
+@define
+class _MatchFloatWithinDistance(object):
+    """
+    See ``matches_float_within_distance``.
+    """
+
+    reference: float
+    distance: int
+    max_distance: int
+
+    def match(self, actual):
+        try:
+            distance = unit_of_least_precision_distance(
+                self.reference, actual, self.max_distance
+            )
+        except ValueError:
+            return Mismatch(
+                f"float {actual} is more than {self.max_distance} "
+                f"from {self.reference} - search abandoned "
+                f"(allowed distance is {self.distance})",
+            )
+        else:
+            if distance > self.distance:
+                return Mismatch(
+                    f"distance from {self.reference} "
+                    f"to {actual} "
+                    f"is {distance}, "
+                    f"greater than allowed distance of {self.distance}",
+                )
+        return None
+
+
+def matches_float_within_distance(
+    reference: float, distance: int, max_distance: int = 100
+):
+    """
+    Matches a floating point value that is no more than a given distance in
+    "unit of least precision" steps of a reference value.
+
+    :param reference: The reference floating point value.
+    :param distance: The maximum allowed distance to a matched value.
+
+    :param max_distance: The maximum distance to search (to try to provide
+        extra information when the match fails).
+    """
+
+    return _MatchFloatWithinDistance(reference, distance, max_distance)

--- a/src/_zkapauthorizer/tests/strategies.py
+++ b/src/_zkapauthorizer/tests/strategies.py
@@ -1223,16 +1223,10 @@ def tables() -> SearchStrategy[Table]:
 _sql_integer = integers(min_value=-(2 ** 63) + 1, max_value=2 ** 63 - 1)
 
 # SQLite3 can do infinity and NaN but I don't know how to get them through the
-# Python interface.  SQLite3 can do 64 bit floats but it only guarantees 15
-# digits of precision (maybe only for its base 10 string representations?)
-# which causes values requiring greater precision to fail to round-trip.  The
-# SQLite3 docs are quite clear about what one should expect from floating
-# point values, anyway:
-#
-#    Floating point values are approximate.
+# Python interface.
 #
 # https://www.sqlite.org/floatingpoint.html
-_sql_floats = floats(allow_infinity=False, allow_nan=False, width=32)
+_sql_floats = floats(allow_infinity=False, allow_nan=False, width=64)
 
 # Here's how you can build values that match certain storage type affinities.
 # SQLite3 will actually allow us to store values of any type in any column but

--- a/src/_zkapauthorizer/tests/test_recover.py
+++ b/src/_zkapauthorizer/tests/test_recover.py
@@ -4,10 +4,10 @@ Tests for ``_zkapauthorizer.recover``, the replication recovery system.
 
 from asyncio import run
 from sqlite3 import Connection, connect
-from sys import float_info
-from typing import Dict, Iterator
+from typing import Dict, Iterator, Tuple, Union
 
 from allmydata.client import read_config
+from attrs import define, field
 from fixtures import TempDir
 from hypothesis import assume, given, note, settings
 from hypothesis.stateful import (
@@ -23,6 +23,7 @@ from testtools import TestCase
 from testtools.matchers import (
     AfterPreprocessing,
     Always,
+    Annotate,
     Equals,
     IsInstance,
     MatchesStructure,
@@ -48,7 +49,7 @@ from ..recover import (
 )
 from ..tahoe import MemoryGrid, Tahoe, link, make_directory, upload
 from .fixtures import Treq
-from .matchers import matches_capability
+from .matchers import matches_capability, matches_float_within_distance
 from .resources import client_manager
 from .sql import Table, create_table, escape
 from .strategies import (
@@ -70,19 +71,39 @@ def snapshot(connection: Connection) -> Iterator[str]:
         yield statement + "\n"
 
 
+SQLType = Union[int, float, str, bytes, None]
+
+
 def equals_db(reference: Connection):
     """
     :return: A matcher for a SQLite3 connection to a database with the same
         state as the reference connection's database.
     """
 
-    def structured_dump(db):
+    # The implementation strategy here is motivated by the need to apply a
+    # custom floating point comparison function.  This means we can't just
+    # compare dumped SQL statement strings.  Instead of trying to parse the
+    # SQL statement strings to extract the floating point values, we dump the
+    # database ourselves without bothering to generate the SQL statement
+    # strings in the first place.  Then we can dig into the resulting values,
+    # notice floats, and compare them with our custom logic.
+    #
+    # We need custom logic to compare floats because SQLite3 bugs cause
+    # certain values not to round-trip through the database correctly.  This
+    # is a huge bummer!  Fortunately the error is small and does not
+    # accumulate.
+
+    def structured_dump(db: Connection) -> Iterator[Tuple]:
+        """
+        Dump the whole database, schema and rows, without trying to do any string
+        formatting.
+        """
         tables = list(structured_dump_tables(db))
         for (name, sql) in tables:
             yield sql
             yield from structured_dump_table(db, name)
 
-    def structured_dump_tables(db):
+    def structured_dump_tables(db: Connection) -> Iterator[Tuple[str, str]]:
         curs = db.cursor()
         curs.execute(
             """
@@ -94,7 +115,13 @@ def equals_db(reference: Connection):
         )
         yield from iter(curs)
 
-    def structured_dump_table(db, table_name):
+    def structured_dump_table(
+        db: Connection, table_name: str
+    ) -> Iterator[Tuple[str, str, Tuple[SQLType, ...]]]:
+        """
+        Dump a single database table's rows without trying to do any string
+        formatting.
+        """
         curs = db.cursor()
         curs.execute(f"PRAGMA table_info({escape(table_name)})")
 
@@ -115,51 +142,70 @@ def equals_db(reference: Connection):
 
     return AfterPreprocessing(
         lambda actual: list(structured_dump(actual)),
-        _EqualsEnough(list(structured_dump(reference))),
+        _MatchesDump(list(structured_dump(reference))),
     )
 
 
-class _EqualsEnough:
-    def __init__(self, reference):
-        self.reference = reference
+@define
+class _MatchStatement:
+    """
+    Match a single structured SQL statement.  Statements are tuples like those
+    that ``equals_db`` deals with, not actual SQL strings.
+    """
+
+    reference = field()
 
     def match(self, actual):
-        def compare_row(n, actual, reference):
-            if actual[:1] == ("INSERT",):
-                actual_name, actual_row = actual[1:]
-                reference_name, reference_row = reference[1:]
-                if actual_name != reference_name:
-                    return Mismatch(
-                        "Row {} table name {} != {}".format(
-                            n, actual_name, reference_name
-                        )
-                    )
-                if len(actual_row) != len(reference_row):
-                    return Mismatch(
-                        "Row {} length {} != {}".format(
-                            n, len(actual_row), len(reference_row)
-                        )
-                    )
-                for (actual_field, reference_field) in zip(actual_row, reference_row):
-                    if isinstance(actual_field, float):
-                        if abs(actual_field - reference_field) > (
-                            10 * float_info.epsilon
-                        ):
-                            return Mismatch(
-                                "Row {} float {} too far from reference {}".format(
-                                    n, actual_field, reference_field
-                                )
-                            )
-            else:
-                if actual != reference:
-                    return Mismatch(
-                        "Row {} fields {} != {}".format(n, actual, reference)
-                    )
+        def match_field(reference):
+            if not isinstance(reference, float):
+                return Equals(reference)
 
+            # We can't compare floats for exact equality, not for the usual
+            # reason but because of limitations of SQLite3's support for
+            # floats.  This is particularly bad on Windows.
+            #
+            # https://www.exploringbinary.com/incorrect-decimal-to-floating-point-conversion-in-sqlite/
+            # https://www.mail-archive.com/sqlite-users@mailinglists.sqlite.org/msg56817.html
+            # https://www.sqlite.org/src/tktview?name=1248e6cda8
+            return matches_float_within_distance(reference, 0)
+
+        if actual[:1] == ("INSERT",):
+            # Match an insert-type statement.
+            actual_name, actual_row = actual[1:]
+            reference_name, reference_row = self.reference[1:]
+            if actual_name != reference_name:
+                return Mismatch(
+                    f"table name {actual_name} != {reference_name}",
+                )
+            if len(actual_row) != len(reference_row):
+                return Mismatch(
+                    f"length {len(actual_row)} != {len(reference_row)}",
+                )
+            for (actual_field, reference_field) in zip(actual_row, reference_row):
+                matcher = match_field(reference_field)
+                mismatch = matcher.match(actual_field)
+                if mismatch is not None:
+                    return mismatch
+        else:
+            # Match a DDL statement
+            return Equals(self.reference).match(actual)
+
+
+@define
+class _MatchesDump:
+    """
+    Match a complete database dump's worth of structured SQL statements.
+    """
+
+    reference = field()
+
+    def match(self, actual):
         for n, (a, r) in enumerate(zip(actual, self.reference)):
-            mismatch = compare_row(n, a, r)
+            mismatch = Annotate(f"row {n}", _MatchStatement(r)).match(a)
             if mismatch is not None:
-                return mismatch
+                return
+
+        return None
 
 
 class SnapshotMachine(RuleBasedStateMachine):

--- a/src/_zkapauthorizer/tests/test_recover.py
+++ b/src/_zkapauthorizer/tests/test_recover.py
@@ -8,7 +8,7 @@ from typing import Dict, Iterator
 
 from allmydata.client import read_config
 from fixtures import TempDir
-from hypothesis import assume, given, note, settings
+from hypothesis import assume, given, note, reproduce_failure, settings
 from hypothesis.stateful import (
     RuleBasedStateMachine,
     invariant,
@@ -150,6 +150,9 @@ class StatefulRecoverTests(TestCase):
     Stateful tests for ``recover``.
     """
 
+    @reproduce_failure(
+        "6.37.0", b"AXicY2BkYGAAYxDBwAykmEAcRpAgM1gYpgIJHGSAKGZgAAALiwDc"
+    )
     def test_recover(self):
         """
         Test the snapshot/recovery system using ``SnapshotMachine``.

--- a/src/_zkapauthorizer/tests/test_recover.py
+++ b/src/_zkapauthorizer/tests/test_recover.py
@@ -233,9 +233,6 @@ class StatefulRecoverTests(TestCase):
     Stateful tests for ``recover``.
     """
 
-    @reproduce_failure(
-        "6.37.0", b"AXicY2BkYGAAYxDBwAykmEAcRpAgM1gYpgIJHGSAKGZgAAALiwDc"
-    )
     def test_recover(self):
         """
         Test the snapshot/recovery system using ``SnapshotMachine``.

--- a/src/_zkapauthorizer/tests/test_recover.py
+++ b/src/_zkapauthorizer/tests/test_recover.py
@@ -142,7 +142,9 @@ class _EqualsEnough:
                     )
                 for (actual_field, reference_field) in zip(actual_row, reference_row):
                     if isinstance(actual_field, float):
-                        if abs(actual_field - reference_field) > float_info.epsilon:
+                        if abs(actual_field - reference_field) > (
+                            10 * float_info.epsilon
+                        ):
                             return Mismatch(
                                 "Row {} float {} too far from reference {}".format(
                                     n, actual_field, reference_field

--- a/src/_zkapauthorizer/tests/test_recover.py
+++ b/src/_zkapauthorizer/tests/test_recover.py
@@ -9,7 +9,7 @@ from typing import Dict, Iterator, Tuple, Union
 from allmydata.client import read_config
 from attrs import define, field
 from fixtures import TempDir
-from hypothesis import assume, given, note, settings
+from hypothesis import assume, given, note, reproduce_failure, settings
 from hypothesis.stateful import (
     RuleBasedStateMachine,
     invariant,
@@ -279,6 +279,9 @@ class StatefulRecoverTests(TestCase):
     Stateful tests for ``recover``.
     """
 
+    @reproduce_failure(
+        "6.37.0", b"AXicY2BkYGAAYxDBwAykmEAcRpAgM1gYpgIJHGSAKGZgAAALiwDc"
+    )
     def test_recover(self):
         """
         Test the snapshot/recovery system using ``SnapshotMachine``.


### PR DESCRIPTION
Eventually this might help fix #310 .  Right now all it does is replace the SQL text comparison in the test suite with comparison of the underlying values, mostly without the SQL (the schema ddl is the exception).

This should enable use of a different floating point comparison logic which could allow the near-epsilon differences that seem to come up to pass through without failing the tests.  That part is not implemented yet.  I cannot reproduce these failures on Linux so I want to see some runs of this code on CI before proceeding.
