### PR TITLE
Change all datetimes to timezone-aware UTC values

### DIFF
--- a/src/_zkapauthorizer/schema.py
+++ b/src/_zkapauthorizer/schema.py
@@ -222,4 +222,38 @@ _UPGRADES = {
         )
         """,
     ],
+    7: [
+        # Original rows inserted into the vouchers table used naive datetime
+        # values serialized with no timezone information.  These values are
+        # all in the system's localtime (or at least, whatever the local time
+        # was when they were created - that information is lost, though).
+        # Convert them to UTC and add a timezone marker for compatibility with
+        # new code and to avoid further information loss.
+        #
+        # We can do this with the builtin SQLite3 datetime function and string
+        # concatenation.  Note in particular:
+        #
+        #     "utc" assumes that the time value to its left is in the local
+        #     timezone and adjusts that time value to be in UTC.
+        #
+        # This conversion will do weird stuff for times arbitrarily far in the
+        # past or the future because timezones are hard.  Since there should
+        # be no real values to upgrade that are very far in the past or the
+        # future, we'll just accept that.
+        #
+        # https://www.sqlite.org/lang_datefunc.html
+        """
+        UPDATE [vouchers]
+        SET [created] = datetime([created], "utc") || "+00:00"
+        """,
+        """
+        UPDATE [lease-maintenance-spending]
+        SET [started] = datetime([started], "utc") || "+00:00"
+        """,
+        """
+        UPDATE [lease-maintenance-spending]
+        SET [finished] = datetime([finished], "utc") || "+00:00"
+        WHERE [finished] IS NOT NULL
+        """,
+    ],
 }

--- a/src/_zkapauthorizer/tests/test_client_resource.py
+++ b/src/_zkapauthorizer/tests/test_client_resource.py
@@ -32,7 +32,6 @@ from hypothesis.strategies import (
     SearchStrategy,
     binary,
     builds,
-    datetimes,
     dictionaries,
     fixed_dictionaries,
     integers,
@@ -94,6 +93,7 @@ from ..model import (
     Redeeming,
     Unpaid,
     Voucher,
+    aware_now,
     memory_connect,
 )
 from ..pricecalculator import PriceCalculator
@@ -114,6 +114,7 @@ from .json import loads
 from .matchers import between, matches_json, matches_response
 from .strategies import (
     api_auth_tokens,
+    aware_datetimes,
     client_doublespendredeemer_configurations,
     client_dummyredeemer_configurations,
     client_errorredeemer_configurations,
@@ -730,7 +731,7 @@ class RecoverTests(TestCase):
             get_config,
             api_auth_token,
         )
-        root = root_from_config(config, datetime.now)
+        root = root_from_config(config, aware_now)
         create(root.store, existing_state)
         agent = RequestTraversalAgent(root)
         requesting = authorized_request(
@@ -852,7 +853,7 @@ class RecoverTests(TestCase):
             get_config,
             api_auth_token,
         )
-        root = root_from_config(config, datetime.now, make_downloader)
+        root = root_from_config(config, aware_now, make_downloader)
         agent = RequestTraversalAgent(root)
         requesting = authorized_request(
             api_auth_token,
@@ -884,7 +885,7 @@ class RecoverTests(TestCase):
         reason = "some interesting information"
         fail_downloader = make_fail_downloader(Exception(reason))
         get_fail_downloader = lambda cap: fail_downloader
-        root = root_from_config(config, datetime.now, get_fail_downloader)
+        root = root_from_config(config, aware_now, get_fail_downloader)
         agent = RequestTraversalAgent(root)
 
         # Kick off the recovery attempt.
@@ -960,7 +961,7 @@ class UnblindedTokenTests(TestCase):
                 min_size=1,
             ),
         ),
-        datetimes(),
+        aware_datetimes(),
     )
     def test_latest_lease_maintenance_spending(
         self, get_config, api_auth_token, size_observations, now
@@ -1068,7 +1069,7 @@ class VoucherTests(TestCase):
             get_config,
             api_auth_token,
         )
-        root = root_from_config(config, datetime.now)
+        root = root_from_config(config, aware_now)
         agent = RequestTraversalAgent(root)
         data = BytesIO(dumps_utf8({"voucher": voucher.decode("ascii")}))
         requesting = authorized_request(
@@ -1101,7 +1102,7 @@ class VoucherTests(TestCase):
             get_config,
             api_auth_token,
         )
-        root = root_from_config(config, datetime.now)
+        root = root_from_config(config, aware_now)
         agent = RequestTraversalAgent(root)
         requesting = authorized_request(
             api_auth_token,
@@ -1132,7 +1133,7 @@ class VoucherTests(TestCase):
             get_config,
             api_auth_token,
         )
-        root = root_from_config(config, datetime.now)
+        root = root_from_config(config, aware_now)
         agent = RequestTraversalAgent(root)
         url = "http://127.0.0.1/voucher/{}".format(
             quote(
@@ -1165,7 +1166,7 @@ class VoucherTests(TestCase):
             get_config,
             api_auth_token,
         )
-        root = root_from_config(config, datetime.now)
+        root = root_from_config(config, aware_now)
         agent = RequestTraversalAgent(root)
         requesting = authorized_request(
             api_auth_token,
@@ -1183,7 +1184,7 @@ class VoucherTests(TestCase):
     @given(
         direct_tahoe_configs(client_nonredeemer_configurations()),
         api_auth_tokens(),
-        datetimes(),
+        aware_datetimes(),
         vouchers(),
     )
     def test_get_known_voucher_redeeming(self, config, api_auth_token, now, voucher):
@@ -1215,7 +1216,7 @@ class VoucherTests(TestCase):
     @given(
         direct_tahoe_configs(client_dummyredeemer_configurations()),
         api_auth_tokens(),
-        datetimes(),
+        aware_datetimes(),
         vouchers(),
     )
     def test_get_known_voucher_redeemed(self, config, api_auth_token, now, voucher):
@@ -1247,7 +1248,7 @@ class VoucherTests(TestCase):
     @given(
         direct_tahoe_configs(client_doublespendredeemer_configurations()),
         api_auth_tokens(),
-        datetimes(),
+        aware_datetimes(),
         vouchers(),
     )
     def test_get_known_voucher_doublespend(self, config, api_auth_token, now, voucher):
@@ -1279,7 +1280,7 @@ class VoucherTests(TestCase):
     @given(
         direct_tahoe_configs(client_unpaidredeemer_configurations()),
         api_auth_tokens(),
-        datetimes(),
+        aware_datetimes(),
         vouchers(),
     )
     def test_get_known_voucher_unpaid(self, config, api_auth_token, now, voucher):
@@ -1311,7 +1312,7 @@ class VoucherTests(TestCase):
     @given(
         direct_tahoe_configs(client_errorredeemer_configurations(TRANSIENT_ERROR)),
         api_auth_tokens(),
-        datetimes(),
+        aware_datetimes(),
         vouchers(),
     )
     def test_get_known_voucher_error(self, config, api_auth_token, now, voucher):
@@ -1404,7 +1405,7 @@ class VoucherTests(TestCase):
     @given(
         direct_tahoe_configs(),
         api_auth_tokens(),
-        datetimes(),
+        aware_datetimes(),
         lists(vouchers(), unique=True),
     )
     def test_list_vouchers(self, config, api_auth_token, now, vouchers):
@@ -1439,7 +1440,7 @@ class VoucherTests(TestCase):
     @given(
         direct_tahoe_configs(client_unpaidredeemer_configurations()),
         api_auth_tokens(),
-        datetimes(),
+        aware_datetimes(),
         lists(vouchers(), unique=True),
     )
     def test_list_vouchers_transient_states(
@@ -1687,7 +1688,7 @@ class CalculatePriceTests(TestCase):
             get_config,
             api_auth_token,
         )
-        root = root_from_config(config, datetime.now)
+        root = root_from_config(config, aware_now)
         agent = RequestTraversalAgent(root)
         self.assertThat(
             authorized_request(
@@ -1747,7 +1748,7 @@ class CalculatePriceTests(TestCase):
             config,
             api_auth_token,
         )
-        root = root_from_config(config, datetime.now)
+        root = root_from_config(config, aware_now)
         agent = RequestTraversalAgent(root)
 
         expected_price = PriceCalculator(

--- a/src/_zkapauthorizer/tests/test_model.py
+++ b/src/_zkapauthorizer/tests/test_model.py
@@ -17,7 +17,7 @@
 Tests for ``_zkapauthorizer.model``.
 """
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from functools import partial
 from io import BytesIO
 from itertools import count
