### PR TITLE
WIP: debug coro

### DIFF
--- a/src/_zkapauthorizer/model.py
+++ b/src/_zkapauthorizer/model.py
@@ -188,10 +188,14 @@ def with_cursor_async(f: Callable[..., Awaitable[_T]]) -> Awaitable[_T]:
     async def with_cursor_async(self, *a, **kw):
         with self._connection:
             cursor = self._connection.cursor()
+            print("created cursor")
             try:
+                print("start transaction")
                 cursor.execute("BEGIN IMMEDIATE TRANSACTION")
+                print("run function")
                 return await f(self, cursor, *a, **kw)
             finally:
+                print("close cursor")
                 cursor.close()
 
     return with_cursor_async


### PR DESCRIPTION
Here, I convert to non-asyncio ... but also splatter a bunch of `print`s because this doesn't seem to alight with my expectations.

Good: the prints run in the order I more-or-less expect

Bad: the `SELECT` returns the data even though the cursor hasn't closed. So, something is weird with expectations about the database "or something"

Also-good: hopefully this shows how to run the thing without asyncio.