### PR TITLE
Remove `VoucherStore.from_node_config` in favor of something better factored

### DIFF
--- a/src/_zkapauthorizer/_plugin.py
+++ b/src/_zkapauthorizer/_plugin.py
@@ -73,12 +73,17 @@ class AnnounceableStorageServer(object):
     storage_server = field()
 
 
-def open_store(
-    now: GetTime, node_config: Config, connect: Connect = _connect
-) -> VoucherStore:
+def open_store(now: GetTime, connect: Connect, node_config: Config) -> VoucherStore:
     """
+    Open a ``VoucherStore`` for the given configuration.
+
+    :param now: A function that can be used to get the current time.
+
     :param node_config: The Tahoe-LAFS configuration object for the node
         for which we want to open a store.
+
+    :param connect: A function that can be used to connect to the underlying
+        database.
     """
     db_path = FilePath(node_config.get_private_path(CONFIG_DB_NAME))
     conn = _open_database(partial(connect, db_path.path))
@@ -113,7 +118,7 @@ class ZKAPAuthorizer(object):
         try:
             s = self._stores[key]
         except KeyError:
-            s = open_store(datetime.now, node_config)
+            s = open_store(datetime.now, _connect, node_config)
             self._stores[key] = s
         return s
 

--- a/src/_zkapauthorizer/_plugin.py
+++ b/src/_zkapauthorizer/_plugin.py
@@ -45,8 +45,7 @@ from zope.interface import implementer
 from . import NAME
 from ._types import Connect, GetTime
 from .api import ZKAPAuthorizerStorageClient, ZKAPAuthorizerStorageServer
-from .config import CONFIG_DB_NAME
-from .config import _Config as Config
+from .config import CONFIG_DB_NAME, Config
 from .controller import get_redeemer
 from .lease_maintenance import SERVICE_NAME as MAINTENANCE_SERVICE_NAME
 from .lease_maintenance import (

--- a/src/_zkapauthorizer/_plugin.py
+++ b/src/_zkapauthorizer/_plugin.py
@@ -43,6 +43,7 @@ from twisted.python.filepath import FilePath
 from zope.interface import implementer
 
 from . import NAME
+from ._types import Connect, GetTime
 from .api import ZKAPAuthorizerStorageClient, ZKAPAuthorizerStorageServer
 from .config import CONFIG_DB_NAME
 from .config import _Config as Config
@@ -62,7 +63,6 @@ from .server.spending import get_spender
 from .spending import SpendingController
 from .storage_common import BYTES_PER_PASS, get_configured_pass_value
 from .tahoe import get_tahoe_client
-from .types import Connect, GetTime
 
 _log = Logger()
 

--- a/src/_zkapauthorizer/_types.py
+++ b/src/_zkapauthorizer/_types.py
@@ -1,3 +1,21 @@
+# Copyright 2022 PrivateStorage.io, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Re-usable type definitions for ZKAPAuthorizer.
+"""
+
 from sqlite3 import Connection
 from typing import Any, Callable, Protocol
 
@@ -5,6 +23,10 @@ GetTime = Callable[[], float]
 
 
 class Connect(Protocol):
+    """
+    Connect to a certain (ie, not parameterized) SQLite3 database.
+    """
+
     def __call__(
         self,
         timeout: int = None,

--- a/src/_zkapauthorizer/_types.py
+++ b/src/_zkapauthorizer/_types.py
@@ -1,0 +1,19 @@
+from sqlite3 import Connection
+from typing import Any, Callable, Protocol
+
+GetTime = Callable[[], float]
+
+
+class Connect(Protocol):
+    def __call__(
+        self,
+        timeout: int = None,
+        detect_types: bool = None,
+        isolation_level: str = None,
+        check_same_thread: bool = False,
+        factory: Any = None,
+        cached_statements: Any = None,
+    ) -> Connection:
+        """
+        Get a new database connection.
+        """

--- a/src/_zkapauthorizer/config.py
+++ b/src/_zkapauthorizer/config.py
@@ -40,6 +40,14 @@ _T = TypeVar("_T")
 # directory, if replication is configured.
 REPLICA_RWCAP_BASENAME = NAME + ".replica-rwcap"
 
+# The version number in NAME doesn't match the version here because the
+# database is persistent state and we need to be sure to load the older
+# version even if we signal an API compatibility break by bumping the version
+# number elsewhere.  Consider this version number part of a different scheme
+# where we're versioning our ability to open the database at all.  The schema
+# inside the database is versioned by yet another mechanism.
+CONFIG_DB_NAME = "privatestorageio-zkapauthz-v1.sqlite3"
+
 
 @define
 class EmptyConfig:

--- a/src/_zkapauthorizer/model.py
+++ b/src/_zkapauthorizer/model.py
@@ -33,10 +33,10 @@ from zope.interface import Interface, implementer
 
 from ._base64 import urlsafe_b64decode
 from ._json import dumps_utf8
+from ._types import Connect, GetTime
 from .replicate import Change, EventStream, with_replication
 from .schema import get_schema_upgrades, get_schema_version, run_schema_upgrades
 from .storage_common import pass_value_attribute, required_passes
-from .types import Connect, GetTime
 from .validators import greater_than, has_length, is_base64_encoded
 
 _T = TypeVar("_T")

--- a/src/_zkapauthorizer/model.py
+++ b/src/_zkapauthorizer/model.py
@@ -17,6 +17,8 @@ This module implements models (in the MVC sense) for the client side of
 the storage plugin.
 """
 
+from __future__ import annotations
+
 from datetime import datetime
 from functools import wraps
 from json import loads
@@ -259,7 +261,7 @@ class VoucherStore(object):
     @classmethod
     def from_connection(
         cls, pass_value: int, now: GetTime, conn: Connection
-    ) -> "VoucherStore":
+    ) -> VoucherStore:
         # Make sure we always have a replication-enabled connection even if
         # we're not doing replication yet because we might want to turn it on
         # later.  Also, if we're doing it, we need it to get involved in

