### PR TITLE
Support Python 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,10 @@ jobs:
           destination: "docs"
 
   windows-tests:
+    parameters:
+      py-version:
+        type: "string"
+
     executor:
       # https://circleci.com/developer/orbs/orb/circleci/windows
       name: "win/server-2022"
@@ -64,14 +68,14 @@ jobs:
       - run:
           name: "Setup Environment"
           command: |
-            python -V
-            python -m pip install -v --upgrade pip wheel
-            python -m pip install -v . -r requirements/test.in
-            pip freeze
+            python<< parameters.py-version >> -V
+            python<< parameters.py-version >> -m pip install -v --upgrade pip wheel
+            python<< parameters.py-version >> -m pip install -v . -r requirements/test.in
+            python<< parameters.py-version >> -m pip freeze
       - run:
           name: "Run Tests"
           command: |
-            python -m coverage run `
+            python<< parameters.py-version >> -m coverage run `
               --debug=config `
               --module twisted.trial `
                 --rterrors `
@@ -82,8 +86,8 @@ jobs:
           command: |
             mkdir -p coverage-workspace
             Copy-Item -Path ".coverage.*" -Destination "coverage-workspace"
-            python -m coverage combine
-            python -m coverage report
+            python<< parameters.py-version >> -m coverage combine
+            python<< parameters.py-version >> -m coverage report
 
       - persist_to_workspace:
           root: "coverage-workspace"
@@ -511,35 +515,40 @@ workflows:
         coverage: "false"
     - "build-wheel"
     - "linux-tests":
-        name: "Linux tests, python 3.9"
-        py-version: "39"
-        tahoe-lafs-source: "tahoe-lafs"
-        coverage: "true"
-
-    - "linux-tests":
-        name: "Linux tests, python 3.9, Tahoe-LAFS master"
-        py-version: "39"
-        # This is usually not master@HEAD because it is still pinned to a
-        # certain revision.  The intent is to update it frequently and
-        # discover fixable incompatibilities in small groups and unfixable
-        # incompatibilities early enough to prevent them from going into a
-        # release.
-        tahoe-lafs-source: "tahoe-lafs-master"
-        coverage: "false"
+        matrix:
+          parameters:
+            py-version:
+              - "39"
+            tahoe-lafs-source:
+              - "tahoe-lafs"
+              # This is usually not master@HEAD because it is still pinned to
+              # a certain revision.  The intent is to update it frequently and
+              # discover fixable incompatibilities in small groups and
+              # unfixable incompatibilities early enough to prevent them from
+              # going into a release.
+              - "tahoe-lafs-master"
+            coverage:
+              - "true"
 
     # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
     - "macos-tests":
-        name: "macOS tests, python 3.9 xcode 12.3.0"
-        py-version: "3.9"
-        xcode-version: "12.3.0"
+        matrix:
+          parameters:
+            py-version:
+              - "3.9"
+            xcode-version:
+              - "12.3.0"
 
     - "windows-tests":
-        name: "Windows tests, python 3.9"
+        matrix:
+          parameters:
+            py-version:
+              - "3.9"
 
     - "finish-coverage":
         # Make sure it depends on all coverage-collecting jobs!
         requires:
-          - "Linux tests, python 3.9"
-          - "Linux tests, python 3.9, Tahoe-LAFS master"
-          - "macOS tests, python 3.9 xcode 12.3.0"
-          - "Windows tests, python 3.9"
+          - "linux-tests-true-39-tahoe-lafs"
+          - "linux-tests-true-39-tahoe-lafs-master"
+          - "macos-tests-3.9-12.3.0"
+          - "windows-tests-3.9"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,9 +104,6 @@ jobs:
     macos:
       xcode: << parameters.xcode-version >>
 
-    environment:
-      HOMEBREW_NO_AUTO_UPDATE: 1
-
     steps:
       - "checkout"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,14 +68,14 @@ jobs:
       - run:
           name: "Setup Environment"
           command: |
-            python<< parameters.py-version >> -V
-            python<< parameters.py-version >> -m pip install -v --upgrade pip wheel
-            python<< parameters.py-version >> -m pip install -v . -r requirements/test.in
-            python<< parameters.py-version >> -m pip freeze
+            py -<< parameters.py-version >> -V
+            py -<< parameters.py-version >> -m pip install -v --upgrade pip wheel
+            py -<< parameters.py-version >> -m pip install -v . -r requirements/test.in
+            py -<< parameters.py-version >> -m pip freeze
       - run:
           name: "Run Tests"
           command: |
-            python<< parameters.py-version >> -m coverage run `
+            py -<< parameters.py-version >> -m coverage run `
               --debug=config `
               --module twisted.trial `
                 --rterrors `
@@ -86,8 +86,8 @@ jobs:
           command: |
             mkdir -p coverage-workspace
             Copy-Item -Path ".coverage.*" -Destination "coverage-workspace"
-            python<< parameters.py-version >> -m coverage combine
-            python<< parameters.py-version >> -m coverage report
+            py -<< parameters.py-version >> -m coverage combine
+            py -<< parameters.py-version >> -m coverage report
 
       - persist_to_workspace:
           root: "coverage-workspace"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
       - run:
           name: "Install Python"
           command: |
