### PR TITLE
update to python 3.9 syntax for type annotations

### DIFF
--- a/requirements/test.in
+++ b/requirements/test.in
@@ -13,3 +13,8 @@ black == 21.12b0
 flake8 == 4.0.1
 flake8-isort
 flake8-black
+
+
+# the type shed...
+types-cryptography
+types-PyYAML

--- a/src/_zkapauthorizer/_plugin.py
+++ b/src/_zkapauthorizer/_plugin.py
@@ -20,7 +20,7 @@ Tahoe-LAFS.
 import random
 from datetime import datetime
 from functools import partial
-from typing import Callable, List
+from typing import Callable
 from weakref import WeakValueDictionary
 
 from allmydata.client import _Client
@@ -324,7 +324,7 @@ _SERVICES = [
 ]
 
 
-def get_root_nodes(client_node, node_config) -> List[IFilesystemNode]:
+def get_root_nodes(client_node, node_config) -> list[IFilesystemNode]:
     """
     Get the configured starting points for lease maintenance traversal.
     """

--- a/src/_zkapauthorizer/_plugin.py
+++ b/src/_zkapauthorizer/_plugin.py
@@ -201,8 +201,9 @@ class ZKAPAuthorizer(object):
         )
 
 
-def make_safe_writer(metrics_path, registry):
-    # type: (str, CollectorRegistry) -> Callable[[], None]
+def make_safe_writer(
+    metrics_path: str, registry: CollectorRegistry
+) -> Callable[[], None]:
     """
     Make a no-argument callable that writes metrics from the given registry to
     the given path.  The callable will log errors writing to the path and not

--- a/src/_zkapauthorizer/_storage_client.py
+++ b/src/_zkapauthorizer/_storage_client.py
@@ -21,7 +21,7 @@ implemented in ``_storage_server.py``.
 """
 
 from functools import partial, wraps
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 import attr
 from allmydata.interfaces import IStorageServer
@@ -45,20 +45,20 @@ from .storage_common import (
     slot_testv_and_readv_and_writev_message,
 )
 
