### PR TITLE
Fix most of the rest of the mypy errors

### DIFF
--- a/src/_zkapauthorizer/_storage_server.py
+++ b/src/_zkapauthorizer/_storage_server.py
@@ -44,6 +44,7 @@ from allmydata.storage.server import StorageServer
 from allmydata.storage.shares import get_share_file
 from allmydata.util.base32 import b2a
 from attr.validators import instance_of, provides
+from attrs import frozen
 from challenge_bypass_ristretto import (
     PublicKey,
     SigningKey,
@@ -90,19 +91,19 @@ class NewLengthRejected(Exception):
     """
 
 
-@attr.s
+@frozen
 class _ValidationResult(object):
     """
     The result of validating a list of passes.
 
-    :ivar list[bytes] valid: A list of valid token preimages.
+    :ivar valid: A list of valid token preimages.
 
-    :ivar list[int] signature_check_failed: A list of indexes (into the
-        validated list) of passes which did not have a correct signature.
+    :ivar signature_check_failed: A list of indexes (into the validated list)
+        of passes which did not have a correct signature.
     """
 
-    valid = attr.ib()
-    signature_check_failed = attr.ib()
+    valid: list[bytes]
+    signature_check_failed: list[int]
 
     @classmethod
     def _is_invalid_pass(cls, message, pass_, signing_key):

--- a/src/_zkapauthorizer/model.py
+++ b/src/_zkapauthorizer/model.py
@@ -948,12 +948,6 @@ class Pass(object):
     """
     A ``Pass`` instance completely represents a single Zero-Knowledge Access Pass.
 
-    :ivar bytes pass_bytes: The text value of the pass.  This can be sent to
-        a service provider one time to anonymously prove a prior voucher
-        redemption.  If it is sent more than once the service provider may
-        choose to reject it and the anonymity property is compromised.  Pass
-        text should be kept secret.  If pass text is divulged to third-parties
-        the anonymity property may be compromised.
     """
 
     preimage = attr.ib(
@@ -974,6 +968,15 @@ class Pass(object):
 
     @property
     def pass_bytes(self):
+        """
+        The byte string representation of the pass.
+
+        This can be sent to a service provider one time to anonymously prove a
+        prior voucher redemption.  If it is sent more than once the service
+        provider may choose to reject it and the anonymity property is
+        compromised.  This value should be kept secret.  If this value is
+        divulged to third-parties the anonymity property may be compromised.
+        """
         return b" ".join((self.preimage, self.signature))
 
     @classmethod

--- a/src/_zkapauthorizer/model.py
+++ b/src/_zkapauthorizer/model.py
@@ -27,6 +27,7 @@ from typing import Awaitable, Callable, Optional, Type, TypeVar
 import attr
 from allmydata.node import _Config
 from aniso8601 import parse_datetime
+from attr import define, frozen
 from compose import compose
 from twisted.logger import Logger
 from twisted.python.filepath import FilePath
@@ -235,7 +236,7 @@ def memory_connect(path, *a, **kw):
 _SQLITE3_INTEGER_MAX = 2 ** 63 - 1
 
 
-@attr.s(frozen=True)
+@frozen
 class VoucherStore(object):
     """
     This class implements persistence for vouchers.
@@ -825,7 +826,7 @@ class VoucherStore(object):
 
 
 @implementer(ILeaseMaintenanceObserver)
-@attr.s
+@define
 class LeaseMaintenance(object):
     """
     A state-updating helper for recording pass usage during a lease
@@ -901,7 +902,7 @@ class LeaseMaintenance(object):
         self._rowid = None
 
 
-@attr.s
+@frozen
 class LeaseMaintenanceActivity(object):
     started = attr.ib()
     passes_required = attr.ib()
@@ -919,7 +920,7 @@ class LeaseMaintenanceActivity(object):
 # xs.started, xs.passes_required, xs.finished
 
 
-@attr.s(frozen=True)
+@frozen(order=True)
 class UnblindedToken(object):
     """
     An ``UnblindedToken`` instance represents cryptographic proof of a voucher
@@ -942,7 +943,7 @@ class UnblindedToken(object):
     )
 
 
-@attr.s(frozen=True)
+@frozen
 class Pass(object):
     """
     A ``Pass`` instance completely represents a single Zero-Knowledge Access Pass.
@@ -980,7 +981,7 @@ class Pass(object):
         return cls(*pass_.split(b" "))
 
 
-@attr.s(frozen=True)
+@frozen
 class RandomToken(object):
     """
     :ivar bytes token_value: The base64-encoded representation of the random
@@ -1005,7 +1006,7 @@ def _counter_attribute():
     )
 
 
