### PR TITLE
Turn test-running back on

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,6 @@ jobs:
               --debug=config `
               --module twisted.trial `
                 --rterrors `
-                --dry-run `
                 _zkapauthorizer
 
       - run:
@@ -196,7 +195,6 @@ jobs:
                 --module twisted.trial \
                   --jobs 4 \
                   --rterrors \
-                  --dry-run \
                   _zkapauthorizer
 
           environment:


### PR DESCRIPTION
It was disabled to speed up CI/coverage configuration fixes that didn't need
tests to run but then I forgot to enable it again afterwards.