@@ -35,7 +35,6 @@ from hypothesis.stateful import (
 from hypothesis.strategies import (
     booleans,
     data,
-    datetimes,
     integers,
     lists,
     randoms,
@@ -69,6 +68,7 @@ from ..model import (
     Redeemed,
     Voucher,
     VoucherStore,
+    aware_now,
     memory_connect,
     with_cursor_async,
 )
@@ -90,6 +90,7 @@ from ..replicate import (
 from .fixtures import TempDir, TemporaryVoucherStore
 from .matchers import raises
 from .strategies import (
+    aware_datetimes,
     deletes,
     dummy_ristretto_keys,
     inserts,
@@ -242,7 +243,7 @@ class VoucherStoreCallIfEmptyTests(TestCase):
         self.store_fixture = self.useFixture(
             TemporaryVoucherStore(
                 get_config=lambda basedir, portfile: EmptyConfig(FilePath(basedir)),
-                get_now=datetime.now,
+                get_now=aware_now,
             ),
         )
 
@@ -336,7 +337,7 @@ class VoucherStoreTests(TestCase):
     Tests for ``VoucherStore``.
     """
 
-    @given(tahoe_configs(), datetimes(), vouchers())
+    @given(tahoe_configs(), aware_datetimes(), vouchers())
     def test_get_missing(self, get_config, now, voucher):
         """
         ``VoucherStore.get`` raises ``KeyError`` when called with a
@@ -352,7 +353,7 @@ class VoucherStoreTests(TestCase):
         tahoe_configs(),
         vouchers(),
         lists(random_tokens(), min_size=1, unique=True),
-        datetimes(),
+        aware_datetimes(),
     )
     def test_add(self, get_config, voucher, tokens, now):
         """
@@ -376,7 +377,7 @@ class VoucherStoreTests(TestCase):
         vouchers(),
         lists(voucher_counters(), unique=True, min_size=2, max_size=2),
         lists(random_tokens(), min_size=2, unique=True),
-        datetimes(),
+        aware_datetimes(),
     )
     def test_add_with_distinct_counters(
         self, get_config, voucher, counters, tokens, now
@@ -412,7 +413,7 @@ class VoucherStoreTests(TestCase):
     @given(
         tahoe_configs(),
         vouchers(),
-        datetimes(),
+        aware_datetimes(),
         lists(random_tokens(), min_size=1, unique=True),
     )
     def test_add_idempotent(self, get_config, voucher, now, tokens):
@@ -456,7 +457,7 @@ class VoucherStoreTests(TestCase):
             Equals(tokens),
         )
 
-    @given(tahoe_configs(), datetimes(), lists(vouchers(), unique=True), data())
+    @given(tahoe_configs(), aware_datetimes(), lists(vouchers(), unique=True), data())
     def test_list(self, get_config, now, vouchers, data):
         """
         ``VoucherStore.list`` returns a ``list`` containing a ``Voucher`` object
@@ -549,7 +550,7 @@ class UnblindedTokenStateMachine(RuleBasedStateMachine):
         self.configless = TemporaryVoucherStore(
             get_config=lambda basedir, portfile: EmptyConfig(FilePath(basedir)),
             # Time probably not actually relevant to this state machine.
-            get_now=datetime.now,
+            get_now=aware_now,
         )
         self.configless.setUp()
 
@@ -984,7 +985,7 @@ class UnblindedTokenStoreTests(TestCase):
 
     @given(
         tahoe_configs(),
-        datetimes(),
+        aware_datetimes(),
         vouchers(),
         dummy_ristretto_keys(),
         lists(unblinded_tokens(), unique=True),
@@ -1010,7 +1011,7 @@ class UnblindedTokenStoreTests(TestCase):
 
     @given(
         tahoe_configs(),
-        datetimes(),
+        aware_datetimes(),
         vouchers(),
         dummy_ristretto_keys(),
         booleans(),
@@ -1049,7 +1050,7 @@ class UnblindedTokenStoreTests(TestCase):
 
     @given(
         tahoe_configs(),
-        datetimes(),
+        aware_datetimes(),
         vouchers(),
         dummy_ristretto_keys(),
         paired_tokens(),
@@ -1084,7 +1085,7 @@ class UnblindedTokenStoreTests(TestCase):
 
     @given(
         tahoe_configs(),
-        datetimes(),
+        aware_datetimes(),
         vouchers(),
         lists(random_tokens(), min_size=1, unique=True),
     )
@@ -1112,7 +1113,7 @@ class UnblindedTokenStoreTests(TestCase):
 
     @given(
         tahoe_configs(),
-        datetimes(),
+        aware_datetimes(),
         vouchers(),
         dummy_ristretto_keys(),
         paired_tokens(),
@@ -1136,7 +1137,7 @@ class UnblindedTokenStoreTests(TestCase):
 
     @given(
         tahoe_configs(),
-        datetimes(),
+        aware_datetimes(),
         vouchers(),
     )
     def test_mark_invalid_vouchers_double_spent(self, get_config, now, voucher_value):
@@ -1151,7 +1152,7 @@ class UnblindedTokenStoreTests(TestCase):
 
     @given(
         get_config=tahoe_configs(),
-        now=datetimes(),
+        now=aware_datetimes(),
         voucher_value=vouchers(),
         public_key=dummy_ristretto_keys(),
         completed=booleans(),
@@ -1236,7 +1237,7 @@ class ReplicationTests(TestCase):
             TemporaryVoucherStore(
                 get_config=lambda basedir, portfile: EmptyConfig(FilePath(basedir)),
                 # Time is not relevant to this test
-                get_now=datetime.now,
+                get_now=aware_now,
             )
         ).store
         snapshot_bytes = store.snapshot()

--- a/src/_zkapauthorizer/tests/test_plugin.py
+++ b/src/_zkapauthorizer/tests/test_plugin.py
@@ -37,7 +37,7 @@ from foolscap.broker import Broker
 from foolscap.ipb import IReferenceable, IRemotelyCallable
 from foolscap.referenceable import LocalReferenceable
 from hypothesis import given, settings
-from hypothesis.strategies import datetimes, just, sampled_from, timedeltas
+from hypothesis.strategies import just, sampled_from, timedeltas
 from prometheus_client import Gauge
 from prometheus_client.parser import text_string_to_metric_families
 from testtools import TestCase
@@ -94,6 +94,7 @@ from .foolscap import DummyReferenceable, LocalRemote, get_anonymous_storage_ser
 from .matchers import Provides, matches_response, raises
 from .strategies import (
     announcements,
+    aware_datetimes,
     client_dummyredeemer_configurations,
     client_lease_maintenance_configurations,
     dummy_ristretto_keys,
@@ -123,7 +124,7 @@ def get_rref(interface=None):
 
 class OpenStoreTests(TestCase):
     @skipIf(platform.isWindows(), "Hard to prevent directory creation on Windows")
-    @given(tahoe_configs(), datetimes())
+    @given(tahoe_configs(), aware_datetimes())
     def test_uncreateable_store_directory(self, get_config, now):
         """
         If the underlying directory in the node configuration cannot be created
@@ -632,7 +633,7 @@ class ClientPluginTests(TestCase):
 
     @given(
         get_config=tahoe_configs_with_dummy_redeemer,
-        now=datetimes(),
+        now=aware_datetimes(),
         announcement=announcements(),
         voucher=vouchers(),
         num_passes=pass_counts(),

--- a/src/_zkapauthorizer/tests/test_replicate.py
+++ b/src/_zkapauthorizer/tests/test_replicate.py
@@ -3,7 +3,6 @@ Tests for the replication system in ``_zkapauthorizer.replicate``.
 """
 
 from base64 import b64encode, urlsafe_b64encode
-from datetime import datetime
 from functools import partial
 from io import BytesIO
 from os import urandom
@@ -26,7 +25,7 @@ from twisted.internet.defer import Deferred
 from twisted.python.filepath import FilePath
 
 from ..config import REPLICA_RWCAP_BASENAME, EmptyConfig
-from ..model import RandomToken
+from ..model import RandomToken, aware_now
 from ..recover import recover
 from ..replicate import (
     EventStream,
@@ -37,7 +36,7 @@ from ..replicate import (
 )
 from .fixtures import TempDir, TemporaryVoucherStore
 from .matchers import Matcher, equals_database, returns
-from .strategies import datetimes, tahoe_configs
+from .strategies import aware_datetimes, tahoe_configs
 
 # Helper to construct the replication wrapper without immediately enabling
 # replication.
@@ -329,7 +328,7 @@ class ReplicationServiceTests(TestCase):
         def get_config(rootpath, portnumfile):
             return EmptyConfig(FilePath(rootpath))
 
-        tvs = self.useFixture(TemporaryVoucherStore(get_config, lambda: datetime.now()))
+        tvs = self.useFixture(TemporaryVoucherStore(get_config, aware_now))
 
         rwcap_file = FilePath(tvs.config.get_private_path(REPLICA_RWCAP_BASENAME))
         rwcap_file.parent().makedirs()
@@ -412,7 +411,7 @@ class HypothesisReplicationServiceTests(TestCase):
     Tests for ``_ReplicationService``.
     """
 
-    @given(tahoe_configs(), datetimes())
+    @given(tahoe_configs(), aware_datetimes())
     def test_enable_replication_on_connection(self, get_config, now):
         """
         When the service starts it enables replication on its database connection.

--- a/src/_zkapauthorizer/tests/test_schema.py
+++ b/src/_zkapauthorizer/tests/test_schema.py
@@ -17,14 +17,45 @@
 Tests for ``_zkapauthorizer.schema``.
 """
 
+from datetime import datetime, timezone
+from typing import Optional
+
+from fixtures import TempDir
+from hypothesis import assume, given
+from hypothesis.strategies import SearchStrategy
+from hypothesis.strategies import datetimes as naive_datetimes
+from hypothesis.strategies import integers, none, one_of
 from testtools import TestCase
 from testtools.matchers import Equals
 
-from ..schema import _UPGRADES
+from ..model import memory_connect
+from ..schema import _UPGRADES, get_schema_upgrades, get_schema_version
+
+
+def datetimes() -> SearchStrategy[datetime]:
+    """
+    Build naive datetime instances that represent times that actually happened
+    or will actually happen bounded within a pretty reasonable range around
+    when this code was written.
+    """
+    return naive_datetimes(
+        allow_imaginary=False,
+        # The software has not existing very long.  There is no point going
+        # very far back in time.  Also, according to authorities, timezones
+        # are basically meaningless before 1900 anyway.
+        min_value=datetime(1995, 1, 1, 0, 0),
+        # Similarly, this upgrade is going to happen so going very far into
+        # the future is also less interresting.  Also, the behavior of
+        # calendars and clocks becomes harder to predict the further you go.
+        # In particular, things fall apart around "spring forward" in 2038 - I
+        # suppose because SQLite3 can't figure out the DST rules for any point
+        # after 2 ** 31 - 1 seconds after the POSIX epoch.
+        max_value=datetime(2038, 1, 1, 0, 0),
+    )
 
 
 class UpgradeTests(TestCase):
-    def test_consistency(self):
+    def test_consistency(self) -> None:
         """
         Upgrades are defined for every version up to the latest version.
         """
@@ -32,3 +63,84 @@ class UpgradeTests(TestCase):
             list(_UPGRADES.keys()),
             Equals(list(range(len(_UPGRADES)))),
         )
+
+    @given(
+        datetimes(),
+        one_of(none(), datetimes()),
+        integers(min_value=0, max_value=2**63 - 1),
+    )
+    def test_utc_datetimes(
+        self, start: datetime, finish: Optional[datetime], count: int
+    ) -> None:
+        """
+        The schema upgrades naive, localtime timestamps from before schema version
+        7 to UTC timestamps.
+        """
+        # a datetime instance can be "folded".  When the clock seems to rewind
+        # by an hour for DST, all of the times in that hour will seem to
+        # repeat.  A datetime with fold=1 represents the 2nd time.  Since this
+        # distinction is not present in the database, it is guaranteed that
+        # only one or the other case can work here.  The information is lost
+        # so there's nothing we can do to fix it.  We could make it an error
+        # but that seems bad.  Otherwise, we can arbitrarily pick one
+        # interpretation or the other.  That choice is basically up to SQLite3
+        # since we're using it to do the conversion to UTC.  It happens to
+        # interpret is as the first occurrance rather than the second.  So,
+        # prevent the test from running with the other kind of value.
+        #
+        # https://docs.python.org/3/library/datetime.html#datetime.datetime.fold
+        assume(not start.fold)
+        assume(finish is None or not finish.fold)
+
+        dbpath = self.useFixture(TempDir()).join("utc_datetimes")
+        with memory_connect(dbpath) as conn:
+            cursor = conn.cursor()
+            for upgrade in get_schema_upgrades(get_schema_version(cursor)):
+                cursor.execute(upgrade)
+                if get_schema_version(cursor) == 6:
+                    # Stop here so we can populate the database with some
+                    # state that requires upgrade.
+                    break
+
+            cursor.execute(
+                """
+                INSERT INTO [lease-maintenance-spending] ([started], [finished], [count])
+                VALUES (?, ?, ?)
+                """,
+                (start, finish, count),
+            )
+
+            # Finish the upgrade
+            for upgrade in get_schema_upgrades(get_schema_version(cursor)):
+                cursor.execute(upgrade)
+
+            cursor.execute(
+                """
+                SELECT [started], [finished], [count]
+                FROM [lease-maintenance-spending]
+                """
+            )
+            actual_start, actual_finished, actual_count = cursor.fetchone()
+
+            def expected_datetime(value):
+                return (
+                    value.replace(
+                        # The schema upgrade throws away sub-second precision.
+                        # Perhaps not ideal but in practice it doesn't matter.
+                        microsecond=0
+                    )
+                    # Translate the naive local time into an aware UTC-zoned
+                    # value.
+                    .astimezone(timezone.utc).isoformat(" ")
+                )
+
+            expected_start = expected_datetime(start)
+            if finish is None:
+                expected_finish = None
+            else:
+                expected_finish = expected_datetime(finish)
+
+            self.assertThat(
+                (actual_start, actual_finished, actual_count),
+                Equals((expected_start, expected_finish, count)),
+            )

--- a/src/_zkapauthorizer/validators.py
+++ b/src/_zkapauthorizer/validators.py
@@ -17,11 +17,30 @@ This module implements validators for ``attrs``-defined attributes.
 """
 
 from base64 import b64decode
+from datetime import datetime
+
+
+def is_aware_datetime(value: datetime) -> bool:
+    """
+    :return: ``True`` if and only iff the given value is a timezone-aware
+        datetime instance.
+    """
+    return isinstance(value, datetime) and value.tzinfo is not None
+
+
+def aware_datetime_validator(inst, attr, value) -> None:
+    """
+    An attrs validator that verifies the attribute value is a timezone-aware
+    datetime instance.
+    """
+    if is_aware_datetime(value):
+        return None
+    raise TypeError(f"{attr.name!r} must be an aware datetime instance (got {value!r})")
 
 
 def is_base64_encoded(b64decode=b64decode):
     """
-    Return a a attrs validator that verifies that the attributes is a base64
+    Return an attrs validator that verifies that the attributes is a base64
     encoded byte string.
     """
 


### PR DESCRIPTION
This is related to #371 .  The existing `EventStream` code avoids serializing datetime instances using cbor2 by formatting them into the bound SQL statement string.  This lets it avoid the cbor2 behavior of attempting to serialize naive datetimes - which is to refuse to do so by throwing an exception.

After this change, datetimes are all in UTC and timezone aware (including those which may already be in databases out there).  This will make it easier to change the `EventStream` serialization code to serialize datetime instances.

Also, by switching the in-database datetimes to UTC it makes them unambiguous and prevents losing further data about the timestamps they represent.
