### PR TITLE
add an endpoint for enabling replication

### DIFF
--- a/src/_zkapauthorizer/_plugin.py
+++ b/src/_zkapauthorizer/_plugin.py
@@ -46,7 +46,7 @@ from .controller import get_redeemer
 from .lease_maintenance import SERVICE_NAME as MAINTENANCE_SERVICE_NAME
 from .lease_maintenance import lease_maintenance_service, maintain_leases_from_root
 from .model import VoucherStore
-from .recover import make_fail_downloader
+from .recover import fail_setup_replication, make_fail_downloader
 from .resource import from_configuration as resource_from_configuration
 from .server.spending import get_spender
 from .spending import SpendingController
@@ -189,10 +189,13 @@ class ZKAPAuthorizer(object):
                 )
             )
 
+        setup_replication = fail_setup_replication
+
         return resource_from_configuration(
             node_config,
             store=self._get_store(node_config),
             get_downloader=get_downloader,
+            setup_replication=setup_replication,
             redeemer=self._get_redeemer(node_config, None, reactor),
             clock=reactor,
         )

--- a/src/_zkapauthorizer/recover.py
+++ b/src/_zkapauthorizer/recover.py
@@ -40,6 +40,12 @@ class AlreadyRecovering(Exception):
     """
 
 
+class ReplicationAlreadySetup(Exception):
+    """
+    An attempt was made to setup of replication but it is already set up.
+    """
+
+
 class RecoveryStages(Enum):
     """
     Constants representing the different stages a recovery process may have
@@ -232,3 +238,10 @@ def get_tahoe_lafs_downloader(
         return downloader
 
     return get_downloader
+
+
+async def fail_setup_replication():
+    """
+    A replication setup function that always fails.
+    """
+    raise Exception("Test not set up for replication")

--- a/src/_zkapauthorizer/tests/matchers.py
+++ b/src/_zkapauthorizer/tests/matchers.py
@@ -26,6 +26,7 @@ __all__ = [
 ]
 
 from datetime import datetime
+from json import loads
 
 import attr
 from testtools.matchers import (
@@ -228,3 +229,21 @@ def matches_spent_passes(public_key_hash, spent_passes):
             }
         ),
     )
+
+
+def matches_json(matcher=Always()):
+    """
+    Return a matcher for a JSON string which can be decoded to an object
+    matched by the given matcher.
+    """
+
+    class Matcher:
+        def match(self, s):
+            try:
+                value = loads(s)
+            except Exception as e:
+                return Mismatch(f"Failed to decode {str(s)[:80]!r}: {e}")
+
+            return matcher.match(value)
+
+    return Matcher()


### PR DESCRIPTION
Relates to #235.  This adds the API that a client can use to enable the replication system and learn the recovery capability.  It is not hooked up to anything real yet.