-@attr.s(frozen=True)
+@frozen
 class Pending(object):
     """
     The voucher has not yet been completely redeemed for ZKAPs.
@@ -1014,7 +1015,7 @@ class Pending(object):
         successfully performed for the voucher.
     """
 
-    counter = _counter_attribute()
+    counter: int = _counter_attribute()
 
     def should_start_redemption(self):
         return True
@@ -1026,7 +1027,7 @@ class Pending(object):
         }
 
 
-@attr.s(frozen=True)
+@frozen
 class Redeeming(object):
     """
     This is a non-persistent state in which a voucher exists when the database
@@ -1048,7 +1049,7 @@ class Redeeming(object):
         }
 
 
-@attr.s(frozen=True)
+@frozen
 class Redeemed(object):
     """
     The voucher was successfully redeemed.  Associated tokens were retrieved
@@ -1073,7 +1074,7 @@ class Redeemed(object):
         }
 
 
-@attr.s(frozen=True)
+@frozen
 class DoubleSpend(object):
     finished = attr.ib(validator=attr.validators.instance_of(datetime))
 
@@ -1087,7 +1088,7 @@ class DoubleSpend(object):
         }
 
 
-@attr.s(frozen=True)
+@frozen
 class Unpaid(object):
     """
     This is a non-persistent state in which a voucher exists when the database
@@ -1107,7 +1108,7 @@ class Unpaid(object):
         }
 
 
-@attr.s(frozen=True)
+@frozen
 class Error(object):
     """
     This is a non-persistent state in which a voucher exists when the database
@@ -1129,7 +1130,7 @@ class Error(object):
         }
 
 
-@attr.s(frozen=True)
+@frozen
 class Voucher(object):
     """
     :ivar bytes number: The byte string which gives this voucher its

--- a/src/_zkapauthorizer/replicate.py
+++ b/src/_zkapauthorizer/replicate.py
@@ -86,7 +86,7 @@ class EventStream:
     A series of database operations represented as `Change` instances.
     """
 
-    changes: tuple[Change]
+    changes: tuple[Change, ...]
 
     def highest_sequence(self) -> Optional[int]:
         """

--- a/src/_zkapauthorizer/spending.py
+++ b/src/_zkapauthorizer/spending.py
@@ -128,7 +128,7 @@ class PassGroup(object):
     def unblinded_tokens(self) -> list[UnblindedToken]:
         return list(unblinded_token for (unblinded_token, pass_) in self._tokens)
 
-    def split(self, select_indices: list[int]) -> (PassGroup, PassGroup):
+    def split(self, select_indices: list[int]) -> tuple[PassGroup, PassGroup]:
         selected = []
         unselected = []
         for idx, t in enumerate(self._tokens):

--- a/src/_zkapauthorizer/spending.py
+++ b/src/_zkapauthorizer/spending.py
@@ -99,6 +99,21 @@ class IPassFactory(Interface):
             of the requested size.
         """
 
+    def mark_spent(unblinded_tokens: list[UnblindedToken]) -> None:
+        """
+        See ``IPassGroup.mark_spent``
+        """
+
+    def mark_invalid(reason: str, unblinded_tokens: list[UnblindedToken]) -> None:
+        """
+        See ``IPassGroup.mark_invalid``
+        """
+
+    def reset(unblinded_tokens: list[UnblindedToken]) -> None:
+        """
+        See ``IPassGroup.reset``
+        """
+
 
 @implementer(IPassGroup)
 @attr.s
@@ -148,13 +163,13 @@ class PassGroup(object):
         )
 
     def mark_spent(self) -> None:
-        self._factory._mark_spent(self.unblinded_tokens)
+        self._factory.mark_spent(self.unblinded_tokens)
 
     def mark_invalid(self, reason) -> None:
-        self._factory._mark_invalid(reason, self.unblinded_tokens)
+        self._factory.mark_invalid(reason, self.unblinded_tokens)
 
     def reset(self) -> None:
-        self._factory._reset(self.unblinded_tokens)
+        self._factory.reset(self.unblinded_tokens)
 
 
 @implementer(IPassFactory)
@@ -191,20 +206,20 @@ class SpendingController(object):
         )
         return PassGroup(message, self, list(zip(unblinded_tokens, passes)))
 
-    def _mark_spent(self, unblinded_tokens):
+    def mark_spent(self, unblinded_tokens):
         SPENT_PASSES.log(
             count=len(unblinded_tokens),
         )
         self.discard_unblinded_tokens(unblinded_tokens)
 
