### PR TITLE
Release 22.8.20.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -498,6 +498,7 @@ workflows:
               - "310"
             tahoe-lafs:
               - "1_17_1"
+              - "1_18_0"
               # This is usually not master@HEAD because it is still pinned to
               # a certain revision.  The intent is to update it frequently and
               # discover fixable incompatibilities in small groups and

--- a/flake.lock
+++ b/flake.lock
@@ -85,11 +85,11 @@
     "tahoe-lafs-dev": {
       "flake": false,
       "locked": {
-        "lastModified": 1660571400,
-        "narHash": "sha256-atIr+RwV4zSejX0sPqgqKTR2lNvjI2+H5do6lhrslSk=",
+        "lastModified": 1664893933,
+        "narHash": "sha256-85aDykgcPjRr+y7Q8tKEDd3kKpDwFl3AtMNLQO5Nqqc=",
         "owner": "tahoe-lafs",
         "repo": "tahoe-lafs",
-        "rev": "7dd346a32df34712696606137391c0355bb07a55",
+        "rev": "f56b43468b63a99c5fe22657cde75131344052dd",
         "type": "github"
       },
       "original": {

--- a/nix/tahoe-versions.nix
+++ b/nix/tahoe-versions.nix
@@ -51,7 +51,7 @@ in
       # we'll call it something close to another version we know about.  If we
       # really need to know what version it was then the Nix derivation has
       # this information and we can dig it out.
-      version = "1.17.1.post1";
+      version = "1.18.0.post1";
       postPatch =
         let
           versionFileContents = version: ''

--- a/nix/tahoe-versions.nix
+++ b/nix/tahoe-versions.nix
@@ -7,6 +7,12 @@ let
     version = "1.17.1";
     sha256 = "sha256-Lcf8ED/g5Pn8aZU5NAifVeRCi9XZRnDoROZMIQ18FnI=";
   };
+
+  v1_18_0 = fetchPypi {
+    pname = "tahoe-lafs";
+    version = "1.18.0";
+    sha256 = "sha256-cXpHDfNO3TGta5RGfauqHK7dfy9SM7BLidjP6TbjF/4=";
+  };
 in
 [
   {
@@ -17,6 +23,17 @@ in
     version = "1_17_1";
     buildArgs = {
       src = v1_17_1;
+      requirementsExtra = ''
+      eliot
+      foolscap
+      '';
+    };
+  }
+
+  {
+    version = "1_18_0";
+    buildArgs = {
+      src = v1_18_0;
       requirementsExtra = ''
       eliot
       foolscap

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,9 +46,10 @@ install_requires =
     Twisted[tls,conch] >= 19.10.0
 
     # Tahoe has no stable Python API but we use its Python API so there's
-    # basically no wiggle room here.  We still use a (really tiny) range
-    # because our Nix packaging provides a Tahoe-LAFS with a .postNNN version.
-    tahoe-lafs >=1.17.1,<1.17.2
+    # basically no wiggle room here.  We use a tiny range that just covers
+    # what we test plus a little because our Nix packaging provides a
+    # Tahoe-LAFS with a .postNNN version.
+    tahoe-lafs >=1.17.1,<1.18.1
     treq
     pyutil
     prometheus-client

--- a/src/_zkapauthorizer/__init__.py
+++ b/src/_zkapauthorizer/__init__.py
@@ -27,4 +27,4 @@ stats.eventually = lambda f: f()
 # client plugin exposes, configuration files, etc.
 NAME = "privatestorageio-zkapauthz-v2"
 
-__version__ = "2022.8.20"
+__version__ = "2022.8.20.1"

--- a/src/_zkapauthorizer/__init__.py
+++ b/src/_zkapauthorizer/__init__.py
@@ -27,4 +27,4 @@ stats.eventually = lambda f: f()
 # client plugin exposes, configuration files, etc.
 NAME = "privatestorageio-zkapauthz-v2"
 
-__version__ = "2022.8.20.1"
+__version__ = "2022.8.21"


### PR DESCRIPTION
This widens the allowed range of Tahoe-LAFS versions and bumps the version number.  If it passes CI then we can tag it as a release.  This will make integration with newer Tahoe-LAFS possible without pulling in any of the other recent development work on ZKAPAuthorizer (which is good because it has some known bugs).
