### PR TITLE
restrict the types accepted by the other log_call helpers

### DIFF
--- a/src/_zkapauthorizer/_types.py
+++ b/src/_zkapauthorizer/_types.py
@@ -17,7 +17,16 @@ Re-usable type definitions for ZKAPAuthorizer.
 """
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Callable, Generic, TypedDict, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Generic,
+    Mapping,
+    Sequence,
+    TypedDict,
+    TypeVar,
+    Union,
+)
 
 from attrs import Attribute as _Attribute
 from typing_extensions import TypeAlias
@@ -36,7 +45,7 @@ else:
 
 # mypy does not support recursive types so we can't say much about what's in
 # the containers here.
-JSON = Union[None, int, float, str, list, dict]
+JSON = Union[None, int, float, str, Sequence, Mapping]
 
 ServerConfig = TypedDict(
     "ServerConfig",

--- a/src/_zkapauthorizer/eliot.py
+++ b/src/_zkapauthorizer/eliot.py
@@ -26,6 +26,7 @@ from eliot import log_call as _log_call
 from eliot import start_action
 from eliot.json import EliotJSONEncoder
 from eliot.testing import capture_logging as _capture_logging
+from twisted.internet.defer import Deferred
 from typing_extensions import ParamSpec
 
 from ._types import JSON
@@ -139,21 +140,21 @@ def log_call(
 
 def log_call_deferred(
     action_type: Optional[str] = None,
-) -> Callable[[Callable[P, T]], Callable[P, T]]:
+) -> Callable[[Callable[P, Deferred[JSONT]]], Callable[P, Deferred[JSONT]]]:
     return cast(
-        Callable[[Callable[P, T]], Callable[P, T]],
+        Callable[[Callable[P, Deferred[JSONT]]], Callable[P, Deferred[JSONT]]],
         _log_call_deferred(action_type),
     )
 
 
 def log_call_coroutine(
     action_type: str,
-) -> Callable[[Callable[P, Awaitable[T]]], Callable[P, Awaitable[T]]]:
+) -> Callable[[Callable[P, Awaitable[JSONT]]], Callable[P, Awaitable[JSONT]]]:
     def decorate_log_call_coroutine(
-        f: Callable[P, Awaitable[T]]
-    ) -> Callable[P, Awaitable[T]]:
+        f: Callable[P, Awaitable[JSONT]]
+    ) -> Callable[P, Awaitable[JSONT]]:
         @wraps(f)
-        async def logged_f(*a: P.args, **kw: P.kwargs) -> T:
+        async def logged_f(*a: P.args, **kw: P.kwargs) -> JSONT:
             with start_action(action_type=action_type):
                 return await f(*a, **kw)
 


### PR DESCRIPTION
Follow-up on #434 - there are two more logging decorators that can be improved similarly.