### PR TITLE
Force CI to reset the main branch on checkout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ aliases:
         USERNAME=${CIRCLE_PR_USERNAME:-${CIRCLE_PROJECT_USERNAME}}
         REPONAME=${CIRCLE_PR_REPONAME:-${CIRCLE_PROJECT_REPONAME}}
         git clone "https://github.com/${USERNAME}/${REPONAME}.git" .
-        git checkout -b "${CIRCLE_BRANCH}" "${CIRCLE_SHA1}"
+        git checkout -B "${CIRCLE_BRANCH}" "${CIRCLE_SHA1}"
         TERM=ansi git log -n 1 --pretty=oneline
 
   - &CHECKOUT_WINDOWS
@@ -41,7 +41,7 @@ aliases:
         $USERNAME = if ($Env:CIRCLE_PR_USERNAME -ne $null) { $Env:CIRCLE_PR_USERNAME } else { $Env:CIRCLE_PROJECT_USERNAME }
         $REPONAME = if ($Env:CIRCLE_PR_REPONAME -ne $null) { $Env:CIRCLE_PR_REPONAME } else { $Env:CIRCLE_PROJECT_REPONAME }
         git clone "https://github.com/$USERNAME/$REPONAME.git" .
-        git checkout -b "$Env:CIRCLE_BRANCH" "$Env:CIRCLE_SHA1"
+        git checkout -B "$Env:CIRCLE_BRANCH" "$Env:CIRCLE_SHA1"
         git log -n 1 --pretty=oneline
 
   - &PREPARE_VIRTUALENV


### PR DESCRIPTION
Part of #462

This should fix the CI when building the main branch (which is checkout twice).

I'd like to improve this whole custom checkout, but I'll do this in an other project before porting changes here.
This is just a minimal change to get the CI to build.