-    def _mark_invalid(self, reason, unblinded_tokens):
+    def mark_invalid(self, reason, unblinded_tokens):
         INVALID_PASSES.log(
             reason=reason,
             count=len(unblinded_tokens),
         )
         self.invalidate_unblinded_tokens(reason, unblinded_tokens)
 
-    def _reset(self, unblinded_tokens):
+    def reset(self, unblinded_tokens):
         RESET_PASSES.log(
             count=len(unblinded_tokens),
         )

--- a/src/_zkapauthorizer/storage_common.py
+++ b/src/_zkapauthorizer/storage_common.py
@@ -135,7 +135,7 @@ def get_configured_allowed_public_keys(node_config):
     )
 
 
-_dict_values = type(dict().values())
+_dict_values: type = type(dict().values())
 
 
 def required_passes(bytes_per_pass, share_sizes):

--- a/src/_zkapauthorizer/storage_common.py
+++ b/src/_zkapauthorizer/storage_common.py
@@ -47,7 +47,7 @@ class MorePassesRequired(Exception):
     signature_check_failed: frozenset[int] = attr.ib(converter=frozenset)
 
 
-def _message_maker(label: str) -> Callable[[str], bytes]:
+def _message_maker(label: str) -> Callable[[bytes], bytes]:
     def make_message(storage_index):
         return "{label} {storage_index}".format(
             label=label,

--- a/src/_zkapauthorizer/storage_common.py
+++ b/src/_zkapauthorizer/storage_common.py
@@ -33,19 +33,18 @@ class MorePassesRequired(Exception):
     Storage operations fail with ``MorePassesRequired`` when they are not
     accompanied by a sufficient number of valid passes.
 
-    :ivar int valid_count: The number of valid passes presented in the
-        operation.
+    :ivar valid_count: The number of valid passes presented in the operation.
 
-    ivar int required_count: The number of valid passes which must be
-        presented for the operation to be authorized.
+    ivar required_count: The number of valid passes which must be presented
+        for the operation to be authorized.
 
-    :ivar set[int] signature_check_failed: Indices into the supplied list of
-        passes indicating passes which failed the signature check.
+    :ivar signature_check_failed: Indices into the supplied list of passes
+        indicating passes which failed the signature check.
     """
 
-    valid_count = attr.ib(validator=attr.validators.instance_of(int))
-    required_count = attr.ib(validator=attr.validators.instance_of(int))
-    signature_check_failed = attr.ib(converter=frozenset)
+    valid_count: int = attr.ib(validator=attr.validators.instance_of(int))
+    required_count: int = attr.ib(validator=attr.validators.instance_of(int))
+    signature_check_failed: frozenset[int] = attr.ib(converter=frozenset)
 
 
 def _message_maker(label: str) -> Callable[[str], bytes]:

--- a/src/_zkapauthorizer/tests/storage_common.py
+++ b/src/_zkapauthorizer/tests/storage_common.py
@@ -251,14 +251,14 @@ class _PassFactory(object):
         self.spent.clear()
         self.issued.clear()
 
-    def _mark_spent(self, passes):
+    def mark_spent(self, passes):
         for p in passes:
             if p not in self.in_use:
                 raise ValueError("Pass {} cannot be spent, it is not in use.".format(p))
         self.spent.update(passes)
         self.in_use.difference_update(passes)
 
-    def _mark_invalid(self, reason, passes):
+    def mark_invalid(self, reason, passes):
         for p in passes:
             if p not in self.in_use:
                 raise ValueError(
@@ -267,7 +267,7 @@ class _PassFactory(object):
         self.invalid.update(dict.fromkeys(passes, reason))
         self.in_use.difference_update(passes)
 
-    def _reset(self, passes):
+    def reset(self, passes):
         for p in passes:
             if p not in self.in_use:
                 raise ValueError("Pass {} cannot be reset, it is not in use.".format(p))

--- a/src/_zkapauthorizer/tests/storage_common.py
+++ b/src/_zkapauthorizer/tests/storage_common.py
@@ -16,18 +16,17 @@
 ``allmydata.storage``-related helpers shared across the test suite.
 """
 
-from functools import partial
-from itertools import islice
+from base64 import b64decode, b64encode
 from os import SEEK_CUR
 from struct import pack
-from typing import Callable
+from typing import Callable, Optional
 
 import attr
 from challenge_bypass_ristretto import RandomToken, SigningKey
 from twisted.python.filepath import FilePath
 from zope.interface import implementer
 
-from ..model import NotEnoughTokens
+from ..model import NotEnoughTokens, Pass, UnblindedToken
 from ..spending import IPassFactory, PassGroup
 from .privacypass import make_passes
 from .strategies import bytes_for_share  # Not really a strategy...
@@ -136,35 +135,15 @@ def whitebox_write_sparse_share(sharepath, version, size, leases, now):
         )
 
 
