### PR TITLE
Upgrade to nixpkgs-22.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,16 +43,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1660581366,
-        "narHash": "sha256-et+bi9/jlSF/pHx5AYB9ZP2XDdZEQ0vnF7xlvs4503Y=",
+        "lastModified": 1676253841,
+        "narHash": "sha256-jhuI8Mmky8VCD45OoJEuF6HdPLFBwNrHA0ljjZ/zkfw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3d47bbaa26e7a771059d828eecf3bd8bf28a8b0f",
+        "rev": "a45a8916243a7d27acc358f4fc18c4491f3eeca8",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05",
+        "ref": "nixos-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -60,11 +60,11 @@
     "pypi-deps-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1663101621,
-        "narHash": "sha256-3VSWF+O+RuGBcieAthMJ2flA5Rf07upq1XuYs5AS9jM=",
+        "lastModified": 1676367706,
+        "narHash": "sha256-FY7MKi/Q6IO4hlYiGqVCrXAg+/VJ/pIVS+ZfqeonOx8=",
         "owner": "DavHau",
         "repo": "pypi-deps-db",
-        "rev": "0e7d22a0348ff92015887b7255fb90c02a024b97",
+        "rev": "1974e03fe3ee9d7246e9af3bedbea72e3ea0535c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "A Tahoe-LAFS storage-system plugin which authorizes storage operations based on privacy-respecting tokens.";
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-22.05";
+    nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-22.11";
     flake-utils.url = "github:numtide/flake-utils";
     pypi-deps-db = {
       flake = false;


### PR DESCRIPTION
Upgrade to `nixpkgs-22.11` - and failing at the moment - due to an infinite recursion error:

```
$ nix build

[...]

error: infinite recursion encountered

       at /nix/store/l9wr42c9j4cydpanidi6amch940qbzap-source/pkgs/stdenv/generic/make-derivation.nix:311:7:

          310|       depsBuildBuild              = lib.elemAt (lib.elemAt dependencies 0) 0;
          311|       nativeBuildInputs           = lib.elemAt (lib.elemAt dependencies 0) 1;
             |       ^
          312|       depsBuildTarget             = lib.elemAt (lib.elemAt dependencies 0) 2;
(use '--show-trace' to show detailed location information)
```

These might be related:

- https://github.com/DavHau/mach-nix/issues/470 
- https://github.com/DavHau/mach-nix/issues/529
- https://github.com/DavHau/mach-nix/issues/529#issuecomment-1352723820
 