### PR TITLE
Convert `VoucherStore.call_if_empty` to be/support async functions

### DIFF
--- a/docs/source/designs/backup-recovery.rst
+++ b/docs/source/designs/backup-recovery.rst
@@ -586,8 +586,8 @@ Footnotes
 
 .. [7] The SQL statements from ``iterdump``,
        except for those relating to the event stream table,
-       are joined with newline separators and compressed using lzma.
-       The compressed blob is uploaded as an immutable object.
+       are UTF-8 encoded, `netstring <http://cr.yp.to/proto/netstrings.txt>`_ encoded, and concatenated.
+       The resulting byte string is uploaded as an immutable object.
        The metadata of the object in the containing directory includes the snapshot's sequence number.
 
 .. [8] The upload may proceed concurrently with further database changes.

--- a/src/_zkapauthorizer/_plugin.py
+++ b/src/_zkapauthorizer/_plugin.py
@@ -43,10 +43,13 @@ from zope.interface import implementer
 
 from . import NAME
 from .api import ZKAPAuthorizerStorageClient, ZKAPAuthorizerStorageServer
-from .config import lease_maintenance_from_tahoe_config
 from .controller import get_redeemer
 from .lease_maintenance import SERVICE_NAME as MAINTENANCE_SERVICE_NAME
-from .lease_maintenance import lease_maintenance_service, maintain_leases_from_root
+from .lease_maintenance import (
+    LeaseMaintenanceConfig,
+    lease_maintenance_service,
+    maintain_leases_from_root,
+)
 from .model import VoucherStore
 from .recover import make_fail_downloader, setup_tahoe_lafs_replication
 from .resource import from_configuration as resource_from_configuration
@@ -306,7 +309,7 @@ def _create_maintenance_service(reactor, client_node, store: VoucherStore) -> IS
     def get_now():
         return datetime.utcfromtimestamp(reactor.seconds())
 
-    maint_config = lease_maintenance_from_tahoe_config(node_config)
+    maint_config = LeaseMaintenanceConfig.from_node_config(node_config)
 
     # Create the operation which performs the lease maintenance job when
     # called.

--- a/src/_zkapauthorizer/model.py
+++ b/src/_zkapauthorizer/model.py
@@ -279,7 +279,7 @@ class VoucherStore(object):
         )
 
     @with_cursor_async
-    def call_if_empty(self, cursor, f: Callable[[Cursor], _T]) -> _T:
+    async def call_if_empty(self, cursor, f: Callable[[Cursor], Awaitable[_T]]) -> _T:
         """
         Transactionally determine that the database is empty and call the given
         function if it is or raise ``NotEmpty`` if it is not.
@@ -293,7 +293,7 @@ class VoucherStore(object):
         # `invalid-unblinded-tokens` table and maybe also look at lease
         # maintenance spending.
         if self.list.wrapped(self, cursor) == []:
-            return f(cursor)
+            return await f(cursor)
         else:
             raise NotEmpty()
 

--- a/src/_zkapauthorizer/model.py
+++ b/src/_zkapauthorizer/model.py
@@ -278,11 +278,14 @@ class VoucherStore(object):
             conn,
         )
 
-    @with_cursor
-    def call_if_empty(self, cursor, f: Callable[[Cursor], None]) -> None:
+    @with_cursor_async
+    def call_if_empty(self, cursor, f: Callable[[Cursor], _T]) -> _T:
         """
         Transactionally determine that the database is empty and call the given
         function if it is or raise ``NotEmpty`` if it is not.
+
+        The function may return an ``Awaitable``.  If it does the transaction
+        opened for it will be kept open until the ``Awaitable`` completes.
         """
         # After redeemed-voucher garbage collection is implemented, this won't
         # be enough of a check.  We should check the unblinded-tokens table

--- a/src/_zkapauthorizer/recover.py
+++ b/src/_zkapauthorizer/recover.py
@@ -128,7 +128,7 @@ class StatefulRecoverer:
             return
 
         try:
-            recover(statements_from_download(downloaded_data), cursor)
+            recover(statements_from_snapshot(downloaded_data), cursor)
         except Exception as e:
             self._set_state(
                 RecoveryState(stage=RecoveryStages.import_failed, failure_reason=str(e))
@@ -177,7 +177,7 @@ def make_canned_downloader(data: bytes) -> Downloader:
 noop_downloader = make_canned_downloader(b"")
 
 
-def statements_from_download(data: BinaryIO) -> Iterator[str]:
+def statements_from_snapshot(data: BinaryIO) -> Iterator[str]:
     """
     Read the SQL statements which constitute the replica from a byte string.
     """

--- a/src/_zkapauthorizer/recover.py
+++ b/src/_zkapauthorizer/recover.py
@@ -181,7 +181,15 @@ def statements_from_snapshot(data: BinaryIO) -> Iterator[str]:
     """
     Read the SQL statements which constitute the replica from a byte string.
     """
-    return data.read().decode("ascii").splitlines()
+    s = data.read()
+    pos = 0
+    while pos < len(s):
+        delim = s.index(b":", pos)
+        length = int(s[pos:delim])
+        new_pos = delim + 1 + length
+        statement = s[delim + 1 : new_pos]
+        yield statement.decode("utf-8")
+        pos = new_pos + 1
 
 
 def recover(statements: Iterator[str], cursor) -> None:

--- a/src/_zkapauthorizer/recover.py
+++ b/src/_zkapauthorizer/recover.py
@@ -180,6 +180,8 @@ noop_downloader = make_canned_downloader(b"")
 def statements_from_snapshot(data: BinaryIO) -> Iterator[str]:
     """
     Read the SQL statements which constitute the replica from a byte string.
