### PR TITLE
Adapt to the evolving CI SaaS landscape

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -534,7 +534,7 @@ workflows:
         xcode-version: "12.5.1"
 
     - "windows-tests":
-        name: "Windows tests, python 3.9"
+        name: "Windows tests, python 3.10"
 
     - "finish-coverage":
         # Make sure it depends on all coverage-collecting jobs!
@@ -542,4 +542,4 @@ workflows:
           - "Linux tests, python 3.9"
           - "Linux tests, python 3.9, Tahoe-LAFS master"
           - "macOS tests, python 3.9 xcode 12.5.1"
-          - "Windows tests, python 3.9"
+          - "Windows tests, python 3.10"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -529,9 +529,9 @@ workflows:
 
     # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
     - "macos-tests":
-        name: "macOS tests, python 3.9 xcode 12.3.0"
+        name: "macOS tests, python 3.9 xcode 12.5.1"
         py-version: "3.9"
-        xcode-version: "12.3.0"
+        xcode-version: "12.5.1"
 
     - "windows-tests":
         name: "Windows tests, python 3.9"
@@ -541,5 +541,5 @@ workflows:
         requires:
           - "Linux tests, python 3.9"
           - "Linux tests, python 3.9, Tahoe-LAFS master"
-          - "macOS tests, python 3.9 xcode 12.3.0"
+          - "macOS tests, python 3.9 xcode 12.5.1"
           - "Windows tests, python 3.9"

--- a/.coveragerc
+++ b/.coveragerc
@@ -43,8 +43,9 @@ source =
        # Then the Nix test step combines the data files and rewrites the paths to look like this.
        /tmp/nix-build-zkapauthorizer-tests.drv-*/src/
 
-       # A Windows build embeds source paths like this one.
+       # A Windows build embeds source paths like one of these probably.
        C:\tools\miniconda3\Lib\site-packages\
+       C:\Python310\Lib\site-packages\
 
        # A macOS build embeds source paths like this one.
        /Users/distiller/project/venv/lib/python*/site-packages/


### PR DESCRIPTION
* xcode 12.3.0 was end-of-lifed August 2nd so that kind of job cannot run anymore
* circleci windows image upgrade from Python 3.9 to Python 3.10 so source pages in coverage data changed, breaking the reporter (and there is no Python 3.9 Windows job anymore)