### PR TITLE
add the rest of the API endpoints to the reachability test

### DIFF
--- a/src/_zkapauthorizer/tests/test_client_resource.py
+++ b/src/_zkapauthorizer/tests/test_client_resource.py
@@ -434,6 +434,10 @@ class ResourceTests(TestCase):
             [
                 [b"voucher"],
                 [b"version"],
+                [b"recover"],
+                [b"replicate"],
+                [b"lease-maintenance"],
+                [b"calculate-price"],
             ]
         ),
         api_auth_tokens(),


### PR DESCRIPTION
This test has not kept pace with the actual API, sadly.
