### PR TITLE
Fix floating point comparisons in the recovery tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,11 +259,6 @@ workflows:
 
     # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
     - "macos-tests":
-        name: "macOS tests python 3.8 xcode 11.7.0"
-        py-version: "3.8"
-        xcode-version: "11.7.0"
-
-    - "macos-tests":
         name: "macOS tests python 3.9 xcode 12.3.0"
         py-version: "3.9"
         xcode-version: "12.3.0"

--- a/src/_zkapauthorizer/tests/_float_matchers.py
+++ b/src/_zkapauthorizer/tests/_float_matchers.py
@@ -49,6 +49,9 @@ class _MatchFloatWithinDistance(object):
     max_distance: int
 
     def match(self, actual):
+        if self.reference != actual:
+            return Mismatch(f"{self.reference} != {actual}")
+        return None
         try:
             distance = unit_of_least_precision_distance(
                 self.reference, actual, self.max_distance

--- a/src/_zkapauthorizer/tests/_float_matchers.py
+++ b/src/_zkapauthorizer/tests/_float_matchers.py
@@ -22,6 +22,12 @@ def unit_of_least_precision_distance(
         ** 64.  You probably want to limit the amount of work done to a much
         smaller distance.
     """
+    # Sometimes a value is exactly an integer and may come out of some system
+    # as an int instead of a float.  We can deal with that so let it through.
+    # Provide an early error for any other types, though.
+    if not isinstance(start, (int, float)) or not isinstance(goal, (int, float)):
+        raise TypeError(f"requires ints or floats, got {start!r} and {goal!r} instead")
+
     if isnan(start) or isnan(goal):
         raise ValueError("Cannot find distance to or from NaN")
 

--- a/src/_zkapauthorizer/tests/_float_matchers.py
+++ b/src/_zkapauthorizer/tests/_float_matchers.py
@@ -1,0 +1,87 @@
+from math import isnan, nextafter
+
+from attrs import define
+from testtools.matchers import Mismatch
+
+
+def unit_of_least_precision_distance(
+    start: float, goal: float, max_distance: int
+) -> int:
+    """
+    Compute the distance from ``start`` to ``goal`` in terms of floating point
+    "unit of least precision" ("ULP").
+
+    This is roughly how many floating point values there are between ``start``
+    and ``goal``.
+
+    :return: The distance.
+
+    :raise ValueError: If the distance is greater than ``max_distance``.  The
+        cost of the distance calculation is linear on the size of the distance
+        and the distance between two floating point values could be almost 2
+        ** 64.  You probably want to limit the amount of work done to a much
+        smaller distance.
+    """
+    if isnan(start) or isnan(goal):
+        raise ValueError("Cannot find distance to or from NaN")
+
+    if start == goal:
+        return 0
+
+    distance = 0
+    while distance < max_distance:
+        distance += 1
+        start = nextafter(start, goal)
+        if start == goal:
+            return distance
+
+    raise ValueError(f"{start} is more than {distance} from {goal}")
+
+
+@define
+class _MatchFloatWithinDistance(object):
+    """
+    See ``matches_float_within_distance``.
+    """
+
+    reference: float
+    distance: int
+    max_distance: int
+
+    def match(self, actual):
+        try:
+            distance = unit_of_least_precision_distance(
+                self.reference, actual, self.max_distance
+            )
+        except ValueError:
+            return Mismatch(
+                f"float {actual} is more than {self.max_distance} "
+                f"from {self.reference} - search abandoned "
+                f"(allowed distance is {self.distance})",
+            )
+        else:
+            if distance > self.distance:
+                return Mismatch(
+                    f"distance from {self.reference} "
+                    f"to {actual} "
+                    f"is {distance}, "
+                    f"greater than allowed distance of {self.distance}",
+                )
+        return None
+
+
+def matches_float_within_distance(
+    reference: float, distance: int, max_distance: int = 100
+):
+    """
+    Matches a floating point value that is no more than a given distance in
+    "unit of least precision" steps of a reference value.
+
+    :param reference: The reference floating point value.
+    :param distance: The maximum allowed distance to a matched value.
+
+    :param max_distance: The maximum distance to search (to try to provide
+        extra information when the match fails).
+    """
+
+    return _MatchFloatWithinDistance(reference, distance, max_distance)

--- a/src/_zkapauthorizer/tests/_float_matchers.py
+++ b/src/_zkapauthorizer/tests/_float_matchers.py
@@ -49,9 +49,6 @@ class _MatchFloatWithinDistance(object):
     max_distance: int
 
     def match(self, actual):
-        if self.reference != actual:
-            return Mismatch(f"{self.reference} != {actual}")
-        return None
         try:
             distance = unit_of_least_precision_distance(
                 self.reference, actual, self.max_distance

--- a/src/_zkapauthorizer/tests/_sql_matchers.py
+++ b/src/_zkapauthorizer/tests/_sql_matchers.py
@@ -110,7 +110,7 @@ class _MatchStatement:
             # https://www.exploringbinary.com/incorrect-decimal-to-floating-point-conversion-in-sqlite/
             # https://www.mail-archive.com/sqlite-users@mailinglists.sqlite.org/msg56817.html
             # https://www.sqlite.org/src/tktview?name=1248e6cda8
-            return matches_float_within_distance(reference, 2)
+            return matches_float_within_distance(reference, 3)
 
         if actual[:1] == ("INSERT",):
             if self.reference[:1] != ("INSERT",):

--- a/src/_zkapauthorizer/tests/_sql_matchers.py
+++ b/src/_zkapauthorizer/tests/_sql_matchers.py
@@ -1,0 +1,161 @@
+"""
+Testtools matchers related to SQL functionality.
+"""
+
+from sqlite3 import Connection
+from typing import Iterator, Tuple, Union
+
+from attrs import define, field
+from testtools.matchers import AfterPreprocessing, Annotate, Equals, Mismatch
+
+from ._float_matchers import matches_float_within_distance
+from .sql import escape
+
+SQLType = Union[int, float, str, bytes, None]
+
+
+def equals_database(reference: Connection):
+    """
+    :return: A matcher for a SQLite3 connection to a database with the same
+        state as the reference connection's database.
+    """
+
+    # The implementation strategy here is motivated by the need to apply a
+    # custom floating point comparison function.  This means we can't just
+    # compare dumped SQL statement strings.  Instead of trying to parse the
+    # SQL statement strings to extract the floating point values, we dump the
+    # database ourselves without bothering to generate the SQL statement
+    # strings in the first place.  Then we can dig into the resulting values,
+    # notice floats, and compare them with our custom logic.
+    #
+    # We need custom logic to compare floats because SQLite3 bugs cause
+    # certain values not to round-trip through the database correctly.  This
+    # is a huge bummer!  Fortunately the error is small and does not
+    # accumulate.
+
+    return AfterPreprocessing(
+        lambda actual: list(structured_dump(actual)),
+        _MatchesDump(list(structured_dump(reference))),
+    )
+
+
+def structured_dump(db: Connection) -> Iterator[Tuple]:
+    """
+    Dump the whole database, schema and rows, without trying to do any string
+    formatting.
+    """
+    tables = list(_structured_dump_tables(db))
+    for (name, sql) in tables:
+        yield sql
+        yield from _structured_dump_table(db, name)
+
+
+def _structured_dump_tables(db: Connection) -> Iterator[Tuple[str, str]]:
+    curs = db.cursor()
+    curs.execute(
+        """
+        SELECT [name], [sql]
+        FROM [sqlite_master]
+        WHERE [sql] NOT NULL and [type] == 'table'
+        ORDER BY [name]
+        """
+    )
+    yield from iter(curs)
+
+
+def _structured_dump_table(
+    db: Connection, table_name: str
+) -> Iterator[Tuple[str, str, Tuple[SQLType, ...]]]:
+    """
+    Dump a single database table's rows without trying to do any string
+    formatting.
+    """
+    curs = db.cursor()
+    curs.execute(f"PRAGMA table_info({escape(table_name)})")
+
+    columns = list(
+        (name, type_) for (cid, name, type_, notnull, dftl_value, pk) in list(curs)
+    )
+    column_names = ", ".join(escape(name) for (name, type_) in columns)
+    curs.execute(
+        f"""
+        SELECT {column_names}
+        FROM {escape(table_name)}
+        """
+    )
+
+    for rows in iter(lambda: curs.fetchmany(1024), []):
+        for row in rows:
+            yield "INSERT", table_name, row
+
+
+@define
+class _MatchStatement:
+    """
+    Match a single structured SQL statement.  Statements are tuples like those
+    that ``equals_db`` deals with, not actual SQL strings.
+    """
+
+    reference = field()
+
+    def match(self, actual):
+        def match_field(reference):
+            if not isinstance(reference, float):
+                return Equals(reference)
+
+            # We can't compare floats for exact equality, not for the usual
+            # reason but because of limitations of SQLite3's support for
+            # floats.  This is particularly bad on Windows.
+            #
+            # https://www.exploringbinary.com/incorrect-decimal-to-floating-point-conversion-in-sqlite/
+            # https://www.mail-archive.com/sqlite-users@mailinglists.sqlite.org/msg56817.html
+            # https://www.sqlite.org/src/tktview?name=1248e6cda8
+            return matches_float_within_distance(reference, 0)
+
+        if actual[:1] == ("INSERT",):
+            if self.reference[:1] != ("INSERT",):
+                return Mismatch(
+                    f"{actual} != {self.reference}",
+                )
+            # Match an insert-type statement.
+            actual_name, actual_row = actual[1:]
+            reference_name, reference_row = self.reference[1:]
+            if actual_name != reference_name:
+                return Mismatch(
+                    f"table name {actual_name} != {reference_name}",
+                )
+            if len(actual_row) != len(reference_row):
+                return Mismatch(
+                    f"length {len(actual_row)} != {len(reference_row)}",
+                )
+            for (actual_field, reference_field) in zip(actual_row, reference_row):
+                matcher = match_field(reference_field)
+                mismatch = matcher.match(actual_field)
+                if mismatch is not None:
+                    return mismatch
+        else:
+            # Match a DDL statement
+            return Equals(self.reference).match(actual)
+
+
+@define
+class _MatchesDump:
+    """
+    Match a complete database dump's worth of structured SQL statements.
+    """
+
+    reference = field()
+
+    def match(self, actual):
+        for n, (a, r) in enumerate(zip(actual, self.reference)):
+            mismatch = Annotate(f"row {n}", _MatchStatement(r)).match(a)
+            if mismatch is not None:
+                return mismatch
+
+        if len(actual) != len(self.reference):
+            return Mismatch(
+                f"reference has {len(self.reference)} items; "
+                f"actual as {len(actual)} items",
+            )
+
+        return None

--- a/src/_zkapauthorizer/tests/_sql_matchers.py
+++ b/src/_zkapauthorizer/tests/_sql_matchers.py
@@ -110,7 +110,7 @@ class _MatchStatement:
             # https://www.exploringbinary.com/incorrect-decimal-to-floating-point-conversion-in-sqlite/
             # https://www.mail-archive.com/sqlite-users@mailinglists.sqlite.org/msg56817.html
             # https://www.sqlite.org/src/tktview?name=1248e6cda8
-            return matches_float_within_distance(reference, 1)
+            return matches_float_within_distance(reference, 2)
 
         if actual[:1] == ("INSERT",):
             if self.reference[:1] != ("INSERT",):

--- a/src/_zkapauthorizer/tests/_sql_matchers.py
+++ b/src/_zkapauthorizer/tests/_sql_matchers.py
@@ -107,7 +107,11 @@ def _get_matcher(reference, actual):
         # https://www.exploringbinary.com/incorrect-decimal-to-floating-point-conversion-in-sqlite/
         # https://www.mail-archive.com/sqlite-users@mailinglists.sqlite.org/msg56817.html
         # https://www.sqlite.org/src/tktview?name=1248e6cda8
-        return matches_float_within_distance(reference, 4)
+        #
+        # Our test suite knows about values that round-trip with an error of
+        # as much as 6 ULPs on Windows.  In case there are even worse cases,
+        # we'll allow somewhat more error than that.
+        return matches_float_within_distance(reference, 10)
     return Equals(reference)
 
 

--- a/src/_zkapauthorizer/tests/_sql_matchers.py
+++ b/src/_zkapauthorizer/tests/_sql_matchers.py
@@ -34,14 +34,9 @@ def equals_database(reference: Connection):
     # accumulate.
 
     return AfterPreprocessing(
-        lambda actual: list(actual.iterdump()),
-        Equals(list(reference.iterdump())),
+        lambda actual: list(structured_dump(actual)),
+        _MatchesDump(list(structured_dump(reference))),
     )
-
-    # return AfterPreprocessing(
-    #     lambda actual: list(structured_dump(actual)),
-    #     _MatchesDump(list(structured_dump(reference))),
-    # )
 
 
 def structured_dump(db: Connection) -> Iterator[Tuple]:

--- a/src/_zkapauthorizer/tests/_sql_matchers.py
+++ b/src/_zkapauthorizer/tests/_sql_matchers.py
@@ -34,9 +34,14 @@ def equals_database(reference: Connection):
     # accumulate.
 
     return AfterPreprocessing(
-        lambda actual: list(structured_dump(actual)),
-        _MatchesDump(list(structured_dump(reference))),
+        lambda actual: list(actual.iterdump()),
+        Equals(list(reference.iterdump())),
     )
+
+    # return AfterPreprocessing(
+    #     lambda actual: list(structured_dump(actual)),
+    #     _MatchesDump(list(structured_dump(reference))),
+    # )
 
 
 def structured_dump(db: Connection) -> Iterator[Tuple]:

--- a/src/_zkapauthorizer/tests/_sql_matchers.py
+++ b/src/_zkapauthorizer/tests/_sql_matchers.py
@@ -110,7 +110,7 @@ class _MatchStatement:
             # https://www.exploringbinary.com/incorrect-decimal-to-floating-point-conversion-in-sqlite/
             # https://www.mail-archive.com/sqlite-users@mailinglists.sqlite.org/msg56817.html
             # https://www.sqlite.org/src/tktview?name=1248e6cda8
-            return matches_float_within_distance(reference, 0)
+            return matches_float_within_distance(reference, 1)
 
         if actual[:1] == ("INSERT",):
             if self.reference[:1] != ("INSERT",):

--- a/src/_zkapauthorizer/tests/_sql_matchers.py
+++ b/src/_zkapauthorizer/tests/_sql_matchers.py
@@ -107,7 +107,7 @@ def _get_matcher(reference, actual):
         # https://www.exploringbinary.com/incorrect-decimal-to-floating-point-conversion-in-sqlite/
         # https://www.mail-archive.com/sqlite-users@mailinglists.sqlite.org/msg56817.html
         # https://www.sqlite.org/src/tktview?name=1248e6cda8
-        return matches_float_within_distance(reference, 3)
+        return matches_float_within_distance(reference, 4)
     return Equals(reference)
 
 

--- a/src/_zkapauthorizer/tests/matchers.py
+++ b/src/_zkapauthorizer/tests/matchers.py
@@ -23,6 +23,7 @@ __all__ = [
     "matches_version_dictionary",
     "between",
     "leases_current",
+    "equals_database",
     "matches_float_within_distance",
 ]
 
@@ -53,6 +54,7 @@ from ..model import Pass
 from ..server.spending import _SpendingData
 from ._exception import raises
 from ._float_matchers import matches_float_within_distance
+from ._sql_matchers import equals_database
 
 
 @attr.s

--- a/src/_zkapauthorizer/tests/matchers.py
+++ b/src/_zkapauthorizer/tests/matchers.py
@@ -23,14 +23,13 @@ __all__ = [
     "matches_version_dictionary",
     "between",
     "leases_current",
+    "matches_float_within_distance",
 ]
 
 from datetime import datetime
 from json import loads
-from math import isnan, nextafter
 
 import attr
-from attrs import define
 from testtools.matchers import (
     AfterPreprocessing,
     AllMatch,
@@ -53,6 +52,7 @@ from treq import content
 from ..model import Pass
 from ..server.spending import _SpendingData
 from ._exception import raises
+from ._float_matchers import matches_float_within_distance
 
 
 @attr.s
@@ -269,86 +269,3 @@ def matches_capability(type_matcher):
         get_cap_type,
         type_matcher,
     )
-
-
-def unit_of_least_precision_distance(
-    start: float, goal: float, max_distance: int
-) -> int:
-    """
-    Compute the distance from ``start`` to ``goal`` in terms of floating point
-    "unit of least precision" ("ULP").
-
-    This is roughly how many floating point values there are between ``start``
-    and ``goal``.
-
-    :return: The distance.
-
-    :raise ValueError: If the distance is greater than ``max_distance``.  The
-        cost of the distance calculation is linear on the size of the distance
-        and the distance between two floating point values could be almost 2
-        ** 64.  You probably want to limit the amount of work done to a much
-        smaller distance.
-    """
-    if isnan(start) or isnan(goal):
-        raise ValueError("Cannot find distance to or from NaN")
-
-    if start == goal:
-        return 0
-
-    distance = 0
-    while distance < max_distance:
-        distance += 1
-        start = nextafter(start, goal)
-        if start == goal:
-            return distance
-
-    raise ValueError(f"{start} is more than {distance} from {goal}")
-
-
-@define
-class _MatchFloatWithinDistance(object):
-    """
-    See ``matches_float_within_distance``.
-    """
-
-    reference: float
-    distance: int
-    max_distance: int
-
-    def match(self, actual):
-        try:
-            distance = unit_of_least_precision_distance(
-                self.reference, actual, self.max_distance
-            )
-        except ValueError:
-            return Mismatch(
-                f"float {actual} is more than {self.max_distance} "
-                f"from {self.reference} - search abandoned "
-                f"(allowed distance is {self.distance})",
-            )
-        else:
-            if distance > self.distance:
-                return Mismatch(
-                    f"distance from {self.reference} "
-                    f"to {actual} "
-                    f"is {distance}, "
-                    f"greater than allowed distance of {self.distance}",
-                )
-        return None
-
-
-def matches_float_within_distance(
-    reference: float, distance: int, max_distance: int = 100
-):
-    """
-    Matches a floating point value that is no more than a given distance in
-    "unit of least precision" steps of a reference value.
-
-    :param reference: The reference floating point value.
-    :param distance: The maximum allowed distance to a matched value.
-
-    :param max_distance: The maximum distance to search (to try to provide
-        extra information when the match fails).
-    """
-
-    return _MatchFloatWithinDistance(reference, distance, max_distance)

--- a/src/_zkapauthorizer/tests/matchers.py
+++ b/src/_zkapauthorizer/tests/matchers.py
@@ -27,8 +27,10 @@ __all__ = [
 
 from datetime import datetime
 from json import loads
+from math import isnan, nextafter
 
 import attr
+from attrs import define
 from testtools.matchers import (
     AfterPreprocessing,
     AllMatch,
@@ -267,3 +269,86 @@ def matches_capability(type_matcher):
         get_cap_type,
         type_matcher,
     )
+
+
+def unit_of_least_precision_distance(
+    start: float, goal: float, max_distance: int
+) -> int:
+    """
+    Compute the distance from ``start`` to ``goal`` in terms of floating point
+    "unit of least precision" ("ULP").
+
+    This is roughly how many floating point values there are between ``start``
+    and ``goal``.
+
+    :return: The distance.
+
+    :raise ValueError: If the distance is greater than ``max_distance``.  The
+        cost of the distance calculation is linear on the size of the distance
+        and the distance between two floating point values could be almost 2
+        ** 64.  You probably want to limit the amount of work done to a much
+        smaller distance.
+    """
+    if isnan(start) or isnan(goal):
+        raise ValueError("Cannot find distance to or from NaN")
+
+    if start == goal:
+        return 0
+
+    distance = 0
+    while distance < max_distance:
+        distance += 1
+        start = nextafter(start, goal)
+        if start == goal:
+            return distance
+
+    raise ValueError(f"{start} is more than {distance} from {goal}")
+
+
+@define
+class _MatchFloatWithinDistance(object):
+    """
+    See ``matches_float_within_distance``.
+    """
+
+    reference: float
+    distance: int
+    max_distance: int
+
+    def match(self, actual):
+        try:
+            distance = unit_of_least_precision_distance(
+                self.reference, actual, self.max_distance
+            )
+        except ValueError:
+            return Mismatch(
+                f"float {actual} is more than {self.max_distance} "
+                f"from {self.reference} - search abandoned "
+                f"(allowed distance is {self.distance})",
+            )
+        else:
+            if distance > self.distance:
+                return Mismatch(
+                    f"distance from {self.reference} "
+                    f"to {actual} "
+                    f"is {distance}, "
+                    f"greater than allowed distance of {self.distance}",
+                )
+        return None
+
+
+def matches_float_within_distance(
+    reference: float, distance: int, max_distance: int = 100
+):
+    """
+    Matches a floating point value that is no more than a given distance in
+    "unit of least precision" steps of a reference value.
+
+    :param reference: The reference floating point value.
+    :param distance: The maximum allowed distance to a matched value.
+
+    :param max_distance: The maximum distance to search (to try to provide
+        extra information when the match fails).
+    """
+
+    return _MatchFloatWithinDistance(reference, distance, max_distance)

--- a/src/_zkapauthorizer/tests/strategies.py
+++ b/src/_zkapauthorizer/tests/strategies.py
@@ -1243,6 +1243,18 @@ _sql_integer = integers(min_value=-(2 ** 63) + 1, max_value=2 ** 63 - 1)
 # https://www.sqlite.org/floatingpoint.html
 _sql_floats = floats(allow_infinity=False, allow_nan=False, width=32)
 
+# Exclude surrogates because SQLite3 uses UTF-8 and we don't need them.  Also
+# they have to come in correctly formed pairs to be legal anyway and it's
+# inconvenient to do that with text.
+#
+# Exclude nul characters because SQLite3 only sort of supports them.  You may
+# insert nul characters but don't expect to be able to read them or anything
+# following them back.
+# https://sqlite.org/nulinstr.html
+_sql_text = text(
+    alphabet=characters(blacklist_categories={"Cs"}, blacklist_characters={"\0"})
+)
+
 # Here's how you can build values that match certain storage type affinities.
 # SQLite3 will actually allow us to store values of any type in any column but
 # it might coerce certain values based on the column affinity.  This means,
@@ -1254,7 +1266,7 @@ _sql_floats = floats(allow_infinity=False, allow_nan=False, width=32)
 # all very well tested inside SQLite3 itself.
 _storage_affinity_strategies = {
     StorageAffinity.INT: _sql_integer,
-    StorageAffinity.TEXT: text(),
+    StorageAffinity.TEXT: _sql_text,
     StorageAffinity.BLOB: binary(),
     StorageAffinity.REAL: _sql_floats,
     StorageAffinity.NUMERIC: one_of(_sql_integer, _sql_floats),

--- a/src/_zkapauthorizer/tests/strategies.py
+++ b/src/_zkapauthorizer/tests/strategies.py
@@ -1232,16 +1232,10 @@ def sql_schemas(dict_kwargs=None) -> SearchStrategy[Dict[str, Table]]:
 _sql_integer = integers(min_value=-(2 ** 63) + 1, max_value=2 ** 63 - 1)
 
 # SQLite3 can do infinity and NaN but I don't know how to get them through the
-# Python interface.  SQLite3 can do 64 bit floats but it only guarantees 15
-# digits of precision (maybe only for its base 10 string representations?)
-# which causes values requiring greater precision to fail to round-trip.  The
-# SQLite3 docs are quite clear about what one should expect from floating
-# point values, anyway:
-#
-#    Floating point values are approximate.
+# Python interface.
 #
 # https://www.sqlite.org/floatingpoint.html
-_sql_floats = floats(allow_infinity=False, allow_nan=False, width=32)
+_sql_floats = floats(allow_infinity=False, allow_nan=False, width=64)
 
 # Exclude surrogates because SQLite3 uses UTF-8 and we don't need them.  Also
 # they have to come in correctly formed pairs to be legal anyway and it's

--- a/src/_zkapauthorizer/tests/strategies.py
+++ b/src/_zkapauthorizer/tests/strategies.py
@@ -19,7 +19,7 @@ Hypothesis strategies for property testing.
 from base64 import b64encode, urlsafe_b64encode
 from datetime import datetime, timedelta
 from functools import partial
-from typing import List
+from typing import Dict, List
 from urllib.parse import quote
 
 import attr
@@ -1216,6 +1216,15 @@ def tables() -> SearchStrategy[Table]:
             unique_by=lambda x: x[0],
         ),
     )
+
+
+def sql_schemas(dict_kwargs=None) -> SearchStrategy[Dict[str, Table]]:
+    """
+    Build objects describing multiple tables in a SQLite3 database.
+    """
+    if dict_kwargs is None:
+        dict_kwargs = {}
+    return dictionaries(keys=sql_identifiers(), values=tables(), **dict_kwargs)
 
 
 # Python has unbounded integers but SQLite3 integers must fall into this

--- a/src/_zkapauthorizer/tests/test_matchers.py
+++ b/src/_zkapauthorizer/tests/test_matchers.py
@@ -375,11 +375,32 @@ class EqualsDatabase(TestCase):
     # let's help it keep an eye on them in the future, too.
     @_float_example(
         [
+            # Some examples our CI found
             1.311946107307449e-10,
             1.1466443538665771e-05,
             1.500589370727539,
             1125899906842624.0,
             5.192298096474867e33,
+        ]
+    )
+    @_float_example(
+        [
+            # Examples from Rick Regan's blog post that are broken on Windows.
+            1e-23,
+            8.533e68,
+            4.1006e-184,
+            9.998e307,
+            9.9538452227e-280,
+            6.47660115e-260,
+        ]
+    )
+    @_float_example(
+        [
+            # Examples from Rick Regan's blog post that are broken on Linux.
+            7.4e47,
+            5.92e48,
+            7.35e66,
+            8.32116e55,
         ]
     )
     def test_same_rows(self, schema_and_common):

--- a/src/_zkapauthorizer/tests/test_matchers.py
+++ b/src/_zkapauthorizer/tests/test_matchers.py
@@ -400,6 +400,7 @@ class EqualsDatabase(TestCase):
     @_float_example(
         [
             # Examples from Rick Regan's blog post that are broken on Windows.
+            # https://www.exploringbinary.com/incorrect-decimal-to-floating-point-conversion-in-sqlite/
             1e-23,
             8.533e68,
             4.1006e-184,

--- a/src/_zkapauthorizer/tests/test_matchers.py
+++ b/src/_zkapauthorizer/tests/test_matchers.py
@@ -393,6 +393,8 @@ class EqualsDatabase(TestCase):
             5.192298096474867e33,
             # This one has a distance of 3
             -1.1919735848895067e-35,
+            # This one has a distance of 4
+            1.4958557609758284e-299,
         ]
     )
     @_float_example(

--- a/src/_zkapauthorizer/tests/test_matchers.py
+++ b/src/_zkapauthorizer/tests/test_matchers.py
@@ -395,6 +395,10 @@ class EqualsDatabase(TestCase):
             -1.1919735848895067e-35,
             # This one has a distance of 4
             1.4958557609758284e-299,
+            # This one has a distance of 5
+            1.8691612083773865e-299,
+            # This one has a distance of 6
+            5.9678062582405806e-300,
         ]
     )
     @_float_example(

--- a/src/_zkapauthorizer/tests/test_matchers.py
+++ b/src/_zkapauthorizer/tests/test_matchers.py
@@ -247,7 +247,7 @@ class MatchFloatWithinDistanceTests(TestCase):
         )
 
 
-def _float_example(f):
+def _float_example(fs):
     """
     Help create Hypothesis examples for certain floating point cases.
     """
@@ -255,7 +255,7 @@ def _float_example(f):
     return example(
         (
             {"0": t},
-            {"0": [Insert("0", t, (f,))]},
+            {"0": [Insert("0", t, (f,)) for f in fs]},
         )
     )
 
@@ -364,10 +364,15 @@ class EqualsDatabase(TestCase):
     )
     # Add some known problematic cases.  Hypothesis found these originally but
     # let's help it keep an eye on them in the future, too.
-    @_float_example(1.12589990684262408748e15)
-    @_float_example(1.12589990684262430953e15)
-    @_float_example(1.31194610730744920523e-10)
-    @_float_example(1.31194610730744898319e-10)
+    @_float_example(
+        [
+            1.311946107307449e-10,
+            1.1466443538665771e-05,
+            1.500589370727539,
+            1125899906842624.0,
+            5.192298096474867e33,
+        ]
+    )
     def test_same_rows(self, schema_and_common):
         """
         Two databases with the same schema and the same rows in their tables

--- a/src/_zkapauthorizer/tests/test_matchers.py
+++ b/src/_zkapauthorizer/tests/test_matchers.py
@@ -265,6 +265,16 @@ def copy(src_db: Connection) -> Connection:
     Return an in-memory SQLite3 database that is a copy of the given database.
     """
     db = connect(":memory:")
+    # This round-trips all of the data through strings (in the form of SQL
+    # statements with literal rather than bound arguments).  This is like what
+    # we do in the actual replica/recovery system so we do it here, too.  It
+    # is the source of some error in floating point values on Windows so we
+    # also go to a lot of effort to account for those errors in the test suite
+    # - but we don't actually correct them.
+    #
+    # Anyway, if we switched away from a textual replica format then we could
+    # stop round-tripping through strings like this and drop a lot of
+    # complexity related to fudging minor floating point imprecision.
     list(map(db.execute, src_db.iterdump()))
     return db
 

--- a/src/_zkapauthorizer/tests/test_matchers.py
+++ b/src/_zkapauthorizer/tests/test_matchers.py
@@ -366,6 +366,8 @@ class EqualsDatabase(TestCase):
     # let's help it keep an eye on them in the future, too.
     @_float_example(1.12589990684262408748e15)
     @_float_example(1.12589990684262430953e15)
+    @_float_example(1.31194610730744920523e-10)
+    @_float_example(1.31194610730744898319e-10)
     def test_same_rows(self, schema_and_common):
         """
         Two databases with the same schema and the same rows in their tables

--- a/src/_zkapauthorizer/tests/test_matchers.py
+++ b/src/_zkapauthorizer/tests/test_matchers.py
@@ -391,6 +391,8 @@ class EqualsDatabase(TestCase):
             1.500589370727539,
             1125899906842624.0,
             5.192298096474867e33,
+            # This one has a distance of 3
+            -1.1919735848895067e-35,
         ]
     )
     @_float_example(

--- a/src/_zkapauthorizer/tests/test_recover.py
+++ b/src/_zkapauthorizer/tests/test_recover.py
@@ -145,12 +145,12 @@ class SnapshotMachine(RuleBasedStateMachine):
                 self.connection.execute(statement, args)
 
 
-class StatefulRecoverTests(TestCase):
+class RecoverTests(TestCase):
     """
-    Stateful tests for ``recover``.
+    Tests for ``recover``.
     """
 
-    def test_recover(self):
+    def test_stateful(self):
         """
         Test the snapshot/recovery system using ``SnapshotMachine``.
         """

--- a/src/_zkapauthorizer/tests/test_recover.py
+++ b/src/_zkapauthorizer/tests/test_recover.py
@@ -8,7 +8,7 @@ from typing import Dict, Iterator
 
 from allmydata.client import read_config
 from fixtures import TempDir
-from hypothesis import assume, given, note, settings
+from hypothesis import assume, given, note, reproduce_failure, settings
 from hypothesis.stateful import (
     RuleBasedStateMachine,
     invariant,
@@ -150,6 +150,9 @@ class StatefulRecoverTests(TestCase):
     Stateful tests for ``recover``.
     """
 
+    @reproduce_failure(
+        "6.37.0", b"AXicY2BkYGAAYxDBwAykmEAcRpAgM1gYpgIJHGSAKGZgAAALiwDc"
+    )
     def test_recover(self):
         """
         Test the snapshot/recovery system using ``SnapshotMachine``.

--- a/src/_zkapauthorizer/tests/test_recover.py
+++ b/src/_zkapauthorizer/tests/test_recover.py
@@ -8,7 +8,7 @@ from typing import Dict, Iterator
 
 from allmydata.client import read_config
 from fixtures import TempDir
-from hypothesis import assume, given, note, reproduce_failure, settings
+from hypothesis import assume, given, note, settings
 from hypothesis.stateful import (
     RuleBasedStateMachine,
     invariant,
@@ -150,9 +150,6 @@ class StatefulRecoverTests(TestCase):
     Stateful tests for ``recover``.
     """
 
-    @reproduce_failure(
-        "6.37.0", b"AXicY2BkYGAAYxDBwAykmEAcRpAgM1gYpgIJHGSAKGZgAAALiwDc"
-    )
     def test_recover(self):
         """
         Test the snapshot/recovery system using ``SnapshotMachine``.

--- a/src/_zkapauthorizer/tests/test_recover.py
+++ b/src/_zkapauthorizer/tests/test_recover.py
@@ -46,7 +46,7 @@ from ..recover import (
 )
 from ..tahoe import MemoryGrid, Tahoe, link, make_directory, upload
 from .fixtures import Treq
-from .matchers import matches_capability
+from .matchers import equals_database, matches_capability
 from .resources import client_manager
 from .sql import Table, create_table
 from .strategies import (
@@ -66,17 +66,6 @@ def snapshot(connection: Connection) -> Iterator[str]:
     """
     for statement in connection.iterdump():
         yield statement + "\n"
-
-
-def equals_db(reference: Connection):
-    """
-    :return: A matcher for a SQLite3 connection to a database with the same
-        state as the reference connection's database.
-    """
-    return AfterPreprocessing(
-        lambda actual: list(actual.iterdump()),
-        Equals(list(reference.iterdump())),
-    )
 
 
 class SnapshotMachine(RuleBasedStateMachine):
@@ -103,7 +92,7 @@ class SnapshotMachine(RuleBasedStateMachine):
         recover(statements, new)
         self.case.assertThat(
             new,
-            equals_db(reference=self.connection),
+            equals_database(reference=self.connection),
             "source (reference) database iterdump does not equal "
             "sink (actual) database iterdump",
         )


### PR DESCRIPTION
Fixes #310 

This is like #312 but also adds custom floating point comparison logic which will *allow* the small floating point corruption that SQLite3 introduces in `iterdump` to pass without failing the tests.

Surely this is not as good as avoiding the corruption in the first place but I think that involves designing and using a binary floating point format to replace the `iterdump` format.  We can do that some other time, I guess.