-def integer_passes(limit: int) -> Callable[[bytes, int], list[int]]:
+def get_passes(message: bytes, count: int, signing_key: SigningKey) -> list[Pass]:
     """
-    :return: A function which can be used to get a number of passes.  The
-        function accepts a unicode request-binding message and an integer
-        number of passes.  It returns a list of integers which serve as
-        passes.  Successive calls to the function return unique pass values.
-    """
-    counter = iter(range(limit))
+    :param message: Request-binding message for PrivacyPass.
 
-    def get_passes(message, num_passes):
-        result = list(islice(counter, num_passes))
-        if len(result) < num_passes:
-            raise NotEnoughTokens()
-        return result
+    :param count: The number of passes to get.
 
-    return get_passes
+    :param signing_key: The key to use to sign the passes.
 
-
-def get_passes(
-    message: bytes, count: int, signing_key: SigningKey
-) -> list[RandomToken]:
-    """
-    :param bytes message: Request-binding message for PrivacyPass.
-
-    :param int count: The number of passes to get.
-
-    :param SigningKey signing_key: The key to use to sign the passes.
-
-    :return list[Pass]: ``count`` new random passes signed with the given key
+    :return: ``count`` new random passes signed with the given key
         and bound to the given message.
     """
     assert isinstance(message, bytes)
@@ -175,28 +154,62 @@ def get_passes(
     )
 
 
-def privacypass_passes(signing_key):
+def privacypass_passes(
+    signing_key: SigningKey, limit: Optional[int] = None
+) -> Callable[[bytes, int], list[Pass]]:
     """
     Get a PrivacyPass issuing function.
 
-    :param SigningKey signing_key: The key to use to issue passes.
+    :param signing_key: The key to use to issue passes.
+
+    :param limit: If not None, the maximum number of passes the returned
+        function will issue in total.
 
     :return: Return a function which can be used to get a number of passes.
-        The function accepts a unicode request-binding message and an integer
-        number of passes.  It returns a list of real pass values signed by the
-        given key.  Successive calls to the function return unique passes.
+        The function accepts a request-binding message and a number of passes.
+        It returns a list of real pass values signed by the given key.
+        Successive calls to the function return unique passes.
     """
-    return partial(get_passes, signing_key=signing_key)
+    remaining = limit
+
+    def limited_get_passes(message, count):
+        nonlocal remaining
+
+        if remaining is not None:
+            if count > remaining:
+                raise NotEnoughTokens()
+            remaining -= count
+
+        return get_passes(message, count, signing_key)
+
+    return limited_get_passes
 
 
-def pass_factory(get_passes):
+def pass_factory(get_passes: Callable[[bytes, int], list[Pass]]):
     """
     Get a new factory for passes.
 
-    :param (unicode -> int -> [pass]) get_passes: A function the factory can
-        use to get new passes.
+    :param get_passes: A function the factory can use to get new passes.
     """
     return _PassFactory(get_passes=get_passes)
+
+
+def _pass_to_token(p: Pass) -> UnblindedToken:
+    """
+    Create an unblinded token from a pass.
+
+    This is not part of the PrivacyPass protocol.  This does not create the
+    same unblinded token that was used to create the pass.  This is a
+    work-around for the tests wanting to know slightly different things than
+    the real implementation, and at slightly different times.  See
+    ``_PassFactory``.
+
+    It would probably be an improvement we didn't need this function.
+    """
+    signature_raw = b64decode(p.signature)
+    # expand it to the size required by UnblindedToken
+    signature_raw = signature_raw + signature_raw[:32]
+    return UnblindedToken(b64encode(signature_raw))
 
 
 @implementer(IPassFactory)
@@ -207,39 +220,68 @@ class _PassFactory(object):
 
     :ivar _get_passes: A function for getting passes.
 
-    :ivar in_use: All of the passes given out without a confirmed
-        terminal state.
+    :ivar in_use: All of the unblinded tokens corresponding to passes given
+        out which do not have a confirmed terminal state.
 
-    :ivar invalid: All of the passes given out and returned using
-        ``IPassGroup.invalid`` mapped to the reason given.
+    :ivar invalid: All of the unblinded tokens corresponding to passes given
+        out and returned using ``IPassGroup.invalid`` mapped to the reason
+        given.
 
-    :ivar spent: All of the passes given out and returned via
-        ``IPassGroup.mark_spent``.
+    :ivar spent: All of the unblinded tokens corresponding to passes given out
+        and returned via ``IPassGroup.mark_spent``.
 