-Secrets = Tuple[bytes, bytes, bytes]
-TestWriteVectors = Dict[
+Secrets = tuple[bytes, bytes, bytes]
+TestWriteVectors = dict[
     int,
-    Tuple[
-        List[
-            Tuple[int, int, bytes, bytes],
+    tuple[
+        list[
+            tuple[int, int, bytes, bytes],
         ],
-        List[
-            Tuple[int, bytes],
+        list[
+            tuple[int, bytes],
         ],
         Optional[int],
     ],
 ]
-ReadVector = List[Tuple[int, int]]
+ReadVector = list[tuple[int, int]]
 
 
 class IncorrectStorageServerReference(Exception):

--- a/src/_zkapauthorizer/_storage_server.py
+++ b/src/_zkapauthorizer/_storage_server.py
@@ -428,8 +428,9 @@ class ZKAPAuthorizerStorageServer(Referenceable):
                 get_share_sizes(self._original, storage_index_or_slot, sharenums)
             )
 
-    def remote_stat_shares(self, storage_indexes_or_slots):
-        # type: (List[bytes]) -> List[Dict[int, ShareStat]]
+    def remote_stat_shares(
+        self, storage_indexes_or_slots: List[bytes]
+    ) -> List[Dict[int, ShareStat]]:
         return list(
             dict(get_share_stats(self._original, storage_index_or_slot, None))
             for storage_index_or_slot in storage_indexes_or_slots
@@ -588,9 +589,11 @@ def check_pass_quantity(pass_value, validation, share_sizes):
 
 
 def check_pass_quantity_for_lease(
-    pass_value, storage_index, validation, storage_server
-):
-    # type: (int, bytes, _ValidationResult, ZKAPAuthorizerStorageServer) -> Dict[int, int]
+    pass_value: int,
+    storage_index: bytes,
+    validation: _ValidationResult,
+    storage_server: ZKAPAuthorizerStorageServer,
+) -> Dict[int, int]:
     """
     Check that the given number of passes is sufficient to add or renew a
     lease for one period for the given storage index.
@@ -811,8 +814,7 @@ def stat_slot(storage_server, slot, sharepath):
     )
 
 
-def get_lease_expiration(sharepath):
-    # type: (str) -> Optional[int]
+def get_lease_expiration(sharepath: str) -> Optional[int]:
     """
     Get the latest lease expiration time for the share at the given path, or
     ``None`` if there are no leases on it.
@@ -892,8 +894,9 @@ def add_leases_for_writev(storage_server, storage_index, secrets, tw_vectors, no
             )
 
 
-def get_share_path(storage_server, storage_index, sharenum):
-    # type: (StorageServer, bytes, int) -> FilePath
+def get_share_path(
+    storage_server: StorageServer, storage_index: bytes, sharenum: int
+) -> FilePath:
     """
     Get the path to the given storage server's storage for the given share.
     """
@@ -904,8 +907,9 @@ def get_share_path(storage_server, storage_index, sharenum):
     )
 
 
-def share_has_active_leases(storage_server, storage_index, sharenum, now):
-    # type: (StorageServer, bytes, int, float) -> bool
+def share_has_active_leases(
+    storage_server: StorageServer, storage_index: bytes, sharenum: int, now: float
+) -> bool:
     """
     Determine whether the given share on the given server has an unexpired
     lease or not.
@@ -918,8 +922,13 @@ def share_has_active_leases(storage_server, storage_index, sharenum, now):
     return any(lease.get_expiration_time() > now for lease in share.get_leases())
 
 
-def get_writev_price(storage_server, pass_value, storage_index, tw_vectors, now):
-    # type: (StorageServer, int, bytes, TestAndWriteVectorsForShares, float) -> int
+def get_writev_price(
+    storage_server: StorageServer,
+    pass_value: int,
+    storage_index: bytes,
+    tw_vectors: TestAndWriteVectorsForShares,
+    now: float,
+) -> int:
     """
     Determine the price to execute the given test/write vectors.
     """

--- a/src/_zkapauthorizer/_storage_server.py
+++ b/src/_zkapauthorizer/_storage_server.py
@@ -27,7 +27,7 @@ from functools import partial
 from os import listdir, stat
 from os.path import join
 from struct import calcsize, unpack
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 import attr
 from allmydata.interfaces import TestAndWriteVectorsForShares
@@ -212,8 +212,8 @@ class ZKAPAuthorizerStorageServer(Referenceable):
     )
     _public_key = attr.ib(init=False)
     _metric_spending_successes = attr.ib(init=False)
-    _bucket_writer_disconnect_markers: Dict[
-        BucketWriter, Tuple[IRemoteReference, Any]
+    _bucket_writer_disconnect_markers: dict[
+        BucketWriter, tuple[IRemoteReference, Any]
     ] = attr.ib(
         init=False,
         default=attr.Factory(dict),
@@ -429,8 +429,8 @@ class ZKAPAuthorizerStorageServer(Referenceable):
             )
 
     def remote_stat_shares(
-        self, storage_indexes_or_slots: List[bytes]
-    ) -> List[Dict[int, ShareStat]]:
+        self, storage_indexes_or_slots: list[bytes]
+    ) -> list[dict[int, ShareStat]]:
         return list(
             dict(get_share_stats(self._original, storage_index_or_slot, None))
             for storage_index_or_slot in storage_indexes_or_slots
@@ -593,7 +593,7 @@ def check_pass_quantity_for_lease(
     storage_index: bytes,
     validation: _ValidationResult,
     storage_server: ZKAPAuthorizerStorageServer,
-) -> Dict[int, int]:
+) -> dict[int, int]:
     """
     Check that the given number of passes is sufficient to add or renew a
     lease for one period for the given storage index.

--- a/src/_zkapauthorizer/config.py
+++ b/src/_zkapauthorizer/config.py
@@ -17,7 +17,7 @@ Helpers for reading values from the Tahoe-LAFS configuration.
 """
 
 from datetime import timedelta
-from typing import Optional
+from typing import Any, Optional
 
 from allmydata.node import _Config
 from hyperlink import DecodedURL
@@ -56,8 +56,7 @@ def read_node_url(config: _Config) -> DecodedURL:
     )
 
 
-def lease_maintenance_from_tahoe_config(node_config):
-    # type: (_Config) -> LeaseMaintenanceConfig
+def lease_maintenance_from_tahoe_config(node_config: _Config) -> LeaseMaintenanceConfig:
     """
     Return a ``LeaseMaintenanceConfig`` representing the values from the given
     configuration object.
@@ -131,7 +130,7 @@ def get_configured_lease_duration(node_config):
     return int(upper_bound - min_time_remaining)
 
 
-def _read_duration(cfg, option, default):
+def _read_duration(cfg: _Config, option: str, default: Any) -> Optional[timedelta]:
     """
     Read an integer number of seconds from the ZKAPAuthorizer section of a
     Tahoe-LAFS config.
@@ -142,7 +141,6 @@ def _read_duration(cfg, option, default):
     :return: ``None`` if the option is missing, otherwise the parsed duration
         as a ``timedelta``.
     """
-    # type: (_Config, str) -> Optional[timedelta]
     section_name = "storageclient.plugins." + NAME
     value_str = cfg.get_config(
         section=section_name,

--- a/src/_zkapauthorizer/controller.py
+++ b/src/_zkapauthorizer/controller.py
@@ -23,7 +23,6 @@ from functools import partial
 from hashlib import sha256
 from json import loads
 from operator import delitem, setitem
-from typing import List
 
 import attr
 import challenge_bypass_ristretto
@@ -103,7 +102,7 @@ class RedemptionResult(object):
         the redemption process.
     """
 
-    unblinded_tokens: List[UnblindedToken] = attr.ib(
+    unblinded_tokens: list[UnblindedToken] = attr.ib(
         validator=attr.validators.instance_of(list),
     )
     public_key: str = attr.ib(

--- a/src/_zkapauthorizer/lease_maintenance.py
+++ b/src/_zkapauthorizer/lease_maintenance.py
@@ -20,7 +20,7 @@ refresh leases on all shares reachable from a root.
 from datetime import datetime, timedelta
 from errno import ENOENT
 from functools import partial
-from typing import Any, Dict, Iterable
+from typing import Any, Callable, Dict, Iterable
 
 import attr
 from allmydata.interfaces import IDirectoryNode, IFilesystemNode
@@ -221,8 +221,7 @@ def renew_leases_on_server(
             yield renew_lease(renewal_secret, cancel_secret, storage_index, server)
 
 
-def soonest_expiration(stats):
-    # type: (Iterable[ShareStat]) -> ShareStat
+def soonest_expiration(stats: Iterable[ShareStat]) -> ShareStat:
     """
     :return: The share stat from ``stats`` with a lease which expires before
         all others.
@@ -321,7 +320,7 @@ class _FuzzyTimerService(Service):
     operation = attr.ib()
     initial_interval = attr.ib()
     sample_interval_distribution = attr.ib()
-    get_config = attr.ib()  # type: () -> Any
+    get_config: Callable[[], Any] = attr.ib()
     reactor = attr.ib()
 
     def startService(self):
@@ -450,13 +449,14 @@ class LeaseMaintenanceConfig(object):
         on a lease without renewing it.
     """
 
-    crawl_interval_mean = attr.ib()  # type: datetime.timedelta
-    crawl_interval_range = attr.ib()  # type: datetime.timedelta
-    min_lease_remaining = attr.ib()  # type: datetime.timedelta
+    crawl_interval_mean: datetime.timedelta = attr.ib()
+    crawl_interval_range: datetime.timedelta = attr.ib()
+    min_lease_remaining: datetime.timedelta = attr.ib()
 
 
-def lease_maintenance_config_to_dict(lease_maint_config):
-    # type: (LeaseMaintenanceConfig) -> Dict[str, str]
+def lease_maintenance_config_to_dict(
+    lease_maint_config: LeaseMaintenanceConfig,
+) -> Dict[str, str]:
     return {
         "lease.crawl-interval.mean": _format_duration(
             lease_maint_config.crawl_interval_mean,
@@ -470,18 +470,15 @@ def lease_maintenance_config_to_dict(lease_maint_config):
     }
 
 
-def _format_duration(td):
-    # type: (timedelta) -> str
+def _format_duration(td: timedelta) -> str:
     return str(int(td.total_seconds()))
 
 
-def _parse_duration(duration_str):
-    # type: (str) -> timedelta
+def _parse_duration(duration_str: str) -> timedelta:
     return timedelta(seconds=int(duration_str))
 
 
-def lease_maintenance_config_from_dict(d):
-    # type: (Dict[str, str]) -> LeaseMaintenanceConfig
+def lease_maintenance_config_from_dict(d: Dict[str, str]) -> LeaseMaintenanceConfig:
     return LeaseMaintenanceConfig(
         crawl_interval_mean=_parse_duration(d["lease.crawl-interval.mean"]),
         crawl_interval_range=_parse_duration(d["lease.crawl-interval.range"]),

--- a/src/_zkapauthorizer/lease_maintenance.py
+++ b/src/_zkapauthorizer/lease_maintenance.py
@@ -20,7 +20,7 @@ refresh leases on all shares reachable from a root.
 from datetime import datetime, timedelta
 from errno import ENOENT
 from functools import partial
-from typing import Any, Callable, Dict, Iterable
+from typing import Any, Callable, Iterable
 
 import attr
 from allmydata.interfaces import IDirectoryNode, IFilesystemNode
@@ -449,14 +449,14 @@ class LeaseMaintenanceConfig(object):
         on a lease without renewing it.
     """
 
-    crawl_interval_mean: datetime.timedelta = attr.ib()
-    crawl_interval_range: datetime.timedelta = attr.ib()
-    min_lease_remaining: datetime.timedelta = attr.ib()
+    crawl_interval_mean: timedelta = attr.ib()
+    crawl_interval_range: timedelta = attr.ib()
+    min_lease_remaining: timedelta = attr.ib()
 
 
 def lease_maintenance_config_to_dict(
     lease_maint_config: LeaseMaintenanceConfig,
-) -> Dict[str, str]:
+) -> dict[str, str]:
     return {
         "lease.crawl-interval.mean": _format_duration(
             lease_maint_config.crawl_interval_mean,
@@ -478,7 +478,7 @@ def _parse_duration(duration_str: str) -> timedelta:
     return timedelta(seconds=int(duration_str))
 
 
-def lease_maintenance_config_from_dict(d: Dict[str, str]) -> LeaseMaintenanceConfig:
+def lease_maintenance_config_from_dict(d: dict[str, str]) -> LeaseMaintenanceConfig:
     return LeaseMaintenanceConfig(
         crawl_interval_mean=_parse_duration(d["lease.crawl-interval.mean"]),
         crawl_interval_range=_parse_duration(d["lease.crawl-interval.range"]),

--- a/src/_zkapauthorizer/recover.py
+++ b/src/_zkapauthorizer/recover.py
@@ -95,7 +95,7 @@ class RecoveryState:
 SetState = Callable[[RecoveryState], None]
 
 # An object which can retrieve remote ZKAPAuthorizer state.
-Downloader = Callable[[SetState], Awaitable[BytesIO]]
+Downloader = Callable[[SetState], Awaitable[BinaryIO]]
 
 
 @define
@@ -165,7 +165,7 @@ def make_fail_downloader(reason: Exception) -> Downloader:
     Make a downloader that always fails with the given exception.
     """
 
-    async def fail_downloader(set_state: SetState) -> Awaitable[BytesIO]:
+    async def fail_downloader(set_state: SetState) -> Awaitable[BinaryIO]:
         raise reason
 
     return fail_downloader
@@ -177,7 +177,7 @@ def make_canned_downloader(data: bytes) -> Downloader:
     """
     assert isinstance(data, bytes)
 
-    async def canned_downloader(set_state: SetState) -> Awaitable[BytesIO]:
+    async def canned_downloader(set_state: SetState) -> Awaitable[BinaryIO]:
         return BytesIO(data)
 
     return canned_downloader

--- a/src/_zkapauthorizer/recover.py
+++ b/src/_zkapauthorizer/recover.py
@@ -17,7 +17,7 @@ from collections.abc import Awaitable
 from enum import Enum, auto
 from io import BytesIO
 from sqlite3 import Cursor
-from typing import BinaryIO, Callable, Dict, Iterator, Optional
+from typing import BinaryIO, Callable, Iterator, Optional
 
 from attrs import define
 from twisted.python.filepath import FilePath
@@ -87,7 +87,7 @@ class RecoveryState:
     stage: RecoveryStages = RecoveryStages.inactive
     failure_reason: Optional[str] = None
 
-    def marshal(self) -> Dict[str, Optional[str]]:
+    def marshal(self) -> dict[str, Optional[str]]:
         return {"stage": self.stage.name, "failure-reason": self.failure_reason}
 
 

--- a/src/_zkapauthorizer/resource.py
+++ b/src/_zkapauthorizer/resource.py
@@ -178,7 +178,7 @@ class ReplicateResource(Resource):
         work.
     """
 
-    _setup: Callable[[], Awaitable]
+    _setup: Callable[[], Awaitable[str]]
 
     _log = Logger()
 

--- a/src/_zkapauthorizer/server/spending.py
+++ b/src/_zkapauthorizer/server/spending.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Tuple
+from typing import Any
 
 import attr
 from challenge_bypass_ristretto import PublicKey
@@ -12,7 +12,7 @@ class ISpender(Interface):
     An ``ISpender`` can records spent ZKAPs and reports double spends.
     """
 
-    def mark_as_spent(public_key: PublicKey, passes: List[bytes]) -> None:
+    def mark_as_spent(public_key: PublicKey, passes: list[bytes]) -> None:
         """
         Record the given ZKAPs (associated to the given public key as having
         been spent.
@@ -43,7 +43,7 @@ class RecordingSpender(object):
     _recorder = attr.ib(validator=attr.validators.instance_of(_SpendingData))
 
     @classmethod
-    def make(cls) -> Tuple[_SpendingData, ISpender]:
+    def make(cls) -> tuple[_SpendingData, ISpender]:
         recorder = _SpendingData()
         return recorder, cls(recorder)
 

--- a/src/_zkapauthorizer/server/spending.py
+++ b/src/_zkapauthorizer/server/spending.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, List, Tuple
 
 import attr
 from challenge_bypass_ristretto import PublicKey
@@ -12,8 +12,7 @@ class ISpender(Interface):
     An ``ISpender`` can records spent ZKAPs and reports double spends.
     """
 
-    def mark_as_spent(public_key, passes):
-        # type: (PublicKey, list[bytes]) -> None
+    def mark_as_spent(public_key: PublicKey, passes: List[bytes]) -> None:
         """
         Record the given ZKAPs (associated to the given public key as having
         been spent.
@@ -44,8 +43,7 @@ class RecordingSpender(object):
     _recorder = attr.ib(validator=attr.validators.instance_of(_SpendingData))
 
     @classmethod
-    def make(cls):
-        # type: () -> (_SpendingData, ISpender)
+    def make(cls) -> Tuple[_SpendingData, ISpender]:
         recorder = _SpendingData()
         return recorder, cls(recorder)
 
@@ -55,8 +53,9 @@ class RecordingSpender(object):
         )
 
 
-def get_spender(config, reactor, registry):
-    # type: (dict[str, Any], IReactorTime, CollectorRegistry) -> ISpender
+def get_spender(
+    config: dict[str, Any], reactor: IReactorTime, registry: CollectorRegistry
+) -> ISpender:
     """
     Return an :py:`ISpender` to be used with the given storage server configuration.
     """

--- a/src/_zkapauthorizer/spending.py
+++ b/src/_zkapauthorizer/spending.py
@@ -18,7 +18,7 @@ A module for logic controlling the manner in which ZKAPs are spent.
 
 from __future__ import annotations
 
-from typing import Callable, List, Tuple
+from typing import Callable
 
 import attr
 from zope.interface import Attribute, Interface, implementer
@@ -116,19 +116,19 @@ class PassGroup(object):
 
     _message: bytes = attr.ib(validator=attr.validators.instance_of(bytes))
     _factory: IPassFactory = attr.ib(validator=attr.validators.provides(IPassFactory))
-    _tokens: List[Tuple[UnblindedToken, Pass]] = attr.ib(
+    _tokens: list[tuple[UnblindedToken, Pass]] = attr.ib(
         validator=attr.validators.instance_of(list)
     )
 
     @property
-    def passes(self) -> List[Pass]:
+    def passes(self) -> list[Pass]:
         return list(pass_ for (unblinded_token, pass_) in self._tokens)
 
     @property
-    def unblinded_tokens(self) -> List[UnblindedToken]:
+    def unblinded_tokens(self) -> list[UnblindedToken]:
         return list(unblinded_token for (unblinded_token, pass_) in self._tokens)
 
-    def split(self, select_indices: List[int]) -> (PassGroup, PassGroup):
+    def split(self, select_indices: list[int]) -> (PassGroup, PassGroup):
         selected = []
         unselected = []
         for idx, t in enumerate(self._tokens):
@@ -165,12 +165,12 @@ class SpendingController(object):
     attempts when necessary.
     """
 
-    get_unblinded_tokens: Callable[[int], List[UnblindedToken]] = attr.ib()
-    discard_unblinded_tokens: Callable[[List[UnblindedToken]], None] = attr.ib()
-    invalidate_unblinded_tokens: Callable[[List[UnblindedToken]], None] = attr.ib()
-    reset_unblinded_tokens: Callable[[List[UnblindedToken]], None] = attr.ib()
+    get_unblinded_tokens: Callable[[int], list[UnblindedToken]] = attr.ib()
+    discard_unblinded_tokens: Callable[[list[UnblindedToken]], None] = attr.ib()
+    invalidate_unblinded_tokens: Callable[[list[UnblindedToken]], None] = attr.ib()
+    reset_unblinded_tokens: Callable[[list[UnblindedToken]], None] = attr.ib()
 
-    tokens_to_passes: Callable[[bytes, List[UnblindedToken]], List[Pass]] = attr.ib()
+    tokens_to_passes: Callable[[bytes, list[UnblindedToken]], list[Pass]] = attr.ib()
 
     @classmethod
     def for_store(cls, tokens_to_passes, store):

--- a/src/_zkapauthorizer/tahoe.py
+++ b/src/_zkapauthorizer/tahoe.py
@@ -105,7 +105,7 @@ class TahoeAPIError(Exception):
 @async_retry([_not_enough_servers])
 async def upload(
     client: HTTPClient, inpath: FilePath, api_root: DecodedURL
-) -> Awaitable:  # Awaitable[str] but this requires Python 3.9
+) -> Awaitable[str]:
     """
     Upload data from the given path and return the resulting capability.
 
@@ -142,7 +142,7 @@ async def download(
     api_root: DecodedURL,
     cap: str,
     child_path: Optional[Iterable[str]] = None,
-) -> Awaitable:  # Awaitable[None] but this requires Python 3.9
+) -> Awaitable[None]:
     """
     Download the object identified by the given capability to the given path.
 
@@ -182,7 +182,7 @@ async def download(
 async def make_directory(
     client: HTTPClient,
     api_root: DecodedURL,
-) -> Awaitable:  # Awaitable[str] but this requires Python 3.9
+) -> Awaitable[str]:
     """
     Create a new mutable directory and return the write capability string.
     """
@@ -201,7 +201,7 @@ async def link(
     dir_cap: str,
     entry_name: str,
     entry_cap: str,
-) -> Awaitable:
+) -> Awaitable[None]:
     """
     Link an object into a directory.
 

--- a/src/_zkapauthorizer/tahoe.py
+++ b/src/_zkapauthorizer/tahoe.py
@@ -6,7 +6,7 @@ from collections.abc import Awaitable
 from functools import wraps
 from hashlib import sha256
 from tempfile import mkdtemp
-from typing import Callable, Dict, Iterable, List, Optional
+from typing import Callable, Iterable, Optional
 
 import treq
 from allmydata.node import _Config
@@ -20,7 +20,7 @@ from twisted.python.filepath import FilePath
 from .config import read_node_url
 
 
-def async_retry(matchers: List[Callable[[Exception], bool]]):
+def async_retry(matchers: list[Callable[[Exception], bool]]):
     """
     Decorate a function with automatic retry behavior for certain cases.
 
@@ -271,7 +271,7 @@ class MemoryGrid:
     """
 
     _counter: int = 0
-    _objects: Dict[str, str] = field(default=Factory(dict))
+    _objects: dict[str, str] = field(default=Factory(dict))
 
     def client(self):
         """

--- a/src/_zkapauthorizer/tests/_sql_matchers.py
+++ b/src/_zkapauthorizer/tests/_sql_matchers.py
@@ -3,7 +3,7 @@ Testtools matchers related to SQL functionality.
 """
 
 from sqlite3 import Connection
-from typing import Iterator, Tuple, Union
+from typing import Iterator, Union
 
 from attrs import define, field
 from testtools.matchers import AfterPreprocessing, Annotate, Equals, Mismatch
@@ -39,7 +39,7 @@ def equals_database(reference: Connection):
     )
 
 
-def structured_dump(db: Connection) -> Iterator[Tuple]:
+def structured_dump(db: Connection) -> Iterator[tuple]:
     """
     Dump the whole database, schema and rows, without trying to do any string
     formatting.
@@ -50,7 +50,7 @@ def structured_dump(db: Connection) -> Iterator[Tuple]:
         yield from _structured_dump_table(db, name)
 
 
-def _structured_dump_tables(db: Connection) -> Iterator[Tuple[str, str]]:
+def _structured_dump_tables(db: Connection) -> Iterator[tuple[str, str]]:
     curs = db.cursor()
     curs.execute(
         """
@@ -65,7 +65,7 @@ def _structured_dump_tables(db: Connection) -> Iterator[Tuple[str, str]]:
 
 def _structured_dump_table(
     db: Connection, table_name: str
-) -> Iterator[Tuple[str, str, Tuple[SQLType, ...]]]:
+) -> Iterator[tuple[str, str, tuple[SQLType, ...]]]:
     """
     Dump a single database table's rows without trying to do any string
     formatting.

--- a/src/_zkapauthorizer/tests/matchers.py
+++ b/src/_zkapauthorizer/tests/matchers.py
@@ -29,7 +29,7 @@ __all__ = [
 
 from datetime import datetime
 from json import loads
-from typing import List
+from typing import GenericAlias
 
 import attr
 from testtools.matchers import (
@@ -219,8 +219,8 @@ def matches_response(
 
 
 def matches_spent_passes(
-    public_key_hash: bytes, spent_passes: List[Pass]
-) -> Matcher[_SpendingData]:
+    public_key_hash: bytes, spent_passes: list[Pass]
+) -> GenericAlias(Matcher, (_SpendingData,)):
     """
     Returns a matcher for _SpendingData that checks whether the
     spent pass match the given public key and passes.

--- a/src/_zkapauthorizer/tests/matchers.py
+++ b/src/_zkapauthorizer/tests/matchers.py
@@ -29,6 +29,7 @@ __all__ = [
 
 from datetime import datetime
 from json import loads
+from typing import List
 
 import attr
 from testtools.matchers import (
@@ -217,8 +218,9 @@ def matches_response(
     )
 
 
-def matches_spent_passes(public_key_hash, spent_passes):
-    # type: (bytes, list[Pass]) -> Matcher[_SpendingData]
+def matches_spent_passes(
+    public_key_hash: bytes, spent_passes: List[Pass]
+) -> Matcher[_SpendingData]:
     """
     Returns a matcher for _SpendingData that checks whether the
     spent pass match the given public key and passes.

--- a/src/_zkapauthorizer/tests/sql.py
+++ b/src/_zkapauthorizer/tests/sql.py
@@ -6,7 +6,6 @@ to support testing the replication/recovery system.
 """
 
 from enum import Enum, auto
-from typing import Any, List, Tuple
 
 from attrs import define
 
@@ -44,7 +43,7 @@ class Table:
     :ivar columns: The columns that make up this table.
     """
 
-    columns: List[Tuple[str, Column]]
+    columns: list[tuple[str, Column]]
 
 
 @define(frozen=True)
@@ -61,7 +60,7 @@ class Insert:
 
     table_name: str
     table: Table
-    fields: Tuple[Any]
+    fields: tuple[...]
 
     def statement(self):
         names = ", ".join((escape(name) for (name, _) in self.table.columns))
@@ -92,7 +91,7 @@ class Update:
 
     table_name: str
     table: Table
-    fields: Tuple[Any]
+    fields: tuple[...]
 
     def statement(self):
         field_names = list(name for (name, _) in self.table.columns)

--- a/src/_zkapauthorizer/tests/storage_common.py
+++ b/src/_zkapauthorizer/tests/storage_common.py
@@ -20,7 +20,7 @@ from functools import partial
 from itertools import islice
 from os import SEEK_CUR
 from struct import pack
-from typing import Callable, Dict, List, Set
+from typing import Callable
 
 import attr
 from challenge_bypass_ristretto import RandomToken, SigningKey
@@ -136,7 +136,7 @@ def whitebox_write_sparse_share(sharepath, version, size, leases, now):
         )
 
 
-def integer_passes(limit: int) -> Callable[[bytes, int], List[int]]:
+def integer_passes(limit: int) -> Callable[[bytes, int], list[int]]:
     """
     :return: A function which can be used to get a number of passes.  The
         function accepts a unicode request-binding message and an integer
@@ -156,7 +156,7 @@ def integer_passes(limit: int) -> Callable[[bytes, int], List[int]]:
 
 def get_passes(
     message: bytes, count: int, signing_key: SigningKey
-) -> List[RandomToken]:
+) -> list[RandomToken]:
     """
     :param bytes message: Request-binding message for PrivacyPass.
 
@@ -222,13 +222,13 @@ class _PassFactory(object):
         via ``IPassGroup.reset``.
     """
 
-    _get_passes: Callable[[bytes, int], List[bytes]] = attr.ib()
+    _get_passes: Callable[[bytes, int], list[bytes]] = attr.ib()
 
-    returned: List[int] = attr.ib(default=attr.Factory(list), init=False)
-    in_use: Set[int] = attr.ib(default=attr.Factory(set), init=False)
-    invalid: Dict[int, str] = attr.ib(default=attr.Factory(dict), init=False)
-    spent: Set[int] = attr.ib(default=attr.Factory(set), init=False)
-    issued: Set[int] = attr.ib(default=attr.Factory(set), init=False)
+    returned: list[int] = attr.ib(default=attr.Factory(list), init=False)
+    in_use: set[int] = attr.ib(default=attr.Factory(set), init=False)
+    invalid: dict[int, str] = attr.ib(default=attr.Factory(dict), init=False)
+    spent: set[int] = attr.ib(default=attr.Factory(set), init=False)
+    issued: set[int] = attr.ib(default=attr.Factory(set), init=False)
 
     def get(self, message: bytes, num_passes: int) -> PassGroup:
         passes = []

--- a/src/_zkapauthorizer/tests/strategies.py
+++ b/src/_zkapauthorizer/tests/strategies.py
@@ -19,7 +19,6 @@ Hypothesis strategies for property testing.
 from base64 import b64encode, urlsafe_b64encode
 from datetime import datetime, timedelta
 from functools import partial
-from typing import Dict, List
 from urllib.parse import quote
 
 import attr
@@ -1099,7 +1098,7 @@ class _VoucherInsert(object):
     voucher: bytes = attr.ib()
     expected_tokens: int = attr.ib(validator=attr.validators.gt(0))
     counter: int = attr.ib(validator=attr.validators.ge(0))
-    tokens: List[RandomToken] = attr.ib()
+    tokens: list[RandomToken] = attr.ib()
 
 
 @attr.s(frozen=True)
@@ -1108,7 +1107,7 @@ class _ExistingState(object):
     Represent some state which could already exist in a ``VoucherStore``.
     """
 
-    vouchers: List[_VoucherInsert] = attr.ib()
+    vouchers: list[_VoucherInsert] = attr.ib()
 
 
 def existing_states(min_vouchers: int = 0, max_vouchers: int = 4):
@@ -1218,7 +1217,7 @@ def tables() -> SearchStrategy[Table]:
     )
 
 
-def sql_schemas(dict_kwargs=None) -> SearchStrategy[Dict[str, Table]]:
+def sql_schemas(dict_kwargs=None) -> SearchStrategy[dict[str, Table]]:
     """
     Build objects describing multiple tables in a SQLite3 database.
     """

--- a/src/_zkapauthorizer/tests/test_client_resource.py
+++ b/src/_zkapauthorizer/tests/test_client_resource.py
@@ -20,7 +20,7 @@ plugin.
 from base64 import b32encode
 from datetime import datetime
 from io import BytesIO
-from typing import Optional, Set
+from typing import Optional
 from urllib.parse import quote
 
 import attr
@@ -1503,7 +1503,7 @@ class VoucherTests(TestCase):
         )
 
 
-def mime_types(blacklist: Optional[Set[str]] = None) -> SearchStrategy[str]:
+def mime_types(blacklist: Optional[set[str]] = None) -> SearchStrategy[str]:
     """
     Build MIME types as b"major/minor" byte strings.
 

--- a/src/_zkapauthorizer/tests/test_lease_maintenance.py
+++ b/src/_zkapauthorizer/tests/test_lease_maintenance.py
@@ -94,11 +94,12 @@ class DummyStorageServer(object):
     """
 
     clock = attr.ib()
-    buckets = attr.ib()  # type: Dict[bytes, Dict[int, ShareStat]]
+    buckets: Dict[bytes, Dict[int, ShareStat]] = attr.ib()
     lease_seed = attr.ib()
 
-    def stat_shares(self, storage_indexes):
-        # type: (List[bytes]) -> Deferred[List[Dict[int, ShareStat]]]
+    def stat_shares(
+        self, storage_indexes: List[bytes]
+    ) -> Deferred[List[Dict[int, ShareStat]]]:
         return succeed(list(self.buckets.get(idx, {}) for idx in storage_indexes))
 
     def get_lease_seed(self):
@@ -115,8 +116,13 @@ class SharesAlreadyExist(Exception):
     pass
 
 
-def create_share(storage_server, storage_index, sharenum, size, lease_expiration):
-    # type: (DummyStorageServer, bytes, int, int, int) -> None
+def create_share(
+    storage_server: DummyStorageServer,
+    storage_index: bytes,
+    sharenum: int,
+    size: int,
+    lease_expiration: int,
+) -> None:
     """
     Add a share to a storage index ("bucket").
 

--- a/src/_zkapauthorizer/tests/test_lease_maintenance.py
+++ b/src/_zkapauthorizer/tests/test_lease_maintenance.py
@@ -17,7 +17,6 @@ Tests for ``_zkapauthorizer.lease_maintenance``.
 """
 
 from datetime import datetime, timedelta
-from typing import Dict, List
 
 import attr
 from allmydata.client import SecretHolder
@@ -94,12 +93,12 @@ class DummyStorageServer(object):
     """
 
     clock = attr.ib()
-    buckets: Dict[bytes, Dict[int, ShareStat]] = attr.ib()
+    buckets: dict[bytes, dict[int, ShareStat]] = attr.ib()
     lease_seed = attr.ib()
 
     def stat_shares(
-        self, storage_indexes: List[bytes]
-    ) -> Deferred[List[Dict[int, ShareStat]]]:
+        self, storage_indexes: list[bytes]
+    ) -> Deferred[list[dict[int, ShareStat]]]:
         return succeed(list(self.buckets.get(idx, {}) for idx in storage_indexes))
 
     def get_lease_seed(self):

--- a/src/_zkapauthorizer/tests/test_plugin.py
+++ b/src/_zkapauthorizer/tests/test_plugin.py
@@ -745,24 +745,25 @@ class LeaseMaintenanceServiceTests(TestCase):
         )
 
 
-def has_lease_maintenance_service():
+def has_lease_maintenance_service() -> Matcher:
     """
     Return a matcher for a Tahoe-LAFS client object that has a lease
     maintenance service.
     """
-    # type: () -> Matcher
     return AfterPreprocessing(
         lambda client: client.getServiceNamed(SERVICE_NAME),
         Always(),
     )
 
 
-def has_lease_maintenance_configuration(lease_maint_config):
+def has_lease_maintenance_configuration(
+    lease_maint_config: LeaseMaintenanceConfig,
+) -> Matcher:
     """
     Return a matcher for a Tahoe-LAFS client object that has a lease
     maintenance service with the given configuration.
     """
-    # type: (LeaseMaintenanceConfig) -> Matcher
+
     def get_lease_maintenance_config(lease_maint_service):
         return lease_maint_service.get_config()
 

--- a/src/_zkapauthorizer/tests/test_recover.py
+++ b/src/_zkapauthorizer/tests/test_recover.py
@@ -4,7 +4,7 @@ Tests for ``_zkapauthorizer.recover``, the replication recovery system.
 
 from asyncio import run
 from sqlite3 import Connection, connect
-from typing import Dict, Iterator
+from typing import Iterator
 
 from allmydata.client import read_config
 from fixtures import TempDir
@@ -79,7 +79,7 @@ class SnapshotMachine(RuleBasedStateMachine):
         super().__init__()
         self.case = case
         self.connection = connect(":memory:")
-        self.tables: Dict[str, Table] = {}
+        self.tables: dict[str, Table] = {}
 
     @invariant()
     def snapshot_equals_database(self):

--- a/src/_zkapauthorizer/tests/test_storage_server.py
+++ b/src/_zkapauthorizer/tests/test_storage_server.py
@@ -142,8 +142,9 @@ class ValidationResultTests(TestCase):
             )
 
 
-def read_spending_success_histogram_total(storage_server):
-    # type: (ZKAPAuthorizerStorageServer) -> int
+def read_spending_success_histogram_total(
+    storage_server: ZKAPAuthorizerStorageServer,
+) -> int:
     """
     Read the total number of values across all buckets of the spending success
     metric histogram.
@@ -154,8 +155,9 @@ def read_spending_success_histogram_total(storage_server):
     return sum(b.get() for b in buckets)
 
 
-def read_spending_success_histogram_bucket(storage_server, num_passes):
-    # type: (ZKAPAuthorizerStorageServer, int) -> int
+def read_spending_success_histogram_bucket(
+    storage_server: ZKAPAuthorizerStorageServer, num_passes: int
+) -> int:
     """
     Read the value of a single bucket of the spending success metric
     histogram.


### PR DESCRIPTION
This updates the type annotations (still unchecked) to use syntax instead of comments and parameterize Awaitable (not possible before Py 3.9).