-            brew install python@<< parameters.py-version >>
+            type -p python<< parameters.py-version >> || brew install python@<< parameters.py-version >>
 
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -487,7 +487,7 @@ workflows:
             branches:
               # And make sure it runs for no other branch pushes.
               ignore: "/.*/"
-          repository: "pypi"
+          repository: "testpypi"
           requires:
             - "build-wheel"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,7 @@ jobs:
               --debug=config `
               --module twisted.trial `
                 --rterrors `
+                --dry-run `
                 _zkapauthorizer
 
       - run:
@@ -195,6 +196,7 @@ jobs:
                 --module twisted.trial \
                   --jobs 4 \
                   --rterrors \
+                  --dry-run \
                   _zkapauthorizer
 
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,8 +104,16 @@ jobs:
     macos:
       xcode: << parameters.xcode-version >>
 
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+
     steps:
       - "checkout"
+
+      - run:
+          name: "Install Python"
+          command: |
+            brew install python@<< parameters.py-version >>
 
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -477,7 +477,7 @@ workflows:
             branches:
               # And make sure it runs for no other branch pushes.
               ignore: "/.*/"
-          repository: "testpypi"
+          repository: "pypi"
           requires:
             - "build-wheel"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,7 @@ jobs:
           name: "Install Python"
           command: |
             type -p python<< parameters.py-version >> || brew install python@<< parameters.py-version >>
+            echo 'export PATH="/usr/local/opt/python@<< parameters.py-version >>/bin:$PATH"' >> "$BASH_ENV"
 
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -519,6 +519,7 @@ workflows:
           parameters:
             py-version:
               - "39"
+              - "310"
             tahoe-lafs-source:
               - "tahoe-lafs"
               # This is usually not master@HEAD because it is still pinned to
@@ -536,6 +537,7 @@ workflows:
           parameters:
             py-version:
               - "3.9"
+              - "3.10"
             xcode-version:
               - "12.3.0"
 
@@ -544,11 +546,16 @@ workflows:
           parameters:
             py-version:
               - "3.9"
+              - "3.10"
 
     - "finish-coverage":
         # Make sure it depends on all coverage-collecting jobs!
         requires:
           - "linux-tests-true-39-tahoe-lafs"
           - "linux-tests-true-39-tahoe-lafs-master"
+          - "linux-tests-true-310-tahoe-lafs"
+          - "linux-tests-true-310-tahoe-lafs-master"
           - "macos-tests-3.9-12.3.0"
+          - "macos-tests-3.10-12.3.0"
           - "windows-tests-3.9"
+          - "windows-tests-3.10"

--- a/.coveragerc
+++ b/.coveragerc
@@ -44,8 +44,7 @@ source =
        /tmp/nix-build-zkapauthorizer-tests.drv-*/src/
 
        # A Windows build embeds source paths like one of these probably.
-       C:\tools\miniconda3\Lib\site-packages\
-       C:\Python310\Lib\site-packages\
+       ?:\*\site-packages\
 
        # A macOS build embeds source paths like this one.
        /Users/distiller/project/venv/lib/python*/site-packages/

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "DavHau",
         "repo": "mach-nix",
-        "rev": "3.5.0",
-        "sha256": "185qf6d5xg8qk1hb1y0b5gggr71vdz8v9d5ga4zg7dmcb1aypxcg",
+        "rev": "f15ea8677df951cb4fe608945fd98725dcd033b3",
+        "sha256": "1vi3nbmsdv3rk30pwiizhslbbbp7hy6rxign9d87sl8z6ixngnv8",
         "type": "tarball",
-        "url": "https://github.com/DavHau/mach-nix/archive/3.5.0.tar.gz",
+        "url": "https://github.com/DavHau/mach-nix/archive/f15ea8677df951cb4fe608945fd98725dcd033b3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "DavHau",
         "repo": "pypi-deps-db",
-        "rev": "3e6c4e328bdae5c9f1e8131833275cce26df47f0",
-        "sha256": "01rjxxv2chjjz5l55vplj76d616fld7226ai6lw6rhv93ypzfc13",
+        "rev": "ed4433b11615fc5d84e349ad8f9f2f468165c876",
+        "sha256": "1kf3syafp0zb1j9id3r7rcf63gjhd2wpz2nf3wgn1nwv3gqf15dv",
         "type": "tarball",
-        "url": "https://github.com/DavHau/pypi-deps-db/archive/3e6c4e328bdae5c9f1e8131833275cce26df47f0.tar.gz",
+        "url": "https://github.com/DavHau/pypi-deps-db/archive/ed4433b11615fc5d84e349ad8f9f2f468165c876.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "release2111": {

--- a/requirements/typecheck.in
+++ b/requirements/typecheck.in
@@ -1,2 +1,2 @@
-mypy
+mypy==0.950
 mypy-zope


### PR DESCRIPTION
This adds Python 3.10 builds and test jobs to CI for Windows, NixOS, and macOS.

It also bumps our dependencies of some packaging tools to make these jobs succeed.