### PR TITLE
Some Nix-based development environment amenities

### DIFF
--- a/requirements/elpy.in
+++ b/requirements/elpy.in
@@ -1,0 +1,4 @@
+# support elpy
+pip
+setuptools
+jedi

--- a/shell.nix
+++ b/shell.nix
@@ -18,6 +18,7 @@ let
     requirements =
       ''
       ${builtins.readFile ./requirements/test.in}
+      ${builtins.readFile ./requirements/elpy.in}
       ${zkapauthorizer.requirements}
       '';
   };

--- a/shell.nix
+++ b/shell.nix
@@ -27,6 +27,10 @@ pkgs.mkShell {
   # runs.
   PYTHONDONTWRITEBYTECODE = "1";
 
+  # Put this source tree into the Python import path, too, for a `setup.py
+  # develop`-like experience.
+  PYTHONPATH = "${builtins.toString ./.}/src";
+
   buildInputs = [
     # Supply all of the runtime and testing dependencies.
     python-env


### PR DESCRIPTION
This puts the source tree in the environment so `trial _zkapauthorizer` just works.  It also puts some elpy dependencies into the environment so elpy (emacs python support) can find various dev tools and automatically apply them to sources as they're edited.