-    :ivar issued: All of the passes ever given out.
+    :ivar issued: All of the unblinded tokens corresponding to passes ever
+        given out.
 
-    :ivar returned: A list of passes which were given out but then returned
-        via ``IPassGroup.reset``.
+    :ivar returned: A list of the unblinded tokens corresponding to passes
+        which were given out but then returned via ``IPassGroup.reset``.
     """
 
-    _get_passes: Callable[[bytes, int], list[bytes]] = attr.ib()
+    _get_passes: Callable[[bytes, int], list[Pass]] = attr.ib()
 
-    returned: list[int] = attr.ib(default=attr.Factory(list), init=False)
-    in_use: set[int] = attr.ib(default=attr.Factory(set), init=False)
-    invalid: dict[int, str] = attr.ib(default=attr.Factory(dict), init=False)
-    spent: set[int] = attr.ib(default=attr.Factory(set), init=False)
-    issued: set[int] = attr.ib(default=attr.Factory(set), init=False)
+    returned: list[UnblindedToken] = attr.ib(default=attr.Factory(list), init=False)
+    in_use: set[UnblindedToken] = attr.ib(default=attr.Factory(set), init=False)
+    invalid: dict[UnblindedToken, str] = attr.ib(default=attr.Factory(dict), init=False)
+    spent: set[UnblindedToken] = attr.ib(default=attr.Factory(set), init=False)
+    issued: set[UnblindedToken] = attr.ib(default=attr.Factory(set), init=False)
+
+    # Map unblinded tokens to passes so that we can recover passes from
+    # returned unblinded tokens so we can give those passes out again.
+    token_to_pass: dict[UnblindedToken, Pass] = attr.ib(
+        default=attr.Factory(dict), init=False
+    )
+
+    @property
+    def spent_passes(self) -> set[Pass]:
+        return {self.token_to_pass[t] for t in self.spent}
+
+    @property
+    def issued_passes(self) -> set[Pass]:
+        return {self.token_to_pass[t] for t in self.issued}
+
+    @property
+    def returned_passes(self) -> set[Pass]:
+        return {self.token_to_pass[t] for t in self.returned}
+
+    @property
+    def invalid_passes(self) -> dict[Pass, str]:
+        return {self.token_to_pass[t]: reason for t, reason in self.invalid.items()}
 
     def get(self, message: bytes, num_passes: int) -> PassGroup:
-        passes = []
+        passes: list[Pass] = []
         if self.returned:
-            passes.extend(self.returned[:num_passes])
+            passes.extend(self.token_to_pass[t] for t in self.returned[:num_passes])
             del self.returned[:num_passes]
             num_passes -= len(passes)
         passes.extend(self._get_passes(message, num_passes))
-        self.issued.update(passes)
-        self.in_use.update(passes)
-        return PassGroup(message, self, list(zip(passes, passes)))
+        tokens = [_pass_to_token(p) for p in passes]
+
+        pass_info = list(zip(tokens, passes))
+        self.token_to_pass.update(pass_info)
+
+        self.issued.update(tokens)
+        self.in_use.update(tokens)
+        return PassGroup(message, self, pass_info)
 
     def _clear(self):
         """
@@ -250,26 +292,52 @@ class _PassFactory(object):
         self.invalid.clear()
         self.spent.clear()
         self.issued.clear()
+        self.token_to_pass.clear()
 
-    def mark_spent(self, passes):
-        for p in passes:
-            if p not in self.in_use:
-                raise ValueError("Pass {} cannot be spent, it is not in use.".format(p))
-        self.spent.update(passes)
-        self.in_use.difference_update(passes)
+    def mark_spent(self, unblinded_tokens: list[UnblindedToken]) -> None:
+        """
+        Check the operation for consistency and update internal book-keeping
+        related to the given tokens.
 
-    def mark_invalid(self, reason, passes):
-        for p in passes:
-            if p not in self.in_use:
+        :raise ValueError: If this state transition is illegal for any of the
+            given tokens.
+        """
+        for t in unblinded_tokens:
+            if t not in self.in_use:
                 raise ValueError(
-                    "Pass {} cannot be invalid, it is not in use.".format(p)
+                    f"Unblinded token {t} cannot be spent, it is not in use."
                 )
-        self.invalid.update(dict.fromkeys(passes, reason))
-        self.in_use.difference_update(passes)
+        self.spent.update(unblinded_tokens)
+        self.in_use.difference_update(unblinded_tokens)
 
