### PR TITLE
Non-private Config alias

### DIFF
--- a/src/_zkapauthorizer/config.py
+++ b/src/_zkapauthorizer/config.py
@@ -16,10 +16,18 @@
 Helpers for reading values from the Tahoe-LAFS configuration.
 """
 
+__all__ = [
+    "REPLICA_RWCAP_BASENAME",
+    "EmptyConfig",
+    "empty_config",
+    "read_duration",
+    "read_node_url",
+]
+
 from datetime import timedelta
 from typing import Any, Optional
 
-from allmydata.node import _Config
+from allmydata.node import _Config as Config
 from hyperlink import DecodedURL
 from twisted.python.filepath import FilePath
 
@@ -30,7 +38,7 @@ from . import NAME
 REPLICA_RWCAP_BASENAME = NAME + ".replica-rwcap"
 
 
-class _EmptyConfig(object):
+class EmptyConfig(object):
     """
     Weakly pretend to be a Tahoe-LAFS configuration object with no
     configuration.
@@ -40,10 +48,10 @@ class _EmptyConfig(object):
         return default
 
 
-empty_config = _EmptyConfig()
+empty_config = EmptyConfig()
 
 
-def read_node_url(config: _Config) -> DecodedURL:
+def read_node_url(config: Config) -> DecodedURL:
     """
     Get the root of the node's HTTP API.
     """
@@ -55,7 +63,7 @@ def read_node_url(config: _Config) -> DecodedURL:
     )
 
 
-def read_duration(cfg: _Config, option: str, default: Any) -> Optional[timedelta]:
+def read_duration(cfg: Config, option: str, default: Any) -> Optional[timedelta]:
     """
     Read an integer number of seconds from the ZKAPAuthorizer section of a
     Tahoe-LAFS config.

--- a/src/_zkapauthorizer/lease_maintenance.py
+++ b/src/_zkapauthorizer/lease_maintenance.py
@@ -36,7 +36,7 @@ from twisted.internet.defer import inlineCallbacks, maybeDeferred
 from twisted.python.log import err
 from zope.interface import implementer
 
-from .config import _Config, read_duration
+from .config import Config, read_duration
 from .controller import bracket
 from .foolscap import ShareStat
 from .model import ILeaseMaintenanceObserver
@@ -458,7 +458,7 @@ class LeaseMaintenanceConfig(object):
     min_lease_remaining: timedelta = attr.ib()
 
     @classmethod
-    def from_node_config(cls: Type[_T], node_config: _Config) -> _T:
+    def from_node_config(cls: Type[_T], node_config: Config) -> _T:
         """
         Return a ``LeaseMaintenanceConfig`` representing the values from the given
         configuration object.

--- a/src/_zkapauthorizer/tests/resources.py
+++ b/src/_zkapauthorizer/tests/resources.py
@@ -15,7 +15,7 @@ from testresources import TestResourceManager
 from twisted.python.filepath import FilePath
 from yaml import safe_dump
 
-from ..config import _Config as Config
+from ..config import Config
 
 # An argv prefix to use in place of `tahoe` to run the Tahoe-LAFS CLI.  This
 # runs the CLI via the `__main__` so that we don't rely on `tahoe` being in


### PR DESCRIPTION
Instead of smearing private Tahoe-LAFS `_Config` usage all over ZKAPAuthorizer, we centralize this in one location which we could eventually replace with something else.

Change this to a public API - `Config` instead of `_Config` for the purposes of internal ZKAPAuthorizer code.
