### PR TITLE
add `async_with_cursor` helper

### DIFF
--- a/src/_zkapauthorizer/model.py
+++ b/src/_zkapauthorizer/model.py
@@ -177,7 +177,9 @@ def open_and_initialize(path, connect=None):
     return conn
 
 
-def with_cursor_async(f: Callable[..., Awaitable[_T]]) -> Awaitable[_T]:
+def with_cursor_async(
+    f: Callable[[...], Awaitable[_T]]
+) -> Callable[[Cursor, ...], Awaitable[_T]]:
     """
     Like ``with_cursor`` but support decorating async functions instead.
 

--- a/src/_zkapauthorizer/model.py
+++ b/src/_zkapauthorizer/model.py
@@ -18,7 +18,7 @@ the storage plugin.
 """
 
 from datetime import datetime
-from functools import partial, wraps
+from functools import wraps
 from json import loads
 from sqlite3 import Cursor, OperationalError
 from sqlite3 import connect as _connect

--- a/src/_zkapauthorizer/model.py
+++ b/src/_zkapauthorizer/model.py
@@ -188,10 +188,14 @@ def with_cursor_async(f: Callable[..., Awaitable[_T]]) -> Awaitable[_T]:
     async def with_cursor_async(self, *a, **kw):
         with self._connection:
             cursor = self._connection.cursor()
+            print("created cursor")
             try:
+                print("start transaction")
                 cursor.execute("BEGIN IMMEDIATE TRANSACTION")
+                print("run function")
                 return await f(self, cursor, *a, **kw)
             finally:
+                print("close cursor")
                 cursor.close()
 
     return with_cursor_async

--- a/src/_zkapauthorizer/model.py
+++ b/src/_zkapauthorizer/model.py
@@ -188,14 +188,10 @@ def with_cursor_async(f: Callable[..., Awaitable[_T]]) -> Awaitable[_T]:
     async def with_cursor_async(self, *a, **kw):
         with self._connection:
             cursor = self._connection.cursor()
-            print("created cursor")
             try:
-                print("start transaction")
                 cursor.execute("BEGIN IMMEDIATE TRANSACTION")
-                print("run function")
                 return await f(self, cursor, *a, **kw)
             finally:
-                print("close cursor")
                 cursor.close()
 
     return with_cursor_async

--- a/src/_zkapauthorizer/model.py
+++ b/src/_zkapauthorizer/model.py
@@ -177,9 +177,7 @@ def open_and_initialize(path, connect=None):
     return conn
 
 
-def with_cursor_async(
-    f: Callable[[...], Awaitable[_T]]
-) -> Callable[[Cursor, ...], Awaitable[_T]]:
+def with_cursor_async(f: Callable[..., Awaitable[_T]]) -> Callable[..., Awaitable[_T]]:
     """
     Like ``with_cursor`` but support decorating async functions instead.
 

--- a/src/_zkapauthorizer/model.py
+++ b/src/_zkapauthorizer/model.py
@@ -18,11 +18,11 @@ the storage plugin.
 """
 
 from datetime import datetime
-from functools import wraps
+from functools import partial, wraps
 from json import loads
 from sqlite3 import Cursor, OperationalError
 from sqlite3 import connect as _connect
-from typing import Callable
+from typing import Awaitable, Callable, TypeVar
 
 import attr
 from aniso8601 import parse_datetime
@@ -39,6 +39,8 @@ from .storage_common import (
     required_passes,
 )
 from .validators import greater_than, has_length, is_base64_encoded
+
+_T = TypeVar("T")
 
 
 class NotEmpty(Exception):
@@ -173,6 +175,26 @@ def open_and_initialize(path, connect=None):
 
     cursor.close()
     return conn
+
+
+def with_cursor_async(f: Callable[..., Awaitable[_T]]) -> Awaitable[_T]:
+    """
+    Like ``with_cursor`` but support decorating async functions instead.
+
+    The transaction will be kept open until the async function completes.
+    """
+
+    @wraps(f)
+    async def with_cursor_async(self, *a, **kw):
+        with self._connection:
+            cursor = self._connection.cursor()
+            try:
+                cursor.execute("BEGIN IMMEDIATE TRANSACTION")
+                return await f(self, cursor, *a, **kw)
+            finally:
+                cursor.close()
+
+    return with_cursor_async
 
 
 def with_cursor(f):

--- a/src/_zkapauthorizer/tests/test_model.py
+++ b/src/_zkapauthorizer/tests/test_model.py
@@ -159,6 +159,19 @@ class WithCursorAsyncTests(TestCase):
             Equals([(1,)]),
         )
 
+    def test_db(self):
+        db = connect(":memory:")
+        cursor0 = db.cursor()
+        cursor0.execute("BEGIN IMMEDIATE TRANSACTION")
+        cursor0.execute("CREATE TABLE [foo] ([a] INT)")
+        cursor0.execute("INSERT INTO [foo] VALUES (1)")
+        # note: no close() yet
+        cursor1 = db.cursor()
+        # should cause error
+        print(cursor1.execute("select * from [foo]").fetchall())
+        cursor0.close()
+        cursor1.close()
+
     def test_async(self):
         """
         The given function can return an ``Awaitable`` and the transaction will

--- a/src/_zkapauthorizer/tests/test_model.py
+++ b/src/_zkapauthorizer/tests/test_model.py
@@ -159,7 +159,7 @@ class WithCursorAsyncTests(TestCase):
             Equals([(1,)]),
         )
 
-    def test_db(self):
+    def test_db0(self):
         db = connect(":memory:")
         cursor0 = db.cursor()
         cursor0.execute("BEGIN IMMEDIATE TRANSACTION")
@@ -171,6 +171,18 @@ class WithCursorAsyncTests(TestCase):
         print(cursor1.execute("select * from [foo]").fetchall())
         cursor0.close()
         cursor1.close()
+
+    def test_db1(self):
+        db = connect(":memory:")
+        with db as cursor0:
+            cursor0.execute("BEGIN IMMEDIATE TRANSACTION")
+            cursor0.execute("CREATE TABLE [foo] ([a] INT)")
+            cursor0.execute("INSERT INTO [foo] VALUES (1)")
+
+            # cursor0 still open
+            cursor1 = db.cursor()
+            # should cause error
+            print(cursor1.execute("select * from [foo]").fetchall())
 
     def test_async(self):
         """

--- a/src/_zkapauthorizer/tests/test_model.py
+++ b/src/_zkapauthorizer/tests/test_model.py
@@ -19,10 +19,9 @@ Tests for ``_zkapauthorizer.model``.
 
 from datetime import datetime, timedelta
 from errno import EACCES
-from functools import wraps
 from os import mkdir
 from sqlite3 import Connection, OperationalError, connect
-from typing import Awaitable, Callable, TypeVar
+from typing import TypeVar
 from unittest import skipIf
 
 from fixtures import TempDir


### PR DESCRIPTION
This is related to #235 and even more directly related to #333.

This is necessary for `VoucherStore.call_if_empty` which will need to support async functions for recovery to actually work.