-    def reset(self, passes):
-        for p in passes:
-            if p not in self.in_use:
-                raise ValueError("Pass {} cannot be reset, it is not in use.".format(p))
-        self.returned.extend(passes)
-        self.in_use.difference_update(passes)
+    def mark_invalid(self, reason, unblinded_tokens: list[UnblindedToken]) -> None:
+        """
+        Check the operation for consistency and update internal book-keeping
+        related to the given tokens.
+
+        :raise ValueError: If this state transition is illegal for any of the
+            given tokens.
+        """
+        for t in unblinded_tokens:
+            if t not in self.in_use:
+                raise ValueError(
+                    f"Unblinded token {t} cannot be invalid, it is not in use."
+                )
+        self.invalid.update(dict.fromkeys(unblinded_tokens, reason))
+        self.in_use.difference_update(unblinded_tokens)
+
+    def reset(self, unblinded_tokens: list[UnblindedToken]) -> None:
+        """
+        Check the operation for consistency and update internal book-keeping
+        related to the given tokens.
+
+        :raise ValueError: If this state transition is illegal for any of the
+            given tokens.
+        """
+        for t in unblinded_tokens:
+            if t not in self.in_use:
+                raise ValueError(
+                    f"Unblinded token {t} cannot be reset, it is not in use."
+                )
+        self.returned.extend(unblinded_tokens)
+        self.in_use.difference_update(unblinded_tokens)

--- a/src/_zkapauthorizer/tests/test_storage_client.py
+++ b/src/_zkapauthorizer/tests/test_storage_client.py
@@ -16,7 +16,6 @@
 Tests for ``_zkapauthorizer._storage_client``.
 """
 
-from base64 import b64decode
 from functools import partial
 
 from allmydata.client import config_from_string
@@ -26,7 +25,6 @@ from hypothesis.strategies import integers, sampled_from, sets
 from testtools import TestCase
 from testtools.matchers import (
     AfterPreprocessing,
-    AllMatch,
     Always,
     Equals,
     HasLength,
@@ -50,7 +48,7 @@ from ..storage_common import (
     get_configured_shares_needed,
     get_configured_shares_total,
 )
-from .matchers import even, odd, raises
+from .matchers import raises
 from .storage_common import pass_factory, privacypass_passes
 from .strategies import dummy_ristretto_keys, pass_counts
 

--- a/src/_zkapauthorizer/tests/test_storage_client.py
+++ b/src/_zkapauthorizer/tests/test_storage_client.py
@@ -16,9 +16,11 @@
 Tests for ``_zkapauthorizer._storage_client``.
 """
 
+from base64 import b64decode
 from functools import partial
 
 from allmydata.client import config_from_string
+from challenge_bypass_ristretto import random_signing_key
 from hypothesis import given
 from hypothesis.strategies import integers, sampled_from, sets
 from testtools import TestCase
@@ -41,6 +43,7 @@ from .._storage_client import call_with_passes
 from .._storage_server import _ValidationResult
 from ..api import MorePassesRequired
 from ..model import NotEnoughTokens
+from ..spending import PassGroup
 from ..storage_common import (
     get_configured_allowed_public_keys,
     get_configured_pass_value,
@@ -48,7 +51,7 @@ from ..storage_common import (
     get_configured_shares_total,
 )
 from .matchers import even, odd, raises
-from .storage_common import integer_passes, pass_factory
+from .storage_common import pass_factory, privacypass_passes
 from .strategies import dummy_ristretto_keys, pass_counts
 
 
@@ -168,6 +171,10 @@ class CallWithPassesTests(TestCase):
     Tests for ``call_with_passes``.
     """
 
+    def setUp(self):
+        super().setUp()
+        self.signing_key = random_signing_key()
+
     @given(pass_counts())
     def test_success_result(self, num_passes):
         """
@@ -180,7 +187,10 @@ class CallWithPassesTests(TestCase):
             call_with_passes(
                 lambda group: succeed(result),
                 num_passes,
-                partial(pass_factory(integer_passes(num_passes)).get, b"message"),
+                partial(
+                    pass_factory(privacypass_passes(self.signing_key, num_passes)).get,
+                    b"message",
+                ),
             ),
             succeeded(Is(result)),
         )
