### PR TITLE
implement the replication setup function

### DIFF
--- a/src/_zkapauthorizer/config.py
+++ b/src/_zkapauthorizer/config.py
@@ -26,6 +26,10 @@ from twisted.python.filepath import FilePath
 from . import NAME
 from .lease_maintenance import LeaseMaintenanceConfig
 
+# The basename of the replica read-write capability file in the node's private
+# directory, if replication is configured.
+REPLICA_RWCAP_BASENAME = NAME + ".replica-rwcap"
+
 
 class _EmptyConfig(object):
     """

--- a/src/_zkapauthorizer/recover.py
+++ b/src/_zkapauthorizer/recover.py
@@ -20,8 +20,10 @@ from sqlite3 import Cursor
 from typing import BinaryIO, Callable, Dict, Iterator, Optional
 
 from attrs import define
+from twisted.python.lockfile import FilesystemLock
 
-from .tahoe import Tahoe
+from .config import REPLICA_RWCAP_BASENAME
+from .tahoe import Tahoe, attenuate_writecap
 
 
 class SnapshotMissing(Exception):
@@ -237,3 +239,40 @@ async def fail_setup_replication():
     A replication setup function that always fails.
     """
     raise Exception("Test not set up for replication")
+
+
+async def setup_tahoe_lafs_replication(client: Tahoe) -> Awaitable:
+    """
+    Configure the ZKAPAuthorizer plugin that lives in the Tahoe-LAFS node with
+    the given configuration to replicate its state onto Tahoe-LAFS storage
+    servers using that Tahoe-LAFS node.
+    """
+    # Find the configuration path for this node's replica.
+    config_path = client.get_private_path(REPLICA_RWCAP_BASENAME)
+
+    # Take an advisory lock on the configuration path to avoid concurrency
+    # shennanigans.
+    config_lock = FilesystemLock(config_path.path + ".lock")
+    config_lock.lock()
+    try:
+
+        # Check to see if there is already configuration.
+        if config_path.exists():
+            raise ReplicationAlreadySetup()
+
+        # Create a directory with it
+        rw_cap = await client.make_directory()
+
+        # Store the resulting write-cap in the node's private directory
+        config_path.setContent(rw_cap.encode("ascii"))
+
+    finally:
+        # On success and failure, release the lock since we're done with the
+        # file for now.
+        config_lock.unlock()
+
+    # Attenuate it to a read-cap
+    rocap = attenuate_writecap(rw_cap)
+
+    # Return the read-cap
+    return rocap

--- a/src/_zkapauthorizer/tahoe.py
+++ b/src/_zkapauthorizer/tahoe.py
@@ -317,6 +317,9 @@ class _MemoryTahoe:
     def _nodedir_default(self):
         return FilePath(mkdtemp(suffix=".memory-tahoe"))
 
+    def __attrs_post_init__(self):
+        self._nodedir.child("private").makedirs()
+
     def get_private_path(self, name: str) -> FilePath:
         """
         Get the path to a file in a private directory dedicated to this instance
@@ -333,3 +336,11 @@ class _MemoryTahoe:
 
     async def make_directory(self):
         return self._grid.make_directory()
+
+
+def attenuate_writecap(rw_cap: str) -> str:
+    """
+    Get a read-only capability corresponding to the same data as the given
+    read-write capability.
+    """
+    return capability_from_string(rw_cap).get_readonly().to_string().decode("ascii")

--- a/src/_zkapauthorizer/tahoe.py
+++ b/src/_zkapauthorizer/tahoe.py
@@ -10,6 +10,7 @@ from typing import Callable, Dict, Iterable, List, Optional
 
 import treq
 from allmydata.node import _Config
+from allmydata.uri import from_string as capability_from_string
 from allmydata.util.base32 import b2a as b32encode
 from attrs import Factory, define, field
 from hyperlink import DecodedURL

--- a/src/_zkapauthorizer/tests/matchers.py
+++ b/src/_zkapauthorizer/tests/matchers.py
@@ -247,3 +247,23 @@ def matches_json(matcher=Always()):
             return matcher.match(value)
 
     return Matcher()
+
+
+def matches_capability(type_matcher):
+    """
+    Return a matcher for a unicode string representing a Tahoe-LAFS capability
+    that has a type matched by ``type_matcher``.
+    """
+
+    def get_cap_type(cap: str) -> str:
+        if not isinstance(cap, str):
+            raise Exception(f"expected str cap, got {cap!r}")
+        pieces = cap.split(":")
+        if len(pieces) > 1 and pieces[0] == "URI":
+            return pieces[1]
+        return None
+
+    return AfterPreprocessing(
+        get_cap_type,
+        type_matcher,
+    )

--- a/src/_zkapauthorizer/tests/test_recover.py
+++ b/src/_zkapauthorizer/tests/test_recover.py
@@ -58,7 +58,6 @@ from .strategies import (
     tahoe_configs,
     updates,
 )
-from .test_client_resource import get_config_with_api_token
 
 
 def snapshot(connection: Connection) -> Iterator[str]:

--- a/src/_zkapauthorizer/tests/test_recover.py
+++ b/src/_zkapauthorizer/tests/test_recover.py
@@ -39,7 +39,7 @@ from ..recover import (
     noop_downloader,
     recover,
 )
-from ..tahoe import link, make_directory, upload
+from ..tahoe import Tahoe, link, make_directory, upload
 from .fixtures import Treq
 from .resources import client_manager
 from .sql import Table, create_table
@@ -316,7 +316,8 @@ class TahoeLAFSDownloaderTests(TestCase):
             )
         )
 
-        get_downloader = get_tahoe_lafs_downloader(httpclient, config)
+        tahoeclient = Tahoe(httpclient, config)
+        get_downloader = get_tahoe_lafs_downloader(tahoeclient)
         download = get_downloader(replica_dir_cap_str)
 
         downloaded_snapshot_path = yield Deferred.fromCoroutine(


### PR DESCRIPTION
This relates to #235.  It implements a function which will really configure a ZKAPAuthorizer-enabled Tahoe-LAFS node for replication.  This can be plugged in to the resource introduced by #315 (but it is not yet).
