### PR TITLE
Add a skeleton replication service, hooked up to other things

### DIFF
--- a/src/_zkapauthorizer/_plugin.py
+++ b/src/_zkapauthorizer/_plugin.py
@@ -56,7 +56,11 @@ from .lease_maintenance import (
 from .model import VoucherStore
 from .model import open_database as _open_database
 from .recover import make_fail_downloader
-from .replicate import setup_tahoe_lafs_replication
+from .replicate import (
+    is_replication_setup,
+    replication_service,
+    setup_tahoe_lafs_replication,
+)
 from .resource import from_configuration as resource_from_configuration
 from .server.spending import get_spender
 from .spending import SpendingController
@@ -138,6 +142,8 @@ class ZKAPAuthorizer(object):
             s = self._stores[key]
         except KeyError:
             s = open_store(datetime.now, _connect, node_config)
+            if is_replication_setup(node_config):
+                replication_service(s._connection).setServiceParent(self._service)
             self._stores[key] = s
         return s
 

--- a/src/_zkapauthorizer/_types.py
+++ b/src/_zkapauthorizer/_types.py
@@ -19,6 +19,9 @@ Re-usable type definitions for ZKAPAuthorizer.
 from sqlite3 import Connection
 from typing import Any, Callable, Protocol
 
+# A Tahoe-LAFS capability string
+CapStr = str
+
 GetTime = Callable[[], float]
 
 

--- a/src/_zkapauthorizer/model.py
+++ b/src/_zkapauthorizer/model.py
@@ -176,7 +176,6 @@ def initialize_database(conn: Connection) -> None:
         )
 
     cursor.close()
-    return conn
 
 
 def with_cursor_async(f: Callable[..., Awaitable[_T]]) -> Callable[..., Awaitable[_T]]:
@@ -241,18 +240,19 @@ def path_to_memory_uri(path: FilePath) -> str:
             scheme="file",
             # segmentsFrom(FilePath("/")) is tempting but on Windows "/" is
             # not necessarily the root for every path.
-            path=path.path.split(os.sep),
+            path=path.asTextMode().path.split(os.sep),
         )
         .add("mode", "memory")
         .to_text()
     )
 
 
-def memory_connect(path: str, *a, **kw) -> Connection:
+def memory_connect(path: str, *a, uri=None, **kw) -> Connection:
     """
     Always connect to an in-memory SQLite3 database.
     """
-    return _connect(path_to_memory_uri(FilePath(path)), *a, uri=True, **kw)
+    kw["uri"] = True
+    return _connect(path_to_memory_uri(FilePath(path)), *a, **kw)
 
 
 # The largest integer SQLite3 can represent in an integer column.  Larger than