@@ -197,7 +207,10 @@ class CallWithPassesTests(TestCase):
             call_with_passes(
                 lambda group: fail(result),
                 num_passes,
-                partial(pass_factory(integer_passes(num_passes)).get, b"message"),
+                partial(
+                    pass_factory(privacypass_passes(self.signing_key, num_passes)).get,
+                    b"message",
+                ),
             ),
             failed(
                 AfterPreprocessing(
@@ -214,7 +227,7 @@ class CallWithPassesTests(TestCase):
         provider containing ``num_passes`` created by the function passed for
         ``get_passes``.
         """
-        passes = pass_factory(integer_passes(num_passes))
+        passes = pass_factory(privacypass_passes(self.signing_key, num_passes))
 
         self.assertThat(
             call_with_passes(
@@ -223,8 +236,11 @@ class CallWithPassesTests(TestCase):
                 partial(passes.get, b"message"),
             ),
             succeeded(
-                Equals(
-                    sorted(passes.issued),
+                AfterPreprocessing(
+                    set,
+                    Equals(
+                        passes.issued_passes,
+                    ),
                 ),
             ),
         )
@@ -235,7 +251,7 @@ class CallWithPassesTests(TestCase):
         ``call_with_passes`` marks the passes it uses as spent if the operation
         succeeds.
         """
-        passes = pass_factory(integer_passes(num_passes))
+        passes = pass_factory(privacypass_passes(self.signing_key, num_passes))
 
         self.assertThat(
             call_with_passes(
@@ -255,7 +271,7 @@ class CallWithPassesTests(TestCase):
         """
         ``call_with_passes`` returns the passes it uses if the operation fails.
         """
-        passes = pass_factory(integer_passes(num_passes))
+        passes = pass_factory(privacypass_passes(self.signing_key, num_passes))
 
         self.assertThat(
             call_with_passes(
@@ -280,26 +296,34 @@ class CallWithPassesTests(TestCase):
         of passes, still of length ```num_passes``, but without the passes
         which were rejected on the first try.
         """
-        # Half of the passes are going to be rejected so make twice as many as
-        # the operation uses available.
-        passes = pass_factory(integer_passes(num_passes * 2))
+        # We'll reject one pass from each of two calls so make sure we have
+        # two more than necessary.
+        reject_count = 2
+        rejected_passes = set()
+        passes = pass_factory(
+            privacypass_passes(self.signing_key, num_passes + reject_count)
+        )
 
-        def reject_even_pass_values(group):
-            passes = group.passes
-            good_passes = list(idx for (idx, p) in enumerate(passes) if p % 2)
-            bad_passes = list(
-                idx for (idx, p) in enumerate(passes) if idx not in good_passes
-            )
-            if len(good_passes) < num_passes:
+        def maybe_reject_passes(group: PassGroup) -> None:
+            if len(rejected_passes) < reject_count:
+                # Reject the first pass
+                rejected_passes.add(group.passes[0])
+
+                # Signal the failure
                 _ValidationResult(
-                    valid=good_passes,
-                    signature_check_failed=bad_passes,
+                    valid=[pass_.preimage for pass_ in group.passes[1:]],
+                    signature_check_failed=[0],
                 ).raise_for(num_passes)
-            return None
+            else:
+                # Otherwise accept them all.
+                return None
 
+        # To succeed with the given function, `call_with_passes` will have to
+        # have to try (reject_count + 1) times and replace one rejected token
+        # with a fresh one on each call after the first.
         self.assertThat(
             call_with_passes(
-                reject_even_pass_values,
+                maybe_reject_passes,
                 num_passes,
                 partial(passes.get, b"message"),
             ),
@@ -310,14 +334,13 @@ class CallWithPassesTests(TestCase):
             MatchesStructure(
                 returned=HasLength(0),
                 in_use=HasLength(0),
-                invalid=MatchesAll(
-                    HasLength(num_passes),
-                    AllMatch(even()),
+                invalid_passes=MatchesAll(
+                    HasLength(reject_count),
+                    AfterPreprocessing(
+                        lambda d: set(d.keys()), Equals(rejected_passes)
+                    ),
                 ),
-                spent=MatchesAll(
-                    HasLength(num_passes),
-                    AllMatch(odd()),
-                ),
+                spent=HasLength(num_passes),
                 issued=Equals(passes.spent | set(passes.invalid.keys())),
             ),
         )
@@ -329,7 +352,7 @@ class CallWithPassesTests(TestCase):
         no passes have been marked as invalid.  This happens if all passes
         given were valid but too fewer were given.
         """
-        passes = pass_factory(integer_passes(num_passes))
+        passes = pass_factory(privacypass_passes(self.signing_key, num_passes))
 
         def reject_passes(group):
             passes = group.passes
@@ -376,7 +399,7 @@ class CallWithPassesTests(TestCase):
         reported as invalid during its efforts as such and resets all other
         passes it acquired.
         """
-        passes = pass_factory(integer_passes(num_passes + extras))
+        passes = pass_factory(privacypass_passes(self.signing_key, num_passes + extras))
         rejected = []
         accepted = []
 
@@ -420,14 +443,14 @@ class CallWithPassesTests(TestCase):
             MatchesStructure(
                 # Whatever is left in the group when we run out of tokens must
                 # be returned.
-                returned=Equals(accepted),
+                returned_passes=Equals(set(accepted)),
                 in_use=HasLength(0),
-                invalid=AfterPreprocessing(
+                invalid_passes=AfterPreprocessing(
                     lambda invalid: set(invalid.keys()),
                     Equals(set(rejected)),
                 ),
                 spent=HasLength(0),
-                issued=Equals(set(accepted + rejected)),
+                issued_passes=Equals(set(accepted + rejected)),
             ),
         )
 
@@ -452,6 +475,10 @@ class PassFactoryTests(TestCase):
     ``test_spending.PassGroupTests``.
     """
 
+    def setUp(self):
+        super().setUp()
+        self.signing_key = random_signing_key()
+
     @given(pass_counts(), pass_counts())
     def test_returned_passes_reused(self, num_passes_a, num_passes_b):
         """
@@ -462,7 +489,7 @@ class PassFactoryTests(TestCase):
         min_passes = min(num_passes_a, num_passes_b)
         max_passes = max(num_passes_a, num_passes_b)
 
-        factory = pass_factory(integer_passes(max_passes))
+        factory = pass_factory(privacypass_passes(self.signing_key, max_passes))
         group_a = factory.get(message, num_passes_a)
         group_a.reset()
 
@@ -487,7 +514,7 @@ class PassFactoryTests(TestCase):
             perform with the pass group and to assert raises an exception.
         """
         message = b"message"
-        factory = pass_factory(integer_passes(num_passes))
+        factory = pass_factory(privacypass_passes(self.signing_key, num_passes))
         group = factory.get(message, num_passes)
         setup_op(group)
         self.assertThat(

--- a/src/_zkapauthorizer/tests/test_storage_protocol.py
+++ b/src/_zkapauthorizer/tests/test_storage_protocol.py
@@ -323,7 +323,7 @@ class ShareTests(TestCase):
         )
         self.expectThat(
             self.spending_recorder,
-            matches_spent_passes(self.public_key_hash, self.pass_factory.spent),
+            matches_spent_passes(self.public_key_hash, self.pass_factory.spent_passes),
         )
 
         for sharenum, bucket in allocated.items():
@@ -462,7 +462,7 @@ class ShareTests(TestCase):
         # The spent passes have been reported to the spending service.
         self.assertThat(
             self.spending_recorder,
-            matches_spent_passes(self.public_key_hash, self.pass_factory.spent),
+            matches_spent_passes(self.public_key_hash, self.pass_factory.spent_passes),
         )
 
         expected_leases = {}
@@ -523,7 +523,7 @@ class ShareTests(TestCase):
         # The spent passes have been reported to the spending service.
         self.assertThat(
             self.spending_recorder,
-            matches_spent_passes(self.public_key_hash, self.pass_factory.spent),
+            matches_spent_passes(self.public_key_hash, self.pass_factory.spent_passes),
         )
 
         leases = list(self.anonymous_storage_server.get_leases(storage_index))
@@ -777,7 +777,7 @@ class ShareTests(TestCase):
         # The spent passes have been reported to the spending service.
         self.assertThat(
             self.spending_recorder,
-            matches_spent_passes(self.public_key_hash, self.pass_factory.spent),
+            matches_spent_passes(self.public_key_hash, self.pass_factory.spent_passes),
         )
 
         expected = [
@@ -917,7 +917,7 @@ class ShareTests(TestCase):
         # The spent passes have been reported to the spending service.
         self.assertThat(
             self.spending_recorder,
-            matches_spent_passes(self.public_key_hash, self.pass_factory.spent),
+            matches_spent_passes(self.public_key_hash, self.pass_factory.spent_passes),
         )
 
         # And the lease we paid for on every share is present.
@@ -1043,7 +1043,7 @@ class ShareTests(TestCase):
         # The spent passes have been reported to the spending service.
         self.assertThat(
             self.spending_recorder,
-            matches_spent_passes(self.public_key_hash, self.pass_factory.spent),
+            matches_spent_passes(self.public_key_hash, self.pass_factory.spent_passes),
         )
 
         # Not only should the write above succeed but the lease should now be


### PR DESCRIPTION
Follow-up to #353 which does some of the harder work.  In particular, a0a8bfc71a702baff189455dd94432eb0bb3c8c4 involves somewhat deeper changes.  `_PassFactory` previously worked with both `int` and `Pass` values.  I didn't want to try to imagine how I might convince mypy that both of these things are legal  in a coherent way - so I dropped the `int` variation.

I think the rest of the revisions are fairly straightforward.

Two mypy errors remain after this, both fixed by #356 
