### PR TITLE
Take the first snapshot

### DIFF
--- a/src/_zkapauthorizer/_plugin.py
+++ b/src/_zkapauthorizer/_plugin.py
@@ -59,8 +59,7 @@ from .recover import make_fail_downloader
 from .replicate import (
     _ReplicationCapableConnection,
     get_replica_rwcap,
-    get_tahoe_lafs_direntry_pruner,
-    get_tahoe_lafs_direntry_uploader,
+    get_tahoe_lafs_direntry_replica,
     is_replication_setup,
     replication_service,
     setup_tahoe_lafs_replication,
@@ -170,11 +169,8 @@ class ZKAPAuthorizer(object):
         """
         client = get_tahoe_client(self.reactor, node_config)
         mutable = get_replica_rwcap(node_config)
-        uploader = get_tahoe_lafs_direntry_uploader(client, mutable)
-        pruner = get_tahoe_lafs_direntry_pruner(client, mutable)
-        replication_service(replicated_conn, uploader, pruner).setServiceParent(
-            self._service
-        )
+        replica = get_tahoe_lafs_direntry_replica(client, mutable)
+        replication_service(replicated_conn, replica).setServiceParent(self._service)
         return mutable
 
     def _get_redeemer(self, node_config, announcement):

--- a/src/_zkapauthorizer/_plugin.py
+++ b/src/_zkapauthorizer/_plugin.py
@@ -35,7 +35,7 @@ from attrs import Factory, define, field
 from challenge_bypass_ristretto import PublicKey, SigningKey
 from eliot import start_action
 from prometheus_client import CollectorRegistry, write_to_textfile
-from twisted.application.service import IService, IServiceCollection, MultiService
+from twisted.application.service import IService, MultiService
 from twisted.internet import task
 from twisted.internet.defer import succeed
 from twisted.logger import Logger
@@ -120,7 +120,7 @@ class ZKAPAuthorizer(object):
     _get_tahoe_client: Callable[[Any, Config], ITahoeClient] = field()
 
     _stores: WeakValueDictionary = field(default=Factory(WeakValueDictionary))
-    _service: IServiceCollection = field()
+    _service: MultiService = field()
 
     @_service.default
     def _service_default(self):

--- a/src/_zkapauthorizer/_plugin.py
+++ b/src/_zkapauthorizer/_plugin.py
@@ -167,7 +167,7 @@ class ZKAPAuthorizer(object):
         Create a replication service for the given database and arrange for it to
         start and stop when the reactor starts and stops.
         """
-        client = get_tahoe_client(self.reactor, node_config)
+        client = self._get_tahoe_client(self.reactor, node_config)
         mutable = get_replica_rwcap(node_config)
         replica = get_tahoe_lafs_direntry_replica(client, mutable)
         replication_service(replicated_conn, replica).setServiceParent(self._service)

--- a/src/_zkapauthorizer/config.py
+++ b/src/_zkapauthorizer/config.py
@@ -25,7 +25,7 @@ __all__ = [
 ]
 
 from datetime import timedelta
-from typing import TypeVar, Union
+from typing import Protocol, TypeVar, Union
 
 from allmydata.node import _Config as Config
 from attrs import define
@@ -47,6 +47,31 @@ REPLICA_RWCAP_BASENAME = NAME + ".replica-rwcap"
 # where we're versioning our ability to open the database at all.  The schema
 # inside the database is versioned by yet another mechanism.
 CONFIG_DB_NAME = "privatestorageio-zkapauthz-v1.sqlite3"
+
+
+class TahoeConfig(Protocol):
+    """
+    A representation of the configuration for a Tahoe-LAFS node.
+    """
+
+    def get_config(
+        self,
+        section: str,
+        option: str,
+        default: object = object(),
+        boolean: bool = False,
+    ) -> object:
+        """
+        Read an option from a section of the configuration.
+        """
+
+    def get_private_path(self, name: str) -> str:
+        """
+        Construct a path beneath the private directory of the node this
+        configuration belongs to.
+
+        :param name: A path relative to the private directory.
+        """
 
 
 @define

--- a/src/_zkapauthorizer/replicate.py
+++ b/src/_zkapauthorizer/replicate.py
@@ -98,14 +98,39 @@ Uploader = Callable[[str, Callable[[], BinaryIO]], Awaitable[None]]
 # function which can remove entries from ZKAPAuthorizer state.
 Pruner = Callable[[Callable[[str], bool]], Awaitable[None]]
 
+# function which can list all entries in ZKAPAuthorizer state
+Lister = Callable[[], Awaitable[list[str]]]
+
+
+@frozen
+class Replica:
+    """
+    Manage a specific replica.
+    """
+
+    upload: Uploader
+    prune: Pruner
+    list: Lister
+
 
 class ReplicationJob(Enum):
     """
     The kinds of jobs that the Replication queue knows about
+
+    :ivar startup: Represent the job that is run once when the replication
+        service starts and which is responsible for inspecting local and
+        remote state to determine if any actions are immediately necessary
+        (even before any further local changes are made).
+
+    :ivar event_stream: Represent the job to upload a new event stream object.
+
+    :ivar snapshot: Represent the job to upload a new snapshot object and
+        prune now-obsolete event stream objects.
     """
 
-    event_stream = 1
-    snapshot = 2
+    startup = 1
+    event_stream = 2
+    snapshot = 3
 
 
 @frozen
@@ -590,6 +615,34 @@ def get_tahoe_lafs_direntry_pruner(
     return maybe_unlink
 
 
+def get_tahoe_lafs_direntry_lister(
+    client: ITahoeClient, directory_mutable_cap: str
+) -> Lister:
+    """
+    Bind a Tahoe client to a mutable directory in a callable that will list
+    the entries of that directory.
+    """
+
+    async def lister():
+        entries = await client.list_directory(directory_mutable_cap)
+        return sorted(entries.keys())
+
+    return lister
+
+
+def get_tahoe_lafs_direntry_replica(
+    client: ITahoeClient, directory_mutable_cap: str
+) -> Replica:
+    """
+    Get an object that can interact with a replica stored in a Tahoe-LAFS
+    mutable directory.
+    """
+    uploader = get_tahoe_lafs_direntry_uploader(client, directory_mutable_cap)
+    pruner = get_tahoe_lafs_direntry_pruner(client, directory_mutable_cap)
+    lister = get_tahoe_lafs_direntry_lister(client, directory_mutable_cap)
+    return Replica(uploader, pruner, lister)
+
+
 def add_events(
     cursor: _SQLite3Cursor,
     events: Iterable[tuple[str, Sequence[SQLType]]],
@@ -736,8 +789,7 @@ class _ReplicationService(Service):
     _logger = Logger()
 
     _connection: _ReplicationCapableConnection = field()
-    _uploader: Uploader
-    _pruner: Pruner
+    _replica: Replica
     _replicating: Optional[Deferred] = field(init=False, default=None)
 
     _changes: AccumulatedChanges = AccumulatedChanges.no_changes()
@@ -766,13 +818,7 @@ class _ReplicationService(Service):
             self._unreplicated_connection
         )
 
-        # we should upload a snapshot immediately if there isn't one
-        # already (but also that's async-work to determine..) and if
-        # we _do_ decide to upload a snapshot, we should _not_ upload
-        # an event-stream immediately
-
-        if self.should_upload_eventstream(self._changes):
-            self.queue_event_upload()
+        self.queue_job(ReplicationJob.startup)
 
         # Start the actual work of reacting to changes by uploading them (as
         # appropriate).
@@ -794,12 +840,19 @@ class _ReplicationService(Service):
 
         return None
 
+    def queue_job(self, job: ReplicationJob) -> None:
+        """
+        Queue a job, if it is not already queued, to be executed after any other
+        queued jobs.
+        """
+        if job not in self._jobs.pending:
+            self._jobs.put(job)
+
     def queue_event_upload(self) -> None:
         """
         Request an event-stream upload of outstanding events.
         """
-        if ReplicationJob.event_stream not in self._jobs.pending:
-            self._jobs.put(ReplicationJob.event_stream)
+        self.queue_job(ReplicationJob.event_stream)
 
     def queue_snapshot_upload(self) -> None:
         """
@@ -807,8 +860,7 @@ class _ReplicationService(Service):
         event-streams will also be pruned after the snapshot is
         successfully uploaded.
         """
-        if ReplicationJob.snapshot not in self._jobs.pending:
-            self._jobs.put(ReplicationJob.snapshot)
+        self.queue_job(ReplicationJob.snapshot)
 
     async def wait_for_uploads(self) -> None:
         """
@@ -821,8 +873,24 @@ class _ReplicationService(Service):
                 await self._do_one_event_upload()
             elif job == ReplicationJob.snapshot:
                 await self._do_one_snapshot_upload()
+            elif job == ReplicationJob.startup:
+                await self._do_startup()
             else:
                 raise Exception("internal error")  # pragma: nocover
+
+    async def _do_startup(self) -> None:
+        """
+        Check local and remote state to determine if there is any work that should
+        be done immediately.
+
+        Currently, this will upload a snapshot if none exists in the replica,
+        or upload an event stream if there are events that warrant immediate
+        upload.
+        """
+        if await self.should_upload_snapshot():
+            self.queue_snapshot_upload()
+        elif self.should_upload_eventstream(self._changes):
+            self.queue_event_upload()
 
     async def _do_one_snapshot_upload(self) -> None:
         """
@@ -844,7 +912,7 @@ class _ReplicationService(Service):
         snap = snapshot(self._connection)
 
         # upload snapshot
-        await self._uploader("snapshot", lambda: BytesIO(snap))
+        await self._replica.upload("snapshot", lambda: BytesIO(snap))
 
         # remove local event history (that should now be encapsulated
         # by the snapshot we just uploaded)
@@ -873,7 +941,7 @@ class _ReplicationService(Service):
                     return True
             return False
 
-        await self._pruner(is_old_eventstream)
+        await self._replica.prune(is_old_eventstream)
 
     async def _do_one_event_upload(self) -> None:
         """
@@ -888,7 +956,7 @@ class _ReplicationService(Service):
             return
 
         # otherwise, upload the events we found.
-        await self._uploader(event_stream_name(high_seq), events.to_bytes)
+        await self._replica.upload(event_stream_name(high_seq), events.to_bytes)
 
         # then discard the uploaded events from the local database.
         prune_events_to(self._unreplicated_connection, high_seq)
@@ -949,6 +1017,13 @@ class _ReplicationService(Service):
         self.queue_event_upload()
         self._changes = AccumulatedChanges.no_changes()
 
+    async def should_upload_snapshot(self) -> bool:
+        """
+        :returns: True if there is no remote snapshot
+        """
+        entries = await self._replica.list()
+        return "snapshot" not in entries
+
     def should_upload_eventstream(self, changes: AccumulatedChanges) -> bool:
         """
         :returns: True if we have accumulated enough statements to upload
@@ -959,8 +1034,7 @@ class _ReplicationService(Service):
 
 def replication_service(
     replicated_connection: _ReplicationCapableConnection,
-    uploader: Uploader,
-    pruner: Pruner,
+    replica: Replica,
 ) -> IService:
     """
     Return a service which implements the replication process documented in
@@ -968,6 +1042,5 @@ def replication_service(
     """
     return _ReplicationService(
         connection=replicated_connection,
-        uploader=uploader,
-        pruner=pruner,
+        replica=replica,
     )

--- a/src/_zkapauthorizer/replicate.py
+++ b/src/_zkapauthorizer/replicate.py
@@ -666,7 +666,7 @@ class AccumulatedChanges:
     size: int
 
     @classmethod
-    def no_changes(cls):
+    def no_changes(cls) -> AccumulatedChanges:
         """
         Create an ``AccumulatedChanges`` that represents no changes.
         """

--- a/src/_zkapauthorizer/replicate.py
+++ b/src/_zkapauthorizer/replicate.py
@@ -623,7 +623,7 @@ def get_tahoe_lafs_direntry_lister(
     the entries of that directory.
     """
 
-    async def lister():
+    async def lister() -> list[str]:
         entries = await client.list_directory(directory_mutable_cap)
         return sorted(entries.keys())
 

--- a/src/_zkapauthorizer/replicate.py
+++ b/src/_zkapauthorizer/replicate.py
@@ -298,7 +298,7 @@ def get_replica_rwcap(config: Config) -> CapStr:
     :raises: Exception if replication is not setup
     """
     rwcap_file = FilePath(config.get_private_path(REPLICA_RWCAP_BASENAME))
-    return rwcap_file.getContent()
+    return rwcap_file.getContent().decode("ascii")
 
 
 @define

--- a/src/_zkapauthorizer/tahoe.py
+++ b/src/_zkapauthorizer/tahoe.py
@@ -519,7 +519,7 @@ class MemoryGrid:
             obj = self._objects[cap]
             if kind(obj) == "dirnode":
                 return ["dirnode", {"rw_uri": cap}]
-            return ["filenode", {"size": len(obj)}]
+            return ["filenode", {"size": len(obj), "ro_uri": cap}]
 
         dirobj = self._objects[dir_cap]
         if isinstance(dirobj, _Directory):

--- a/src/_zkapauthorizer/tahoe.py
+++ b/src/_zkapauthorizer/tahoe.py
@@ -360,7 +360,7 @@ class ITahoeClient(Interface):
         :param entry_name: The name of the entry to remove.
         """
 
-    async def list_directory(dir_cap: CapStr) -> dict[CapStr, list[Any]]:
+    async def list_directory(dir_cap: CapStr) -> dict[str, list[Any]]:
         """
         List the entries linked into a directory.
         """
@@ -509,7 +509,7 @@ class MemoryGrid:
         else:
             raise NotADirectoryError()
 
-    def list_directory(self, dir_cap: CapStr) -> dict[CapStr, list[Any]]:
+    def list_directory(self, dir_cap: CapStr) -> dict[str, list[Any]]:
         def kind(entry):
             if isinstance(entry, _Directory):
                 return "dirnode"

--- a/src/_zkapauthorizer/tests/common.py
+++ b/src/_zkapauthorizer/tests/common.py
@@ -24,6 +24,7 @@ from inspect import iscoroutinefunction
 from typing import Awaitable, Callable, Union
 
 from attrs import Factory, define, field
+from eliot import log_call
 from twisted.internet.defer import Deferred
 from twisted.python.reflect import fullyQualifiedName
 from zope.interface import classImplements
@@ -113,6 +114,7 @@ class _DelayedController:
 
     _waiting: list[Deferred[None]] = field(default=Factory(list))
 
+    @log_call(action_type="zkapauthorizer:tests:delayed-controller:run")
     def run(self) -> None:
         """
         Run all methods which have been called (and delayed) up to this point.

--- a/src/_zkapauthorizer/tests/common.py
+++ b/src/_zkapauthorizer/tests/common.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from functools import partial
 from inspect import iscoroutinefunction
-from typing import Awaitable, Callable, Union
+from typing import Awaitable, Callable, TypeVar, Union
 
 from attrs import Factory, define, field
 from eliot import log_call
@@ -69,7 +69,10 @@ def flushErrors(exc_type: type) -> list[Exception]:
     return _logObserver.flushErrors(exc_type)
 
 
-def delayedProxy(iface, obj) -> tuple[_DelayedController, object]:
+_A = TypeVar("_A")
+
+
+def delayedProxy(iface, obj: _A) -> tuple[_DelayedController, _A]:
     """
     Wrap ``obj`` in a proxy for ``iface`` which inserts an arbitrary delay
     prior to the execution of each method.

--- a/src/_zkapauthorizer/tests/test_plugin.py
+++ b/src/_zkapauthorizer/tests/test_plugin.py
@@ -434,6 +434,9 @@ class ServiceTests(TestCase):
         # _replicating getting set
         reactor.run()
 
+        # Let's make sure the service eventually stops.
+        self.addCleanup(plugin._service.stopService)
+
         # There is no public interface for just getting the database
         # abstraction, so...
         store = plugin._get_store(node_config)

--- a/src/_zkapauthorizer/tests/test_plugin.py
+++ b/src/_zkapauthorizer/tests/test_plugin.py
@@ -420,13 +420,17 @@ class ServiceTests(TestCase):
         grid = MemoryGrid()
         tahoe = grid.client(FilePath(node_config._basedir))
 
-        reactor = MemoryReactorClock()
-        plugin = ZKAPAuthorizer(NAME, reactor, no_tahoe_client)
-
         # Place it into replication mode.
         self.assertThat(
             Deferred.fromCoroutine(setup_tahoe_lafs_replication(tahoe)),
             succeeded(Always()),
+        )
+
+        reactor = MemoryReactorClock()
+        plugin = ZKAPAuthorizer(
+            NAME,
+            reactor,
+            lambda reactor, config: grid.client(FilePath(config._basedir)),
         )
 
         # This causes MemoryReactorClock to run all the hooks, which

--- a/src/_zkapauthorizer/tests/test_replicate.py
+++ b/src/_zkapauthorizer/tests/test_replicate.py
@@ -401,8 +401,8 @@ class ReplicationServiceTests(TestCase):
         # in replication mode.  To start, make sure that database changes are
         # not already being captured.  They should not be since nothing has
         # placed the connection into replication mode yet.
-        # store.start_lease_maintenance().finish()
-        # self.assertThat(get_events(store._connection).changes, HasLength(0))
+        store.start_lease_maintenance().finish()
+        self.assertThat(get_events(store._connection).changes, HasLength(0))
 
         service = replication_service(store._connection, noop_replica)
         service.startService()

--- a/src/_zkapauthorizer/tests/test_replicate.py
+++ b/src/_zkapauthorizer/tests/test_replicate.py
@@ -353,7 +353,7 @@ def has_files(grid: MemoryGrid, dir_cap: CapStr, count: int) -> bool:
     return len(grid.list_directory(dir_cap)) >= count
 
 
-def repeatUntil(condition: Callable[[], bool], action: Callable[[], object]) -> None:
+def repeat_until(condition: Callable[[], bool], action: Callable[[], object]) -> None:
     """
     Run an action repeatedly until a condition is true.
     """
@@ -476,7 +476,7 @@ class ReplicationServiceTests(TestCase):
         self.addCleanup(srv.stopService)
 
         with start_action(action_type="zkapauthorizer:tests:wait-for-snapshot"):
-            repeatUntil(partial(has_files_bound, 1), delay_controller.run)
+            repeat_until(partial(has_files_bound, 1), delay_controller.run)
 
         # then it does a list_directory for pruning purposes.  if we don't let
         # it run then the event-stream upload for the first add_tokens() can't
@@ -504,7 +504,7 @@ class ReplicationServiceTests(TestCase):
 
         # Finish the first event-stream upload.
         with start_action(action_type="zkapauthorizer:tests:wait-for-event-stream"):
-            repeatUntil(partial(has_files_bound, 2), delay_controller.run)
+            repeat_until(partial(has_files_bound, 2), delay_controller.run)
 
         self.assertThat(
             sorted(grid.list_directory(replica_cap)),
@@ -513,7 +513,7 @@ class ReplicationServiceTests(TestCase):
 
         # Allow subsequent uploads.
         with start_action(action_type="zkapauthorizer:tests:wait-for-event-stream"):
-            repeatUntil(partial(has_files_bound, 3), delay_controller.run)
+            repeat_until(partial(has_files_bound, 3), delay_controller.run)
 
         # Now both the first upload and a second upload should have completed.
         # There is no third upload because the data for the 2nd and 3rd
@@ -576,7 +576,7 @@ class ReplicationServiceTests(TestCase):
         self.addCleanup(srv.stopService)
 
         with start_action(action_type="zkapauthorizer:tests:wait-for-snapshot"):
-            repeatUntil(partial(has_files_bound, 1), delay_controller.run)
+            repeat_until(partial(has_files_bound, 1), delay_controller.run)
 
         # then it does a list_directory for pruning purposes.  if we don't let
         # it run then the event-stream upload for the first add_tokens() can't
@@ -591,7 +591,7 @@ class ReplicationServiceTests(TestCase):
 
         # Allow the resulting event-stream upload to complete.
         with start_action(action_type="zkapauthorizer:tests:wait-for-event-stream"):
-            repeatUntil(partial(has_files_bound, 2), delay_controller.run)
+            repeat_until(partial(has_files_bound, 2), delay_controller.run)
 
         # ..so we should have uploaded here
         self.assertThat(

--- a/src/_zkapauthorizer/tests/test_spending.py
+++ b/src/_zkapauthorizer/tests/test_spending.py
@@ -28,9 +28,7 @@ from testtools.matchers import (
     MatchesStructure,
 )
 from testtools.twistedsupport import succeeded
-from twisted.python.filepath import FilePath
 
-from ..config import EmptyConfig
 from ..spending import IPassGroup, SpendingController
 from .fixtures import TemporaryVoucherStore
 from .matchers import Provides
@@ -48,12 +46,7 @@ class PassGroupTests(TestCase):
         ``IPassFactory.get`` returns an ``IPassGroup`` provider containing the
         requested number of passes.
         """
-        configless = self.useFixture(
-            TemporaryVoucherStore(
-                get_config=lambda basedir, portfile: EmptyConfig(FilePath(basedir)),
-                get_now=lambda: now,
-            ),
-        )
+        configless = self.useFixture(TemporaryVoucherStore(get_now=lambda: now))
         # Make sure there are enough tokens for us to extract!
         self.assertThat(
             configless.redeem(voucher, num_passes),
@@ -87,12 +80,7 @@ class PassGroupTests(TestCase):
         random,
         data,
     ):
-        configless = self.useFixture(
-            TemporaryVoucherStore(
-                get_config=lambda basedir, portfile: EmptyConfig(FilePath(basedir)),
-                get_now=lambda: now,
-            ),
-        )
+        configless = self.useFixture(TemporaryVoucherStore(get_now=lambda: now))
         # Make sure there are enough tokens for us to use!
         self.assertThat(
             configless.redeem(voucher, num_passes),


### PR DESCRIPTION
Fixes #379 

Rather than thread a third replica-related argument through the various layers, I wrapped the new "list directory entries" up with the existing uploader and pruner in a single `Replica` type (still preserving the possibility of non-Tahoe-LAFS-based replicas).

I also moved a lot of repetitive test code for creating a `TemporaryVoucherStore` with an empty Tahoe configuration into `TemporaryVoucherStore` itself by giving it a default empty configuration and letting most tests get that value.

I also adjusted the existing `test_enable_replication_on_connection` to make an assertion about behavior instead of internal implementation details.

The actual feature is implemented with a new `startup` job type that is queued first, once, when the replication service starts.

I noticed there is a test missing for the `should_upload_eventstream` logic that was already present (and is moved by this PR).  I'll add that test in a follow-up.

Other follow-up work will be making `should_upload_snapshot` smarter: it should decide yes if a new snapshot would be much smaller than the on-grid footprint of the stored snapshot and all of its event stream objects.  Also, periodic re-checking of this condition (perhaps after each event-stream object upload).
