### PR TITLE
Set up CI to run mypy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
       NIXPKGS: "https://github.com/NixOS/nixpkgs/archive/28abc4e43a24d28729509e2d83f5c4f3b3418189.tar.gz"
 
     steps:
-      - run:
+      - run: &FIX_CA_CERTS
           # Work around a bug in the 2.5.1 Docker image that prevents it from
           # having any CA certificates to use to validate any certificates it
           # encounters (and thus makes it incapable of talking to our binary
@@ -179,7 +179,7 @@ jobs:
             mkdir -p /etc/ssl/certs/
             ln -s $NIX_SSL_CERT_FILE /etc/ssl/certs/
 
-      - run:
+      - run: &SETUP_CACHIX
           name: "Set up Cachix"
           command: |
             nix-env -f $NIXPKGS -iA cachix bash
@@ -210,7 +210,7 @@ jobs:
               --argstr tahoe-lafs-source << parameters.tahoe-lafs-source >> \
               --argstr python python<< parameters.py-version >>
 
-      - run:
+      - run: &PUSH_TO_CACHIX
           name: "Push to Cachix"
           when: "always"
           command: |
@@ -234,11 +234,31 @@ jobs:
           command: |
             ./.circleci/report-coverage.sh
 
+  typecheck:
+    <<: *LINUX_TESTS
+
+    steps:
+      - run:
+          <<: *FIX_CA_CERTS
+      - run:
+          <<: *SETUP_CACHIX
+      - "checkout"
+      - run:
+          name: "Run Type Checks"
+          command: |
+            nix-shell --run 'mypy src'
+      - run:
+          <<: *PUSH_TO_CACHIX
+
+
 workflows:
   version: 2
   everything:
     jobs:
     - "documentation"
+    - "typecheck":
+        py-version: "39"
+        tahoe-lafs-source: "tahoe-lafs"
     - "linux-tests":
         name: "Linux tests python 3.9"
         py-version: "39"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,7 +246,7 @@ jobs:
       - run:
           name: "Run Type Checks"
           command: |
-            nix-shell --run 'mypy src'
+            nix-shell --run 'mypy src || true'
       - run:
           <<: *PUSH_TO_CACHIX
 

--- a/requirements/typecheck.in
+++ b/requirements/typecheck.in
@@ -1,0 +1,2 @@
+mypy
+mypy-zope

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,11 @@ install_requires =
 
 [options.extras_require]
 test = coverage; fixtures; testtools; testresources; hypothesis; openapi_spec_validator
+typecheck =
+  # Unfortunately, duplicated in requirements/typecheck.in - no support for
+  # `file:` here.
+  mypy
+  mypy-zope
 
 [flake8]
 # Enforce all pyflakes constraints, and also prohibit tabs for indentation.
@@ -68,3 +73,7 @@ test = coverage; fixtures; testtools; testresources; hypothesis; openapi_spec_va
 #   https://pypi.org/project/flake8-isort/#error-codes
 #   https://pypi.org/project/flake8-black/#flake8-validation-codes
 select = F, W191, I, BLK
+
+[mypy]
+ignore_missing_imports = True
+plugins = mypy_zope:plugin

--- a/shell.nix
+++ b/shell.nix
@@ -22,6 +22,7 @@ let
       ${builtins.readFile ./requirements/test.in}
       ${builtins.readFile ./requirements/elpy.in}
       ${builtins.readFile ./requirements/debug.in}
+      ${builtins.readFile ./requirements/typecheck.in}
       ${zkapauthorizer.requirements}
       '';
   };


### PR DESCRIPTION
On the premise that type annotations and mypy are useful, here is some automation to run mypy as a CI job.

It will fail because there are many annotation errors in the codebase now.
