### PR TITLE
Fix Python 3.10 Windows CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,7 @@ jobs:
       - run:
           name: "Setup Environment"
           command: |
+            py --list
             py -<< parameters.py-version >> -V
             py -<< parameters.py-version >> -m pip install -v --upgrade pip wheel
             py -<< parameters.py-version >> -m pip install -v . -r requirements/test.in

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,9 @@ jobs:
       name: "win/server-2022"
       # resource class, can be "medium", "large", "xlarge", "2xlarge"
       size: "medium"
+      # The default Windows machine image changes from time to time - which
+      # often breaks things.  Avoid that.
+      version: "2022.08.1"
 
     steps:
       # Commands are run in a Windows virtual machine environment


### PR DESCRIPTION
The Windows image for the Windows CI environment was changed at the beginning of March 2023.  The new image does not have Python 3.10, only Python 3.9 and Python 3.11.

The Windows Python 3.10 CI job therefore failed as `py` could not find a Python 3.10 to use.

This pins the Windows image to the September 2022 Windows image which does have Python 3.10.

Later we can also pin a newer image if we want to test against Python 3.11.

This does not try to fix the Python 3.9 macOS CI job which seems to fail for unrelated reasons now.