--- a/src/_zkapauthorizer/model.py
+++ b/src/_zkapauthorizer/model.py
@@ -19,6 +19,7 @@ the storage plugin.
 
 from __future__ import annotations
 
+import os
 from datetime import datetime
 from functools import wraps
 from json import loads
@@ -237,7 +238,9 @@ def path_to_memory_uri(path: FilePath) -> str:
         DecodedURL()
         .replace(
             scheme="file",
-            path=path.segmentsFrom(FilePath("/")),
+            # segmentsFrom(FilePath("/")) is tempting but on Windows "/" is
+            # not necessarily the root for every path.
+            path=path.path.split(os.sep),
         )
         .add("mode", "memory")
         .to_text()

--- a/src/_zkapauthorizer/model.py
+++ b/src/_zkapauthorizer/model.py
@@ -220,6 +220,19 @@ def with_cursor(f):
 
 
 def path_to_memory_uri(path: FilePath) -> str:
+    """
+    Construct a SQLite3 database URI for an in-memory connection to a database
+    identified by the given path.
+
+    Since in-memory databases do not exist on disk the path does not actually
+    specify where on the filesystem the database exists.  Instead, it serves
+    as a key so that the same in-memory database can be opened multiple times
+    by supplying the same path (and similarly, different paths will result in
+    connections to different in-memory databases).
+
+    :return: A string suitable to be passed as the first argument to
+        ``sqlite3.connect`` along with the `uri=True` keyword argument.
+    """
     return (
         DecodedURL()
         .replace(

--- a/src/_zkapauthorizer/model.py
+++ b/src/_zkapauthorizer/model.py
@@ -22,12 +22,11 @@ from functools import wraps
 from json import loads
 from sqlite3 import Connection, Cursor, OperationalError
 from sqlite3 import connect as _connect
-from typing import Awaitable, Callable, Optional, Type, TypeVar
+from typing import Awaitable, Callable, TypeVar
 
 import attr
-from allmydata.node import _Config
 from aniso8601 import parse_datetime
-from compose import compose
+from hyperlink import DecodedURL
 from twisted.logger import Logger
 from twisted.python.filepath import FilePath
 from zope.interface import Interface, implementer
@@ -36,11 +35,8 @@ from ._base64 import urlsafe_b64decode
 from ._json import dumps_utf8
 from .replicate import Change, EventStream, with_replication
 from .schema import get_schema_upgrades, get_schema_version, run_schema_upgrades
-from .storage_common import (
-    get_configured_pass_value,
-    pass_value_attribute,
-    required_passes,
-)
+from .storage_common import pass_value_attribute, required_passes
+from .types import Connect, GetTime
 from .validators import greater_than, has_length, is_base64_encoded
 
 _T = TypeVar("_T")
@@ -88,42 +84,40 @@ class NotEnoughTokens(Exception):
     """
 
 
-# The version number in _zkapauthorizer.api.NAME doesn't match the version
-# here because the database is persistent state and we need to be sure to load
-# the older version even if we signal an API compatibility break by bumping
-# the version number elsewhere.  Consider this version number part of a
-# different scheme where we're versioning our ability to open the database at
-# all.  The schema inside the database is versioned by yet another mechanism.
-CONFIG_DB_NAME = "privatestorageio-zkapauthz-v1.sqlite3"
-
-_ConnectParamSpec = [str, int, bool, str, bool]
-_ConnectFunction = Callable[_ConnectParamSpec, Connection]
-
-
-def open_and_initialize(path: FilePath, connect: _ConnectFunction) -> Connection:
+def open_and_initialize(connect: Connect) -> Connection:
     """
     Open a SQLite3 database for use as a voucher store.
 
     Create the database and populate it with a schema, if it does not already
     exist.
 
-    :param path: The location of the SQLite3 database file.
+    :return: A SQLite3 connection object in which any necessary application
+        schema has been created.
+    """
+    conn = open_database(connect)
+    initialize_database(conn)
+    return conn
 
-    :return: A SQLite3 connection object for the database at the given path.
+
+def open_database(connect: Connect) -> Connection:
+    """
+    Create and return a database connection using the required connect
+    parameters.
     """
     try:
-        path.parent().makedirs(ignoreExistingDirectory=True)
-    except OSError as e:
-        raise StoreOpenError(e)
-
-    try:
-        conn = connect(
-            path.path,
-            isolation_level="IMMEDIATE",
-        )
+        return connect(isolation_level="IMMEDIATE")
     except OperationalError as e:
         raise StoreOpenError(e)
 
+
+def initialize_database(conn: Connection) -> None:
+    """
+    Make any persistent and temporary schema changes required to make the
+    given database compatible with this version of the software.
+
+    If the database has an older schema version, it will be upgraded.
+    Temporary tables required by application code will also be created.
+    """
     cursor = conn.cursor()
 
     with conn:
@@ -223,11 +217,23 @@ def with_cursor(f):
     return with_cursor
 
 
-def memory_connect(path, *a, **kw):
+def path_to_memory_uri(path: FilePath) -> str:
+    return (
+        DecodedURL()
+        .replace(
+            scheme="file",
+            path=path.segmentsFrom(FilePath("/")),
+        )
+        .add("mode", "memory")
+        .to_text()
+    )
+
+
+def memory_connect(path: str, *a, **kw) -> Connection:
     """
     Always connect to an in-memory SQLite3 database.
     """
-    return _connect(":memory:", *a, **kw)
+    return _connect(path_to_memory_uri(FilePath(path)), *a, uri=True, **kw)
 
 
 # The largest integer SQLite3 can represent in an integer column.  Larger than
@@ -244,50 +250,23 @@ class VoucherStore(object):
         ``datetime`` instance.
     """
 
-    _log = Logger()
-
     pass_value = pass_value_attribute()
-
-    database_path = attr.ib(validator=attr.validators.instance_of(FilePath))
     now = attr.ib()
-
     _connection = attr.ib()
 
+    _log = Logger()
+
     @classmethod
-    def from_node_config(
-        cls: Type[_T],
-        node_config: _Config,
-        now: Callable[[], datetime],
-        connect: Optional[_ConnectFunction] = None,
-    ) -> _T:
-        """
-        Create or open the ``VoucherStore`` for a given node.
-
-        :param node_config: The Tahoe-LAFS configuration object for the node
-            for which we want to open a store.
-
-        :param now: See ``VoucherStore.now``.
-
-        :param connect: An alternate database connection function.  This is
-            primarily for the purposes of the test suite.
-        """
-        if connect is None:
-            connect = _connect
-
-        db_path = FilePath(node_config.get_private_path(CONFIG_DB_NAME))
-        conn = open_and_initialize(
-            db_path,
-            # Make sure we always have a replication-enabled connection even
-            # if we're not doing replication yet because we might want to turn
-            # it on later.
-            compose(with_replication, connect),
-        )
-        return cls(
-            get_configured_pass_value(node_config),
-            db_path,
-            now,
-            conn,
-        )
+    def from_connection(
+        cls, pass_value: int, now: GetTime, conn: Connection
+    ) -> "VoucherStore":
+        # Make sure we always have a replication-enabled connection even if
+        # we're not doing replication yet because we might want to turn it on
+        # later.  Also, if we're doing it, we need it to get involved in
+        # database initialization which happens next.
+        replicating_conn = with_replication(conn)
+        initialize_database(replicating_conn)
+        return cls(pass_value=pass_value, now=now, connection=replicating_conn)
 
     def snapshot(self) -> bytes:
         """

--- a/src/_zkapauthorizer/tests/fixtures.py
+++ b/src/_zkapauthorizer/tests/fixtures.py
@@ -86,7 +86,7 @@ class TemporaryVoucherStore(Fixture):
     def _setUp(self):
         self.tempdir = self.useFixture(TempDir())
         self.config = self.get_config(self.tempdir.join("node"), "tub.port")
-        self.store = open_store(self.get_now, self.config, memory_connect)
+        self.store = open_store(self.get_now, memory_connect, self.config)
         self.addCleanup(self._cleanUp)
 
     def _cleanUp(self):
@@ -117,7 +117,7 @@ class ConfiglessMemoryVoucherStore(Fixture):
         return DummyRedeemer(self._public_key)
 
     def _setUp(self):
-        self.store = open_store(self.get_now, empty_config, memory_connect)
+        self.store = open_store(self.get_now, memory_connect, empty_config)
         self.addCleanup(self._cleanUp)
 
     def _cleanUp(self):

--- a/src/_zkapauthorizer/tests/fixtures.py
+++ b/src/_zkapauthorizer/tests/fixtures.py
@@ -33,7 +33,8 @@ from twisted.internet.task import Clock, deferLater
 from twisted.python.filepath import FilePath
 from twisted.web.client import Agent, HTTPConnectionPool
 
-from ..config import EmptyConfig
+from .._plugin import open_store
+from ..config import empty_config
 from ..controller import DummyRedeemer, IRedeemer, PaymentController
 from ..model import VoucherStore, memory_connect
 
@@ -85,11 +86,7 @@ class TemporaryVoucherStore(Fixture):
     def _setUp(self):
         self.tempdir = self.useFixture(TempDir())
         self.config = self.get_config(self.tempdir.join("node"), "tub.port")
-        self.store = VoucherStore.from_node_config(
-            self.config,
-            self.get_now,
-            memory_connect,
-        )
+        self.store = open_store(self.get_now, self.config, memory_connect)
         self.addCleanup(self._cleanUp)
 
     def _cleanUp(self):
@@ -120,11 +117,7 @@ class ConfiglessMemoryVoucherStore(Fixture):
         return DummyRedeemer(self._public_key)
 
     def _setUp(self):
-        self.store = VoucherStore.from_node_config(
-            EmptyConfig(FilePath(".")),
-            self.get_now,
-            memory_connect,
-        )
+        self.store = open_store(self.get_now, empty_config, memory_connect)
         self.addCleanup(self._cleanUp)
 
     def _cleanUp(self):

--- a/src/_zkapauthorizer/tests/test_client_resource.py
+++ b/src/_zkapauthorizer/tests/test_client_resource.py
@@ -229,8 +229,8 @@ def root_from_config(
         config,
         open_store(
             now,
-            config,
             memory_connect,
+            config,
         ),
         get_downloader=get_downloader,
         setup_replication=setup_replication,

--- a/src/_zkapauthorizer/tests/test_client_resource.py
+++ b/src/_zkapauthorizer/tests/test_client_resource.py
@@ -83,6 +83,7 @@ from .. import __file__ as package_init_file
 from .. import __version__ as zkapauthorizer_version
 from .._base64 import urlsafe_b64decode
 from .._json import dumps_utf8
+from .._plugin import open_store
 from ..configutil import config_string_from_sections
 from ..model import (
     DoubleSpend,
@@ -91,7 +92,6 @@ from ..model import (
     Redeeming,
     Unpaid,
     Voucher,
-    VoucherStore,
     memory_connect,
 )
 from ..pricecalculator import PriceCalculator
@@ -227,9 +227,9 @@ def root_from_config(
     """
     return from_configuration(
         config,
-        VoucherStore.from_node_config(
-            config,
+        open_store(
             now,
+            config,
             memory_connect,
         ),
         get_downloader=get_downloader,

--- a/src/_zkapauthorizer/tests/test_model.py
+++ b/src/_zkapauthorizer/tests/test_model.py
@@ -848,12 +848,9 @@ class EventStreamTests(TestCase):
         Various kinds of SQL statements can be serialized into and out of
         the event-stream.
         """
-        tempdir = self.useFixture(TempDir())
-        store = VoucherStore.from_node_config(
-            get_config(tempdir.join("node"), "tub.port"),
-            lambda: now,
-            memory_connect,
-        )
+        store = self.useFixture(
+            TemporaryVoucherStore(get_config, lambda: now),
+        ).store
 
         # generate some SQL events
         sql_statements = []

--- a/src/_zkapauthorizer/tests/test_plugin.py
+++ b/src/_zkapauthorizer/tests/test_plugin.py
@@ -19,7 +19,7 @@ Tests for the Tahoe-LAFS plugin.
 from datetime import timedelta
 from functools import partial
 from io import StringIO
-from os import makedirs
+from os import mkdir
 
 from allmydata.client import config_from_string, create_client_from_config
 from allmydata.interfaces import (
@@ -55,6 +55,7 @@ from testtools.matchers import (
     MatchesAll,
     MatchesListwise,
     MatchesStructure,
+    Raises,
 )
 from testtools.twistedsupport import succeeded
 from testtools.twistedsupport._deferred import extract_result
@@ -68,12 +69,12 @@ from twisted.web.resource import IResource
 from twisted.plugins.zkapauthorizer import storage_server_plugin
 
 from .. import NAME
-from .._plugin import get_root_nodes, load_signing_key
+from .._plugin import get_root_nodes, load_signing_key, open_store
 from .._storage_client import IncorrectStorageServerReference
 from ..controller import DummyRedeemer, IssuerConfigurationMismatch, PaymentController
 from ..foolscap import RIPrivacyPassAuthorizedStorageServer
 from ..lease_maintenance import SERVICE_NAME, LeaseMaintenanceConfig
-from ..model import NotEnoughTokens, VoucherStore
+from ..model import NotEnoughTokens, StoreOpenError
 from ..spending import GET_PASSES
 from .common import skipIf
 from .fixtures import DetectLeakedDescriptors
@@ -106,6 +107,58 @@ def get_rref(interface=None):
     if interface is None:
         interface = RIPrivacyPassAuthorizedStorageServer
     return LocalRemote(DummyReferenceable(interface))
+
+
+class OpenStoreTests(TestCase):
+    @skipIf(platform.isWindows(), "Hard to prevent directory creation on Windows")
+    @given(tahoe_configs(), datetimes())
+    def test_uncreateable_store_directory(self, get_config, now):
+        """
+        If the underlying directory in the node configuration cannot be created
+        then ``open_store`` raises ``StoreOpenError``.
+        """
+        nodedir = FilePath(self.useFixture(TempDir()).join("node"))
+
+        # Create the node directory without permission to create the
+        # underlying directory.
+        mkdir(nodedir.path, 0o500)
+
+        config = get_config(nodedir.path, "tub.port")
+
+        self.assertThat(
+            partial(open_store, lambda: now, config),
+            Raises(
+                AfterPreprocessing(
+                    lambda exc_info: exc_info[1],
+                    IsInstance(StoreOpenError),
+                ),
+            ),
+        )
+
+    @skipIf(
+        platform.isWindows(), "Hard to prevent database from being opened on Windows"
+    )
+    @given(tahoe_configs(), datetimes())
+    def test_unopenable_store(self, get_config, now):
+        """
+        If the underlying database file cannot be opened then ``open_store``
+        raises ``StoreOpenError``.
+        """
+        nodedir = FilePath(self.useFixture(TempDir()).join("node"))
+        nodedir.child("private").makedirs()
+
+        config = get_config(nodedir.path, "tub.port")
+
+        # Create the underlying database file.
+        open_store(lambda: now, config)
+
+        # Prevent further access to it.
+        nodedir.child("private").chmod(0o000)
+
+        self.assertThat(
+            lambda: open_store(lambda: now, config),
+            raises(StoreOpenError),
+        )
 
 
 class GetRRefTests(TestCase):
@@ -364,11 +417,10 @@ class ClientPluginTests(TestCase):
         ``get_storage_client`` returns an object which provides
         ``IStorageServer``.
         """
-        tempdir = self.useFixture(TempDir())
-        node_config = get_config(
-            tempdir.join("node"),
-            "tub.port",
-        )
+        nodedir = FilePath(self.useFixture(TempDir()).join("node"))
+        nodedir.child("private").makedirs()
+
+        node_config = get_config(nodedir.path, "tub.port")
 
         storage_client = storage_server_plugin.get_storage_client(
             node_config,
@@ -387,9 +439,11 @@ class ClientPluginTests(TestCase):
         ``get_storage_client`` raises an exception when called with an
         announcement and local configuration which specify different issuers.
         """
-        tempdir = self.useFixture(TempDir())
+        nodedir = FilePath(self.useFixture(TempDir()).join("node"))
+        nodedir.child("private").makedirs()
+
         node_config = config_from_string(
-            tempdir.join("node"),
+            nodedir.path,
             "tub.port",
             config_text.encode("utf-8"),
         )
@@ -431,11 +485,9 @@ class ClientPluginTests(TestCase):
         provider then the storage methods of the client raise exceptions that
         clearly indicate this.
         """
-        tempdir = self.useFixture(TempDir())
-        node_config = get_config(
-            tempdir.join("node"),
-            "tub.port",
-        )
+        nodedir = FilePath(self.useFixture(TempDir()).join("node"))
+        nodedir.child("private").makedirs()
+        node_config = get_config(nodedir.path, "tub.port")
 
         storage_client = storage_server_plugin.get_storage_client(
             node_config,
@@ -481,13 +533,12 @@ class ClientPluginTests(TestCase):
         The ``ZKAPAuthorizerStorageServer`` returned by ``get_storage_client``
         spends unblinded tokens from the plugin database.
         """
-        tempdir = self.useFixture(TempDir())
-        node_config = get_config(
-            tempdir.join("node"),
-            "tub.port",
-        )
+        nodedir = FilePath(self.useFixture(TempDir()).join("node"))
+        nodedir.child("private").makedirs()
+        node_config = get_config(nodedir.path, "tub.port")
 
-        store = VoucherStore.from_node_config(node_config, lambda: now)
+        # Populate the database with unspent tokens.
+        store = open_store(lambda: now, node_config)
 
         controller = PaymentController(
             store,
@@ -504,6 +555,7 @@ class ClientPluginTests(TestCase):
             succeeded(Always()),
         )
 
+        # Try to spend a pass via the storage client plugin.
         storage_client = storage_server_plugin.get_storage_client(
             node_config,
             announcement,
@@ -555,9 +607,9 @@ class ClientResourceTests(TestCase):
         """
         ``get_client_resource`` returns an object that provides ``IResource``.
         """
-        tempdir = self.useFixture(TempDir())
-        nodedir = tempdir.join("node")
-        config = get_config(nodedir, "tub.port")
+        nodedir = FilePath(self.useFixture(TempDir()).join("node"))
+        nodedir.child("private").makedirs()
+        config = get_config(nodedir.path, "tub.port")
         self.assertThat(
             storage_server_plugin.get_client_resource(
                 config,
@@ -630,11 +682,9 @@ class LeaseMaintenanceServiceTests(TestCase):
         :param rootcap: ``True`` to write some bytes to the node's ``rootcap``
             file, ``False`` otherwise.
         """
-        tempdir = self.useFixture(TempDir())
-        nodedir = tempdir.join("node")
-        privatedir = tempdir.join("node", "private")
-        makedirs(privatedir)
-        config = get_config(nodedir, "tub.port")
+        nodedir = FilePath(self.useFixture(TempDir()).join("node"))
+        nodedir.child("private").makedirs()
+        config = get_config(nodedir.path, "tub.port")
 
         # In Tahoe-LAFS 1.17 write_private_config is broken.  It mixes bytes
         # and unicode in an os.path.join() call that always fails with a

--- a/src/_zkapauthorizer/tests/test_plugin.py
+++ b/src/_zkapauthorizer/tests/test_plugin.py
@@ -20,6 +20,7 @@ from datetime import timedelta
 from functools import partial
 from io import StringIO
 from os import mkdir
+from sqlite3 import connect
 
 from allmydata.client import config_from_string, create_client_from_config
 from allmydata.interfaces import (
@@ -126,7 +127,7 @@ class OpenStoreTests(TestCase):
         config = get_config(nodedir.path, "tub.port")
 
         self.assertThat(
-            partial(open_store, lambda: now, config),
+            partial(open_store, lambda: now, connect, config),
             Raises(
                 AfterPreprocessing(
                     lambda exc_info: exc_info[1],
@@ -150,13 +151,13 @@ class OpenStoreTests(TestCase):
         config = get_config(nodedir.path, "tub.port")
 
         # Create the underlying database file.
-        open_store(lambda: now, config)
+        open_store(lambda: now, connect, config)
 
         # Prevent further access to it.
         nodedir.child("private").chmod(0o000)
 
         self.assertThat(
-            lambda: open_store(lambda: now, config),
+            lambda: open_store(lambda: now, connect, config),
             raises(StoreOpenError),
         )
 
@@ -538,7 +539,7 @@ class ClientPluginTests(TestCase):
         node_config = get_config(nodedir.path, "tub.port")
 
         # Populate the database with unspent tokens.
-        store = open_store(lambda: now, node_config)
+        store = open_store(lambda: now, connect, node_config)
 
         controller = PaymentController(
             store,


### PR DESCRIPTION
This came from @meejah 's comments about how `VoucherStore`'s reliance on the Tahoe-LAFS config object to find its database seemed less than ideal.

Ultimately this code still uses the Tahoe-LAFS config object to find the database path, but it does so in the glue code in `_plugin.py` instead of the database code in `model.py`.
