### PR TITLE
Hook up replication configuration for real

### DIFF
--- a/src/_zkapauthorizer/_plugin.py
+++ b/src/_zkapauthorizer/_plugin.py
@@ -46,11 +46,12 @@ from .controller import get_redeemer
 from .lease_maintenance import SERVICE_NAME as MAINTENANCE_SERVICE_NAME
 from .lease_maintenance import lease_maintenance_service, maintain_leases_from_root
 from .model import VoucherStore
-from .recover import fail_setup_replication, make_fail_downloader
+from .recover import make_fail_downloader, setup_tahoe_lafs_replication
 from .resource import from_configuration as resource_from_configuration
 from .server.spending import get_spender
 from .spending import SpendingController
 from .storage_common import BYTES_PER_PASS, get_configured_pass_value
+from .tahoe import get_tahoe_client
 
 _log = Logger()
 
@@ -189,7 +190,10 @@ class ZKAPAuthorizer(object):
                 )
             )
 
-        setup_replication = fail_setup_replication
+        setup_replication = partial(
+            setup_tahoe_lafs_replication,
+            get_tahoe_client(reactor, node_config),
+        )
 
         return resource_from_configuration(
             node_config,

--- a/src/_zkapauthorizer/tahoe.py
+++ b/src/_zkapauthorizer/tahoe.py
@@ -16,6 +16,7 @@ from attrs import Factory, define, field
 from hyperlink import DecodedURL
 from treq.client import HTTPClient
 from twisted.python.filepath import FilePath
+from twisted.web.client import Agent
 
 from .config import read_node_url
 
@@ -344,3 +345,17 @@ def attenuate_writecap(rw_cap: str) -> str:
     read-write capability.
     """
     return capability_from_string(rw_cap).get_readonly().to_string().decode("ascii")
+
+
+def get_tahoe_client(reactor, node_config: _Config) -> Tahoe:
+    """
+    Return a Tahoe-LAFS client appropriate for the given node configuration.
+
+    :param reactor: The reactor the client will use for I/O.
+
+    :param node_config: The Tahoe-LAFS client node configuration for the
+        client (giving, for example, the root URI of the node's HTTP API).
+    """
+    agent = Agent(reactor)
+    http_client = HTTPClient(agent)
+    return Tahoe(http_client, node_config)


### PR DESCRIPTION
This relates to #235.  It plugs the replication configuration function introduced in #316 into the HTTP API so it is possible to configure replication for real (of course replication itself is still unimplemented).
