### PR TITLE
Avoid double-redeeming vouchers

### DIFF
--- a/src/_zkapauthorizer/controller.py
+++ b/src/_zkapauthorizer/controller.py
@@ -929,11 +929,11 @@ class PaymentController(object):
             if voucher_obj.state.should_start_redemption():
                 counter_start = voucher_obj.state.start_at_counter()
             else:
-                raise ValueError(
-                    "Cannot redeem voucher in state {}.".format(
-                        voucher_obj.state,
-                    ),
+                self._log.info(
+                    "Cannot redeem voucher in state {state}.",
+                    state=voucher_obj.state,
                 )
+                return None
 
         self._log.info(
             "Starting redemption of {voucher}[{start}..{end}] for {num_tokens} tokens.",

--- a/src/_zkapauthorizer/controller.py
+++ b/src/_zkapauthorizer/controller.py
@@ -915,7 +915,7 @@ class PaymentController(object):
         """
         # Try to get an existing voucher object for the given number.
         try:
-            voucher_obj = self.store.get(voucher)
+            voucher_obj = self.get_voucher(voucher)
         except KeyError:
             # This is our first time dealing with this number.
             counter_start = 0


### PR DESCRIPTION
Fixes #437 

Before we would try to redeem a voucher concurrently if someone asked us to but only one of these attempts could ever succeed.  Now we'll notice if we're already redeeming in the cases that would have led to concurrency and just log the fact instead.