### PR TITLE
Tahoe list directory

### DIFF
--- a/src/_zkapauthorizer/tahoe.py
+++ b/src/_zkapauthorizer/tahoe.py
@@ -261,6 +261,7 @@ class Tahoe(object):
         return link(self.client, self._api_root, dir_cap, entry_name, entry_cap)
 
 
+CapStr = str
 @define
 class MemoryGrid:
     """
@@ -285,16 +286,16 @@ class MemoryGrid:
         """
         return _MemoryTahoe(self)
 
-    def upload(self, data: bytes) -> str:
+    def upload(self, data: bytes) -> CapStr:
         cap = str(self._counter)
         self._objects[cap] = data
         self._counter += 1
         return cap
 
-    def download(self, cap: str) -> bytes:
+    def download(self, cap: CapStr) -> bytes:
         return self._objects[cap]
 
-    def make_directory(self) -> str:
+    def make_directory(self) -> CapStr:
         def encode(s: bytes):
             return b32encode(s.encode("ascii")).decode("ascii")
 
@@ -362,7 +363,7 @@ class _MemoryTahoe:
         return self._grid.link(dir_cap, entry_name, entry_cap)
 
 
-def attenuate_writecap(rw_cap: str) -> str:
+def attenuate_writecap(rw_cap: CapStr) -> CapStr:
     """
     Get a read-only capability corresponding to the same data as the given
     read-write capability.

--- a/src/_zkapauthorizer/tahoe.py
+++ b/src/_zkapauthorizer/tahoe.py
@@ -338,13 +338,13 @@ class MemoryGrid:
 
         return cap
 
-    def link(self, dir_cap, entry_name, entry_cap):
+    def link(self, dir_cap: CapStr, entry_name: str, entry_cap: CapStr) -> None:
         d = capability_from_string(dir_cap)
         assert not d.is_readonly()
         assert d.is_mutable()
         self._objects[dir_cap][entry_name] = entry_cap
 
-    def list_directory(self, dir_cap):
+    def list_directory(self, dir_cap: CapStr) -> dict[CapStr, FSEntry]:
         def kind(entry):
             if isinstance(entry, dict):
                 return "dirnode"

--- a/src/_zkapauthorizer/tahoe.py
+++ b/src/_zkapauthorizer/tahoe.py
@@ -90,7 +90,7 @@ def _scrub_caps_from_url(url: DecodedURL) -> DecodedURL:
     return url
 
 
-@define(frozen=True, auto_exc=False)
+@define(auto_exc=False)
 class TahoeAPIError(Exception):
     """
     Some error was reported from a Tahoe-LAFS HTTP API.

--- a/src/_zkapauthorizer/tahoe.py
+++ b/src/_zkapauthorizer/tahoe.py
@@ -333,7 +333,7 @@ class MemoryGrid:
 
         self._counter += 1
         cap = f"URI:DIR2:{writekey}:{fingerprint}"
-        rocap = capability_from_string(cap).get_readonly().to_string().decode("ascii")
+        rocap = attenuate_writecap(cap)
         self._objects[cap] = self._objects[rocap] = {}
 
         return cap

--- a/src/_zkapauthorizer/tests/resources.py
+++ b/src/_zkapauthorizer/tests/resources.py
@@ -8,11 +8,14 @@ from tempfile import mkdtemp
 from time import sleep
 from typing import Iterator, Optional
 
+from allmydata.client import config_from_string
 from attrs import define
 from hyperlink import DecodedURL
 from testresources import TestResourceManager
 from twisted.python.filepath import FilePath
 from yaml import safe_dump
+
+from ..config import _Config as Config
 
 # An argv prefix to use in place of `tahoe` to run the Tahoe-LAFS CLI.  This
 # runs the CLI via the `__main__` so that we don't rely on `tahoe` being in
@@ -212,6 +215,16 @@ class TahoeClient:
     create_output: Optional[str] = None
     process: Optional[Popen] = None
     node_url: Optional[FilePath] = None
+
+    def read_config(self) -> Config:
+        """
+        Read this client node's configuration file into a configuration object.
+        """
+        return config_from_string(
+            self.node_dir.path,
+            "tub.port",
+            self.node_dir.child("tahoe.cfg").getContent(),
+        )
 
     def run(self):
         """


### PR DESCRIPTION
Related to #235 - this adds `Tahoe.list_directory` which the replication system needs so it can inspect the on-grid state to determine if a snapshot needs to be created and uploaded.