+
+    :see: http://cr.yp.to/proto/netstrings.txt
     """
     s = data.read()
     pos = 0

--- a/src/_zkapauthorizer/recover.py
+++ b/src/_zkapauthorizer/recover.py
@@ -3,7 +3,6 @@ A system for recovering local ZKAPAuthorizer state from a remote replica.
 """
 
 __all__ = [
-    "AlreadyRecovering",
     "RecoveryStages",
     "RecoveryState",
     "SetState",
@@ -30,12 +29,6 @@ from .tahoe import Tahoe, attenuate_writecap
 class SnapshotMissing(Exception):
     """
     No snapshot was not found in the replica directory.
-    """
-
-
-class AlreadyRecovering(Exception):
-    """
-    A recovery attempt is already in-progress so another one cannot be made.
     """
 
 
@@ -119,12 +112,9 @@ class StatefulRecoverer:
 
         :param cursor: A database cursor which can be used to populate the
             database with recovered state.
-
-        :raise AlreadyRecovering: If recovery has already been attempted
-            (successfully or otherwise).
         """
         if self._state.stage != RecoveryStages.inactive:
-            raise AlreadyRecovering()
+            return
 
         self._set_state(RecoveryState(stage=RecoveryStages.started))
         try:

--- a/src/_zkapauthorizer/resource.py
+++ b/src/_zkapauthorizer/resource.py
@@ -43,8 +43,8 @@ from . import NAME
 from . import __version__ as _zkapauthorizer_version
 from ._base64 import urlsafe_b64decode
 from ._json import dumps_utf8
-from .config import get_configured_lease_duration
 from .controller import PaymentController, get_redeemer
+from .lease_maintenance import LeaseMaintenanceConfig
 from .model import NotEmpty, VoucherStore
 from .pricecalculator import PriceCalculator
 from .private import create_private_tree
@@ -150,7 +150,7 @@ def from_configuration(
     )
     calculate_price = _CalculatePrice(
         calculator,
-        get_configured_lease_duration(node_config),
+        LeaseMaintenanceConfig.from_node_config(node_config).get_lease_duration(),
     )
 
     root = create_private_tree(

--- a/src/_zkapauthorizer/resource.py
+++ b/src/_zkapauthorizer/resource.py
@@ -258,9 +258,9 @@ class RecoverResource(Resource):
 
         try:
             downloader = self.get_downloader(cap)
-            self.store.call_if_empty(
-                lambda cursor: Deferred.fromCoroutine(
-                    self.recoverer.recover(downloader, cursor)
+            Deferred.fromCoroutine(
+                self.store.call_if_empty(
+                    lambda cursor: self.recoverer.recover(downloader, cursor),
                 ),
             )
         except NotEmpty:

--- a/src/_zkapauthorizer/resource.py
+++ b/src/_zkapauthorizer/resource.py
@@ -25,6 +25,7 @@ from collections.abc import Awaitable
 from json import loads
 from typing import Callable
 
+from allmydata.uri import ReadonlyDirectoryURI, from_string
 from attr import Factory, define, field
 from twisted.internet.defer import Deferred, inlineCallbacks
 from twisted.logger import Logger
@@ -231,8 +232,6 @@ class RecoverResource(Resource):
         return dumps_utf8(self.recoverer.state().marshal())
 
     def render_POST(self, request):
-        from allmydata.uri import ReadonlyDirectoryURI, from_string
-
         if wrong_content_type(request, "application/json"):
             return NOT_DONE_YET
 

--- a/src/_zkapauthorizer/tests/test_lease_maintenance.py
+++ b/src/_zkapauthorizer/tests/test_lease_maintenance.py
@@ -52,7 +52,7 @@ from twisted.internet.task import Clock
 from twisted.python.filepath import FilePath
 from zope.interface import implementer
 
-from ..config import empty_config, lease_maintenance_from_tahoe_config
+from ..config import empty_config
 from ..foolscap import ShareStat
 from ..lease_maintenance import (
     LeaseMaintenanceConfig,
@@ -76,7 +76,7 @@ from .strategies import (
     storage_indexes,
 )
 
-default_lease_maint_config = lease_maintenance_from_tahoe_config(empty_config)
+default_lease_maint_config = LeaseMaintenanceConfig.from_node_config(empty_config)
 
 
 def dummy_maintain_leases():


### PR DESCRIPTION
This is related to #235 and specifically to the last buillet point of #333.  Since recovery is async, `call_if_empty` must support async functions.  This makes `call_if_empty` async and fixes the web resource code to work with this.

It _also_ changes the format of snapshots from bare-SQL strings concatenated to netstring-encoded SQL strings concatenated.  This is necessary to be able to actually recover a snapshot ~which the new unit test that demonstrates `call_if_empty` / `recover` integrate requires~ which a test in a follow-up PR will demonstrate/require.  Otherwise, the dumped SQL statements with embedded newlines get split into pieces and cause syntax errors when recovery tries to execute them.
