### PR TITLE
Stop SyntaxWarnings because of some escaped blank

### DIFF
--- a/src/_zkapauthorizer/replicate.py
+++ b/src/_zkapauthorizer/replicate.py
@@ -390,7 +390,7 @@ MutationObserver = Callable[[_SQLite3Cursor, Iterable[Mutation]], Callable[[], N
 
 @define
 class _ReplicationCapableConnection:
-    """
+    r"""
     Wrap a ``sqlite3.Connection`` to provide additional snapshot- and
     streaming replication-related features.
 
@@ -487,7 +487,7 @@ class _ReplicationCapableConnection:
 
 @define
 class _ReplicationCapableCursor:
-    """
+    r"""
     Wrap a ``sqlite3.Cursor`` to provide additional streaming
     replication-related features.
 

--- a/src/_zkapauthorizer/replicate.py
+++ b/src/_zkapauthorizer/replicate.py
@@ -395,7 +395,7 @@ class _ReplicationCapableConnection:
     streaming replication-related features.
 
     All of this type's methods are intended to behave the same way as
-    ``sqlite3.Connection``\ 's methods except they may also add some
+    ``sqlite3.Connection`` 's methods except they may also add some
     additional functionality to support replication.
 
     :ivar _replicating: ``True`` if this connection is currently in
@@ -492,7 +492,7 @@ class _ReplicationCapableCursor:
     replication-related features.
 
     All of this type's attributes and methods are intended to behave the same
-    way as ``sqlite3.Cursor``\ 's methods except they may also add some
+    way as ``sqlite3.Cursor`` 's methods except they may also add some
     additional functionality to support replication.
     """
 

--- a/src/_zkapauthorizer/replicate.py
+++ b/src/_zkapauthorizer/replicate.py
@@ -395,7 +395,7 @@ class _ReplicationCapableConnection:
     streaming replication-related features.
 
     All of this type's methods are intended to behave the same way as
-    ``sqlite3.Connection`` 's methods except they may also add some
+    ``sqlite3.Connection``\ 's methods except they may also add some
     additional functionality to support replication.
 
     :ivar _replicating: ``True`` if this connection is currently in
@@ -492,7 +492,7 @@ class _ReplicationCapableCursor:
     replication-related features.
 
     All of this type's attributes and methods are intended to behave the same
-    way as ``sqlite3.Cursor`` 's methods except they may also add some
+    way as ``sqlite3.Cursor``\ 's methods except they may also add some
     additional functionality to support replication.
     """
 


### PR DESCRIPTION
I see these often at the very beginning when running tests - I removed that backslash, but also, not so sure what I'm doing here.  @crwood is removing these okay?  Why are they there in the first place?
```
    _zkapauthorizer/replicate.py:393: SyntaxWarning: invalid escape sequence '\ '
    _zkapauthorizer/replicate.py:490: SyntaxWarning: invalid escape sequence '\ '
```