### PR TITLE
Have CI using SHA1 digests instead of branches to checkout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,9 @@ aliases:
     run:
       name: Checkout code
       command: |
-        git clone "https://github.com/${CIRCLE_PR_USERNAME}/${CIRCLE_PR_REPONAME}.git" .
+        USERNAME=${CIRCLE_PR_USERNAME:-${CIRCLE_PROJECT_USERNAME}}
+        REPONAME=${CIRCLE_PR_REPONAME:-${CIRCLE_PROJECT_REPONAME}}
+        git clone "https://github.com/${USERNAME}/${REPONAME}.git" .
         git checkout -b "${CIRCLE_BRANCH}" "${CIRCLE_SHA1}"
         TERM=ansi git log -n 1 --pretty=oneline
 
@@ -33,7 +35,9 @@ aliases:
     run:
       name: Checkout code
       command: |
-        git clone "https://github.com/$Env:CIRCLE_PR_USERNAME/$Env:CIRCLE_PR_REPONAME.git" .
+        $USERNAME = if ($Env:CIRCLE_PR_USERNAME -ne $null) { $Env:CIRCLE_PR_USERNAME } else { $Env:CIRCLE_PROJECT_USERNAME }
+        $REPONAME = if ($Env:CIRCLE_PR_REPONAME -ne $null) { $Env:CIRCLE_PR_REPONAME } else { $Env:CIRCLE_PROJECT_REPONAME }
+        git clone "https://github.com/$USERNAME/$REPONAME.git" .
         git checkout -b "$Env:CIRCLE_BRANCH" "$Env:CIRCLE_SHA1"
         git log -n 1 --pretty=oneline
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,9 @@ orbs:
 aliases:
   # Custom checkout step using https URL instead of the ssh one provided by GitHub OAuth
   # This avoids us having to manage keys only to read a public repo - until we have to push?
+  # But we have to handle remote branches from external fork (CIRCLE_PR_XXX)
+  # and local branches from the project itself (CIRCLE_PROJECT)
+  # In addition, the code will differ between bash and powershell
   - &CHECKOUT
     run:
       name: Checkout code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ aliases:
       command: |
         git clone "https://github.com/${CIRCLE_PR_USERNAME}/${CIRCLE_PR_REPONAME}.git" .
         git checkout -b "${CIRCLE_BRANCH}" "${CIRCLE_SHA1}"
-        git log -n 1 --pretty=oneline
+        TERM=ansi git log -n 1 --pretty=oneline
 
   - &CHECKOUT_WINDOWS
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,13 +25,15 @@ aliases:
     run:
       name: Checkout code
       command: |
-        git clone -b "${CIRCLE_BRANCH}" "https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git" .
+        git clone "https://github.com/${CIRCLE_PR_USERNAME}/${CIRCLE_PR_REPONAME}.git" .
+        git checkout "${CIRCLE_SHA1}"
 
   - &CHECKOUT_WINDOWS
     run:
       name: Checkout code
       command: |
-        git clone -b "$Env:CIRCLE_BRANCH" "https://github.com/$Env:CIRCLE_PROJECT_USERNAME/$Env:CIRCLE_PROJECT_REPONAME.git" .
+        git clone "https://github.com/$Env:CIRCLE_PR_USERNAME/$Env:CIRCLE_PR_REPONAME.git" .
+        git checkout "$Env:CIRCLE_SHA1"
 
   - &PREPARE_VIRTUALENV
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ aliases:
       command: |
         git clone "https://github.com/${CIRCLE_PR_USERNAME}/${CIRCLE_PR_REPONAME}.git" .
         git checkout -b "${CIRCLE_BRANCH}" "${CIRCLE_SHA1}"
+        git log -n 1 --pretty=oneline
 
   - &CHECKOUT_WINDOWS
     run:
@@ -34,6 +35,7 @@ aliases:
       command: |
         git clone "https://github.com/$Env:CIRCLE_PR_USERNAME/$Env:CIRCLE_PR_REPONAME.git" .
         git checkout -b "$Env:CIRCLE_BRANCH" "$Env:CIRCLE_SHA1"
+        git log -n 1 --pretty=oneline
 
   - &PREPARE_VIRTUALENV
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,14 +26,14 @@ aliases:
       name: Checkout code
       command: |
         git clone "https://github.com/${CIRCLE_PR_USERNAME}/${CIRCLE_PR_REPONAME}.git" .
-        git checkout "${CIRCLE_SHA1}"
+        git checkout -b "${CIRCLE_BRANCH}" "${CIRCLE_SHA1}"
 
   - &CHECKOUT_WINDOWS
     run:
       name: Checkout code
       command: |
         git clone "https://github.com/$Env:CIRCLE_PR_USERNAME/$Env:CIRCLE_PR_REPONAME.git" .
-        git checkout "$Env:CIRCLE_SHA1"
+        git checkout -b "$Env:CIRCLE_BRANCH" "$Env:CIRCLE_SHA1"
 
   - &PREPARE_VIRTUALENV
     run:


### PR DESCRIPTION
Part of PrivateStorageio/ZKAPAuthorizer#462

Since PrivateStorageio/ZKAPAuthorizer#467, CI checkout the code via https.
However, this has broken CI for builds triggered by PR from forks (vs branches within the project).
For instance [here](https://app.circleci.com/pipelines/github/PrivateStorageio/ZKAPAuthorizer/1922/workflows/9350e360-164f-4437-86cc-bc35152e57bb/jobs/9049?invite=true#step-101-5):

```
fatal: Remote branch pull/466 not found in upstream origin
```

This PR should fix this by using the correct user and repo names (the remote/GitHub ones instead of the CircleCI ones).

In addition, the checkout will now use (and print) the SHA1 digest instead of the branch name.
This should also improve reproducibility by ensuring CircleCI builds the right thing.