@@ -269,8 +269,8 @@ class VoucherStore(object):
         ``datetime`` instance.
     """
 
-    pass_value = pass_value_attribute()
-    now = attr.ib()
+    pass_value: int = pass_value_attribute()
+    now: GetTime = attr.ib()
     _connection = attr.ib()
 
     _log = Logger()

--- a/src/_zkapauthorizer/replicate.py
+++ b/src/_zkapauthorizer/replicate.py
@@ -62,11 +62,15 @@ from sqlite3 import Connection, Cursor
 from typing import BinaryIO, Callable, Iterator, Optional
 
 import cbor2
-from attrs import define, frozen
+from attrs import define, field, frozen
 from compose import compose
+from twisted.application.service import IService, Service
+from twisted.internet.defer import CancelledError, Deferred, succeed
+from twisted.python.failure import Failure
+from twisted.python.filepath import FilePath
 from twisted.python.lockfile import FilesystemLock
 
-from .config import REPLICA_RWCAP_BASENAME
+from .config import REPLICA_RWCAP_BASENAME, Config
 from .tahoe import ITahoeClient, attenuate_writecap
 
 
@@ -176,6 +180,15 @@ async def setup_tahoe_lafs_replication(client: ITahoeClient) -> str:
 
     # Return the read-cap
     return rocap
+
+
+def is_replication_setup(config: Config) -> bool:
+    """
+    :return: ``True`` if and only if replication has previously been setup for
+        the Tahoe-LAFS node associated with the given configuration.
+    """
+    # Find the configuration path for this node's replica.
+    return FilePath(config.get_private_path(REPLICA_RWCAP_BASENAME)).exists()
 
 
 def with_replication(connection: Connection):
@@ -343,3 +356,57 @@ def get_tahoe_lafs_direntry_uploader(
         )
 
     return upload
+
+
+@define
+class _ReplicationService(Service):
+    """
+    Perform all activity related to maintaining a remote replica of the local
+    ZKAPAuthorizer database.
+
+    :ivar _connection: A connection to the database being replicated.
+
+    :ivar _replicating: The long-running replication operation.  This is never
+        expected to complete but it will be cancelled when the service stops.
+    """
+
+    name = "replication-service"  # type: ignore # Service assigns None, screws up type inference
+
+    _connection: _ReplicationCapableConnection
+    _replicating: Optional[Deferred] = field(init=False, default=None)
+
+    def startService(self) -> None:
+        super().startService()
+        # Tell the store to initiate replication when appropriate.  The
+        # service should only be created and started if replication has been
+        # turned on - so, make sure replication is turned on at the database
+        # layer.
+        self._replicating = succeed(None)
+
+    def stopService(self) -> Deferred:
+        """
+        Cancel the replication operation and then wait for it to complete.
+        """
+        super().stopService()
+
+        replicating = self._replicating
+        if replicating is None:
+            return succeed(None)
+
+        self._replicating = None
+
+        def catch_cancelled(err: Failure) -> None:
+            err.trap(CancelledError)
+            return None
+
+        replicating.addErrback(catch_cancelled)
+        replicating.cancel()
+        return replicating
+
+
+def replication_service(connection) -> IService:
+    """
+    Return a service which implements the replication process documented in
+    the ``backup-recovery`` design document.
+    """
+    return _ReplicationService(connection=connection)

--- a/src/_zkapauthorizer/replicate.py
+++ b/src/_zkapauthorizer/replicate.py
@@ -67,7 +67,7 @@ from compose import compose
 from twisted.python.lockfile import FilesystemLock
 
 from .config import REPLICA_RWCAP_BASENAME
-from .tahoe import Tahoe, attenuate_writecap
+from .tahoe import ITahoeClient, attenuate_writecap
 
 
 @frozen
@@ -141,7 +141,7 @@ async def fail_setup_replication():
     raise Exception("Test not set up for replication")
 
 
-async def setup_tahoe_lafs_replication(client: Tahoe) -> str:
+async def setup_tahoe_lafs_replication(client: ITahoeClient) -> str:
     """
     Configure the ZKAPAuthorizer plugin that lives in the Tahoe-LAFS node with
     the given configuration to replicate its state onto Tahoe-LAFS storage
