### PR TITLE
Use https instead of ssh to checkout the code from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,13 +19,19 @@ orbs:
   win: "circleci/windows@4.1.1"
 
 aliases:
+  # Custom checkout step using https URL instead of the ssh one provided by GitHub OAuth
+  # This avoids us having to manage keys only to read a public repo - until we have to push?
   - &CHECKOUT
     run:
-      # Custom checkout step using https URL instead of the ssh one provided by GitHub OAuth
-      # This avoids us having to manage keys only to read a public repo - until we have to push?
       name: Checkout code
       command: |
         git clone -b "${CIRCLE_BRANCH}" "https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git" .
+
+  - &CHECKOUT_WINDOWS
+    run:
+      name: Checkout code
+      command: |
+        git clone -b "$Env:CIRCLE_BRANCH" "https://github.com/$Env:CIRCLE_PROJECT_USERNAME/$Env:CIRCLE_PROJECT_REPONAME.git" .
 
   - &PREPARE_VIRTUALENV
     run:
@@ -93,7 +99,7 @@ jobs:
 
     steps:
       # Commands are run in a Windows virtual machine environment
-      - <<: *CHECKOUT
+      - <<: *CHECKOUT_WINDOWS
       - run:
           name: "Setup Environment"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,14 @@ orbs:
   win: "circleci/windows@4.1.1"
 
 aliases:
+  - &CHECKOUT
+    run:
+      # Custom checkout step using https URL instead of the ssh one provided by GitHub OAuth
+      # This avoids us having to manage keys only to read a public repo - until we have to push?
+      name: Checkout code
+      command: |
+        git clone -b "${CIRCLE_BRANCH}" "https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git" .
+
   - &PREPARE_VIRTUALENV
     run:
       name: "Prepare virtualenv"
@@ -55,7 +63,7 @@ jobs:
       PIP_REQUIREMENTS: "-r docs/requirements.txt"
 
     steps:
-      - "checkout"
+      - <<: *CHECKOUT
 
       - <<: *PREPARE_VIRTUALENV
 
@@ -85,7 +93,7 @@ jobs:
 
     steps:
       # Commands are run in a Windows virtual machine environment
-      - "checkout"
+      - <<: *CHECKOUT
       - run:
           name: "Setup Environment"
           command: |
@@ -128,7 +136,7 @@ jobs:
       xcode: << parameters.xcode-version >>
 
     steps:
-      - "checkout"
+      - <<: *CHECKOUT
 
       - run:
           name: "Install Python"
@@ -255,7 +263,7 @@ jobs:
       # The only reason we need the source for this step is to get
       # nix/twine.nix that defines the shell environment we can use to upload
       # the wheel.
-      - "checkout"
+      - <<: *CHECKOUT
 
       - attach_workspace:
           at: "release-workspace"
@@ -284,7 +292,7 @@ jobs:
       <<: *NIX_ENVIRON
 
     steps:
-      - "checkout"
+      - <<: *CHECKOUT
       - run:
           name: "Build Wheel"
           command: |
@@ -336,7 +344,7 @@ jobs:
             # instead of building it locally, if possible.
             cachix use "${CACHIX_NAME}"
 
-      - "checkout"
+      - <<: *CHECKOUT
 
       - run:
           name: "Run Test Suite"
@@ -377,7 +385,7 @@ jobs:
     steps:
       - run:
           <<: *SETUP_CACHIX
-      - "checkout"
+      - <<: *CHECKOUT
 
       - run:
           name: "Check Black"
@@ -410,7 +418,7 @@ jobs:
       - <<: *NIX_DOCKER
 
     steps:
-      - "checkout"
+      - <<: *CHECKOUT
       - attach_workspace:
           at: "coverage-workspace"
 


### PR DESCRIPTION
Part of #462

This PR would avoid us having to manage some SSH key(s) only to read a public repo (until we have to push?).
It introduces a re-usable [custom checkout step](https://support.circleci.com/hc/en-us/articles/115015659247-How-do-I-modify-the-checkout-step) using https URL instead of the ssh one provided by GitHub OAuth.
