### PR TITLE
Pin attrs until we have a compatible tahoe-lafs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,10 @@ packages =
     twisted.plugins
 
 install_requires =
-    attrs
+    # Pin attrs with `provides()` until we have a tahoe-lafs release
+    # that doesn't need it anymore. TODO: Remove that pin when tahoe-lafs
+    # 1.20 is out.
+    attrs <= 23.2.0
     cattrs
     zope.interface
     eliot >= 1.11


### PR DESCRIPTION
This pin can and should be removed when we start
to depend on tahoe-lafs 1.20 or up.