@@ -308,7 +308,7 @@ snapshot: Callable[[Connection], bytes] = compose(
 
 
 async def tahoe_lafs_uploader(
-    client: Tahoe,
+    client: ITahoeClient,
     recovery_cap: str,
     get_snapshot_data: Callable[[], BinaryIO],
     entry_name: str,
@@ -322,7 +322,7 @@ async def tahoe_lafs_uploader(
 
 
 def get_tahoe_lafs_direntry_uploader(
-    client: Tahoe,
+    client: ITahoeClient,
     directory_mutable_cap: str,
     entry_name: str = "snapshot.sql",
 ):

--- a/src/_zkapauthorizer/tahoe.py
+++ b/src/_zkapauthorizer/tahoe.py
@@ -394,12 +394,14 @@ class MemoryGrid:
     _counter: int = 0
     _objects: dict[CapStr, Union[bytes, _Directory]] = field(default=Factory(dict))
 
-    def client(self):
+    def client(self, basedir: Optional[FilePath] = None) -> ITahoeClient:
         """
         Create a ``Tahoe``-alike that is backed by this object instead of by a
         real Tahoe-LAFS storage grid.
         """
-        return _MemoryTahoe(self)
+        if basedir is None:
+            return _MemoryTahoe(self)
+        return _MemoryTahoe(self, basedir)
 
     def upload(self, data: bytes) -> CapStr:
         cap = str(self._counter)

--- a/src/_zkapauthorizer/tahoe.py
+++ b/src/_zkapauthorizer/tahoe.py
@@ -19,8 +19,10 @@ from treq.client import HTTPClient
 from twisted.internet.error import ConnectionRefusedError
 from twisted.python.filepath import FilePath
 from twisted.web.client import Agent
+from zope.interface import Interface, implementer
 
 from .config import read_node_url
+from ._types import CapStr
 
 
 def async_retry(matchers: list[Callable[[Exception], bool]]):
@@ -271,6 +273,52 @@ async def link(
     raise TahoeAPIError("put", uri, resp.code, content)
 
 
+class ITahoeClient(Interface):
+    """
+    A simple Tahoe-LAFS client interface.
+    """
+
+    def get_private_path(name: str) -> FilePath:
+        """
+        Get the path to a file in the client node's private directory.
+        """
+
+    async def download(outpath: FilePath, cap: CapStr, child_path: list[str]) -> None:
+        """
+        Download the contents of an object to a given local path.
+        """
+
+    async def upload(get_data_provider: Callable[[], BinaryIO]) -> CapStr:
+        """
+        Upload some data, creating a new object, and returning a capability for
+        it.
+
+        :param get_data_provider: A callable which returns the data to be
+            uploaded.  This may be called more than once in case a retry is
+            required.
+        """
+
+    async def make_directory() -> CapStr:
+        """
+        Create a new, empty, mutable directory.
+        """
+
+    async def link(dir_cap: CapStr, entry_name: str, entry_cap: CapStr) -> None:
+        """
+        Link an object into a directory.
+
+        :param dir_cap: The capability of the directory to link into.
+        :param entry_name: The name of the new link.
+        :param entry_cap: The capability of the object to link in.
+        """
+
+    async def list_directory(dir_cap: CapStr) -> dict[CapStr, list[Any]]:
+        """
+        List the entries linked into a directory.
+        """
+
+
+@implementer(ITahoeClient)
 @define
 class Tahoe(object):
     """
@@ -312,9 +360,6 @@ class Tahoe(object):
 
     def link(self, dir_cap, entry_name, entry_cap):
         return link(self.client, self._api_root, dir_cap, entry_name, entry_cap)
-
-
-CapStr = str
 
 
 @define
@@ -422,6 +467,7 @@ _no_children_message = (
 )
 
 
+@implementer(ITahoeClient)
 @define
 class _MemoryTahoe:
     """
@@ -491,7 +537,7 @@ def attenuate_writecap(rw_cap: CapStr) -> CapStr:
     return capability_from_string(rw_cap).get_readonly().to_string().decode("ascii")
 
 
-def get_tahoe_client(reactor, node_config: _Config) -> Tahoe:
+def get_tahoe_client(reactor, node_config: Config) -> ITahoeClient:
     """
     Return a Tahoe-LAFS client appropriate for the given node configuration.
 

--- a/src/_zkapauthorizer/tahoe.py
+++ b/src/_zkapauthorizer/tahoe.py
@@ -10,7 +10,6 @@ from tempfile import mkdtemp
 from typing import Any, BinaryIO, Callable, Iterable, Optional, Union
 
 import treq
-from allmydata.node import _Config
 from allmydata.uri import from_string as capability_from_string
 from allmydata.util.base32 import b2a as b32encode
 from attrs import Factory, define, field
@@ -21,8 +20,8 @@ from twisted.python.filepath import FilePath
 from twisted.web.client import Agent
 from zope.interface import Interface, implementer
 
-from .config import read_node_url
 from ._types import CapStr
+from .config import Config, read_node_url
 
 
 def async_retry(matchers: list[Callable[[Exception], bool]]):
@@ -330,7 +329,7 @@ class Tahoe(object):
     """
 
     client: HTTPClient
-    _node_config: _Config
+    _node_config: Config
 
     @property
     def _api_root(self):

--- a/src/_zkapauthorizer/tests/test_plugin.py
+++ b/src/_zkapauthorizer/tests/test_plugin.py
@@ -60,8 +60,7 @@ from testtools.matchers import (
 )
 from testtools.twistedsupport import succeeded
 from testtools.twistedsupport._deferred import extract_result
-from twisted.internet.task import Clock
-from twisted.internet.testing import MemoryReactor
+from twisted.internet.testing import MemoryReactorClock
 from twisted.plugin import getPlugins
 from twisted.python.filepath import FilePath
 from twisted.python.runtime import platform
@@ -246,7 +245,7 @@ class ServerPluginTests(TestCase):
     """
 
     def setup_example(self):
-        self.reactor = Clock()
+        self.reactor = MemoryReactorClock()
         self.plugin = ZKAPAuthorizer(NAME, self.reactor)
 
     @given(server_configurations(SIGNING_KEY_PATH))
@@ -378,14 +377,14 @@ class ServiceTests(TestCase):
         Children of ``ZKAPAuthorizer._service`` are started when the reactor
         starts and stopped when the reactor stops.
         """
-        reactor = MemoryReactor()
+        reactor = MemoryReactorClock()
         plugin = ZKAPAuthorizer(NAME, reactor)
 
-        # MemoryReactor does correctly implement callWhenRunning but it does
-        # not implement shutdown hooks meaningfully... So instead of asserting
-        # about the behavior we want, assert about how the plugin pokes the
-        # reactor. :/ This is lame.  Maybe Twisted will make MemoryReactor
-        # better.
+        # MemoryReactorClock does correctly implement callWhenRunning but it
+        # does not implement shutdown hooks meaningfully... So instead of
+        # asserting about the behavior we want, assert about how the plugin
+        # pokes the reactor. :/ This is lame.  Maybe Twisted will make
+        # MemoryReactorClock better.
         self.assertThat(
             reactor.whenRunningHooks,
             Equals([(plugin._service.startService, (), {})]),
@@ -452,7 +451,7 @@ class ClientPluginTests(TestCase):
         ``get_storage_client`` returns an object which provides
         ``IStorageServer``.
         """
-        reactor = Clock()
+        reactor = MemoryReactorClock()
         plugin = ZKAPAuthorizer(NAME, reactor)
 
         nodedir = FilePath(self.useFixture(TempDir()).join("node"))
@@ -477,7 +476,7 @@ class ClientPluginTests(TestCase):
         ``get_storage_client`` raises an exception when called with an
         announcement and local configuration which specify different issuers.
         """
-        reactor = Clock()
+        reactor = MemoryReactorClock()
         plugin = ZKAPAuthorizer(NAME, reactor)
 
         nodedir = FilePath(self.useFixture(TempDir()).join("node"))
@@ -526,7 +525,7 @@ class ClientPluginTests(TestCase):
         provider then the storage methods of the client raise exceptions that
         clearly indicate this.
         """
-        reactor = Clock()
+        reactor = MemoryReactorClock()
         plugin = ZKAPAuthorizer(NAME, reactor)
 
         nodedir = FilePath(self.useFixture(TempDir()).join("node"))
@@ -577,7 +576,7 @@ class ClientPluginTests(TestCase):
         The ``ZKAPAuthorizerStorageServer`` returned by ``get_storage_client``
         spends unblinded tokens from the plugin database.
         """
-        reactor = Clock()
+        reactor = MemoryReactorClock()
         plugin = ZKAPAuthorizer(NAME, reactor)
 
         nodedir = FilePath(self.useFixture(TempDir()).join("node"))
@@ -650,7 +649,7 @@ class ClientResourceTests(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.reactor = Clock()
+        self.reactor = MemoryReactorClock()
         self.plugin = ZKAPAuthorizer(NAME, self.reactor)
 
     @given(tahoe_configs())

--- a/src/_zkapauthorizer/tests/test_plugin.py
+++ b/src/_zkapauthorizer/tests/test_plugin.py
@@ -70,7 +70,7 @@ from twisted.web.resource import IResource
 from twisted.plugins.zkapauthorizer import storage_server_plugin
 
 from .. import NAME
-from .._plugin import get_root_nodes, load_signing_key, open_store
+from .._plugin import ZKAPAuthorizer, get_root_nodes, load_signing_key, open_store
 from .._storage_client import IncorrectStorageServerReference
 from ..controller import DummyRedeemer, IssuerConfigurationMismatch, PaymentController
 from ..foolscap import RIPrivacyPassAuthorizedStorageServer
@@ -85,13 +85,13 @@ from .strategies import (
     announcements,
     client_dummyredeemer_configurations,
     client_lease_maintenance_configurations,
-    clocks,
     dummy_ristretto_keys,
     lease_cancel_secrets,
     lease_maintenance_configurations,
     lease_renew_secrets,
     minimal_tahoe_configs,
     pass_counts,
+    posix_timestamps,
     ristretto_signing_keys,
     server_configurations,
     sharenum_sets,
@@ -244,13 +244,17 @@ class ServerPluginTests(TestCase):
     ``IFoolscapStoragePlugin.get_storage_server``.
     """
 
+    def setup_example(self):
+        self.reactor = Clock()
+        self.plugin = ZKAPAuthorizer(NAME, self.reactor)
+
     @given(server_configurations(SIGNING_KEY_PATH))
     def test_returns_announceable(self, configuration):
         """
-        ``storage_server_plugin.get_storage_server`` returns an instance which
-        provides ``IAnnounceableStorageServer``.
+        ``ZKAPAuthorizer.get_storage_server`` returns an instance which provides
+        ``IAnnounceableStorageServer``.
         """
-        storage_server_deferred = storage_server_plugin.get_storage_server(
+        storage_server_deferred = self.plugin.get_storage_server(
             configuration,
             get_anonymous_storage_server,
         )
@@ -263,10 +267,10 @@ class ServerPluginTests(TestCase):
     def test_returns_referenceable(self, configuration):
         """
         The storage server attached to the result of
-        ``storage_server_plugin.get_storage_server`` provides
-        ``IReferenceable`` and ``IRemotelyCallable``.
+        ``ZKAPAuthorizer.get_storage_server`` provides ``IReferenceable`` and
+        ``IRemotelyCallable``.
         """
-        storage_server_deferred = storage_server_plugin.get_storage_server(
+        storage_server_deferred = self.plugin.get_storage_server(
             configuration,
             get_anonymous_storage_server,
         )
@@ -284,10 +288,10 @@ class ServerPluginTests(TestCase):
     def test_returns_serializable(self, configuration):
         """
         The storage server attached to the result of
-        ``storage_server_plugin.get_storage_server`` can be serialized by a
-        banana Broker (for Foolscap).
+        ``ZKAPAuthorizer.get_storage_server`` can be serialized by a banana
+        Broker (for Foolscap).
         """
-        storage_server_deferred = storage_server_plugin.get_storage_server(
+        storage_server_deferred = self.plugin.get_storage_server(
             configuration,
             get_anonymous_storage_server,
         )
@@ -307,12 +311,12 @@ class ServerPluginTests(TestCase):
     def test_returns_hashable(self, configuration):
         """
         The storage server attached to the result of
-        ``storage_server_plugin.get_storage_server`` is hashable for use as a
+        ``ZKAPAuthorizer.get_storage_server`` is hashable for use as a
         Python dictionary key.
 
         This is another requirement of Foolscap.
         """
-        storage_server_deferred = storage_server_plugin.get_storage_server(
+        storage_server_deferred = self.plugin.get_storage_server(
             configuration,
             get_anonymous_storage_server,
         )
@@ -328,13 +332,15 @@ class ServerPluginTests(TestCase):
             ),
         )
 
-    @given(timedeltas(min_value=timedelta(seconds=1)), clocks())
-    def test_metrics_written(self, metrics_interval, clock):
+    @given(timedeltas(min_value=timedelta(seconds=1)), posix_timestamps())
+    def test_metrics_written(self, metrics_interval, when):
         """
         When the configuration tells us where to put a metrics .prom file
         and an interval how often to do so, test that metrics are actually
         written there after the configured interval.
         """
+        self.reactor.advance(when)
+
         metrics_path = self.useFixture(TempDir()).join("metrics")
         configuration = {
             "prometheus-metrics-path": metrics_path,
@@ -343,10 +349,9 @@ class ServerPluginTests(TestCase):
             "ristretto-signing-key-path": SIGNING_KEY_PATH.path,
         }
         announceable = extract_result(
-            storage_server_plugin.get_storage_server(
+            self.plugin.get_storage_server(
                 configuration,
                 get_anonymous_storage_server,
-                reactor=clock,
             )
         )
         registry = announceable.storage_server._registry
@@ -355,7 +360,7 @@ class ServerPluginTests(TestCase):
         for i in range(2):
             g.set(i)
 
-            clock.advance(metrics_interval.total_seconds())
+            self.reactor.advance(metrics_interval.total_seconds())
             self.assertThat(
                 metrics_path,
                 has_metric(Equals("foo"), Equals(i)),
@@ -418,12 +423,15 @@ class ClientPluginTests(TestCase):
         ``get_storage_client`` returns an object which provides
         ``IStorageServer``.
         """
+        reactor = Clock()
+        plugin = ZKAPAuthorizer(NAME, reactor)
+
         nodedir = FilePath(self.useFixture(TempDir()).join("node"))
         nodedir.child("private").makedirs()
 
         node_config = get_config(nodedir.path, "tub.port")
 
-        storage_client = storage_server_plugin.get_storage_client(
+        storage_client = plugin.get_storage_client(
             node_config,
             announcement,
             get_rref,
@@ -440,6 +448,9 @@ class ClientPluginTests(TestCase):
         ``get_storage_client`` raises an exception when called with an
         announcement and local configuration which specify different issuers.
         """
+        reactor = Clock()
+        plugin = ZKAPAuthorizer(NAME, reactor)
+
         nodedir = FilePath(self.useFixture(TempDir()).join("node"))
         nodedir.child("private").makedirs()
 
@@ -453,7 +464,7 @@ class ClientPluginTests(TestCase):
         self.addDetail("config", text_content(config_text.getvalue()))
         self.addDetail("announcement", text_content(str(announcement)))
         self.assertThat(
-            lambda: storage_server_plugin.get_storage_client(
+            lambda: plugin.get_storage_client(
                 node_config,
                 announcement,
                 get_rref,
@@ -486,11 +497,14 @@ class ClientPluginTests(TestCase):
         provider then the storage methods of the client raise exceptions that
         clearly indicate this.
         """
+        reactor = Clock()
+        plugin = ZKAPAuthorizer(NAME, reactor)
+
         nodedir = FilePath(self.useFixture(TempDir()).join("node"))
         nodedir.child("private").makedirs()
         node_config = get_config(nodedir.path, "tub.port")
 
-        storage_client = storage_server_plugin.get_storage_client(
+        storage_client = plugin.get_storage_client(
             node_config,
             announcement,
             partial(get_rref, RIStorageServer),
@@ -534,30 +548,32 @@ class ClientPluginTests(TestCase):
         The ``ZKAPAuthorizerStorageServer`` returned by ``get_storage_client``
         spends unblinded tokens from the plugin database.
         """
+        reactor = Clock()
+        plugin = ZKAPAuthorizer(NAME, reactor)
+
         nodedir = FilePath(self.useFixture(TempDir()).join("node"))
         nodedir.child("private").makedirs()
         node_config = get_config(nodedir.path, "tub.port")
 
         # Populate the database with unspent tokens.
-        store = open_store(lambda: now, connect, node_config)
+        def redeem():
+            store = open_store(lambda: now, connect, node_config)
 
-        controller = PaymentController(
-            store,
-            DummyRedeemer(public_key),
-            default_token_count=num_passes,
-            num_redemption_groups=1,
-            allowed_public_keys={public_key},
-            clock=Clock(),
-        )
-        # Get a token inserted into the store.
-        redeeming = controller.redeem(voucher)
-        self.assertThat(
-            redeeming,
-            succeeded(Always()),
-        )
+            controller = PaymentController(
+                store,
+                DummyRedeemer(public_key),
+                default_token_count=num_passes,
+                num_redemption_groups=1,
+                allowed_public_keys={public_key},
+                clock=reactor,
+            )
+            # Get a token inserted into the store.
+            return controller.redeem(voucher)
+
+        self.assertThat(redeem(), succeeded(Always()))
 
         # Try to spend a pass via the storage client plugin.
-        storage_client = storage_server_plugin.get_storage_client(
+        storage_client = plugin.get_storage_client(
             node_config,
             announcement,
             get_rref,
@@ -603,6 +619,11 @@ class ClientResourceTests(TestCase):
     ``IFoolscapStoragePlugin.get_client_resource``.
     """
 
+    def setUp(self):
+        super().setUp()
+        self.reactor = Clock()
+        self.plugin = ZKAPAuthorizer(NAME, self.reactor)
+
     @given(tahoe_configs())
     def test_interface(self, get_config):
         """
@@ -612,9 +633,8 @@ class ClientResourceTests(TestCase):
         nodedir.child("private").makedirs()
         config = get_config(nodedir.path, "tub.port")
         self.assertThat(
-            storage_server_plugin.get_client_resource(
+            self.plugin.get_client_resource(
                 config,
-                reactor=Clock(),
             ),
             Provides([IResource]),
         )


### PR DESCRIPTION
Fixes #355 

This adds a do-nothing replication service that is automatically started for a VoucherStore when that VoucherStore is opened if and only if it finds replication configuration living alongside that VoucherStore.

This is about half of the logic we want for "make sure replication is happening".  The other half is for the case where the VoucherStore is already open and someone turns on replication.
